### PR TITLE
feat(backend): standardize validation and error responses across DTOs

### DIFF
--- a/app/backend/src/app.spec.ts
+++ b/app/backend/src/app.spec.ts
@@ -1,4 +1,8 @@
-import { INestApplication, ValidationPipe } from "@nestjs/common";
+import {
+  BadRequestException,
+  INestApplication,
+  ValidationPipe,
+} from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import * as request from "supertest";
 
@@ -8,6 +12,7 @@ import { AppConfigService } from "./config";
 import { AppModule } from "./app.module";
 import { UsernamesService } from "./usernames/usernames.service";
 import { HealthService } from "./health/health.service";
+import { mapValidationErrors } from "./common/utils/validation-error.mapper";
 
 describe("App endpoints", () => {
   let app: INestApplication;
@@ -41,6 +46,15 @@ describe("App endpoints", () => {
         whitelist: true,
         forbidNonWhitelisted: true,
         transform: true,
+        exceptionFactory: (errors) => {
+          const mapped = mapValidationErrors(errors);
+
+          return new BadRequestException({
+            code: "VALIDATION_ERROR",
+            message: mapped.message,
+            fields: mapped.fields,
+          });
+        },
       }),
     );
 

--- a/app/backend/src/common/utils/validation-error.mapper.ts
+++ b/app/backend/src/common/utils/validation-error.mapper.ts
@@ -1,0 +1,29 @@
+import { ValidationError } from "class-validator";
+
+export interface MappedValidationError {
+  message: string;
+  fields: Array<{
+    field: string;
+    errors: string[];
+  }>;
+}
+
+export function mapValidationErrors(
+  errors: ValidationError[],
+): MappedValidationError {
+  const fields = errors.map((error) => {
+    const constraints = error.constraints
+      ? Object.values(error.constraints)
+      : [];
+
+    return {
+      field: error.property,
+      errors: constraints,
+    };
+  });
+
+  return {
+    message: "Validation failed",
+    fields,
+  };
+}

--- a/app/backend/src/links/links.controller.ts
+++ b/app/backend/src/links/links.controller.ts
@@ -1,29 +1,37 @@
-import { Controller, Post, Body, HttpCode, HttpStatus, HttpException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
-import { LinksService } from './links.service';
-import { LinkMetadataRequestDto, LinkMetadataResponseDto } from '../dto';
-import { LinkValidationError } from './errors';
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  BadRequestException,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from "@nestjs/swagger";
+import { LinksService } from "./links.service";
+import { LinkMetadataRequestDto, LinkMetadataResponseDto } from "../dto";
+import { LinkValidationError } from "./errors";
 
-@ApiTags('links')
-@Controller('links')
+@ApiTags("links")
+@Controller("links")
 export class LinksController {
   constructor(private readonly linksService: LinksService) {}
 
-  @Post('metadata')
+  @Post("metadata")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: 'Generate canonical link metadata',
-    description: 'Validates payment link parameters and generates canonical metadata for frontend consumption',
+    summary: "Generate canonical link metadata",
+    description:
+      "Validates payment link parameters and generates canonical metadata for frontend consumption",
   })
   @ApiBody({ type: LinkMetadataRequestDto })
   @ApiResponse({
     status: 200,
-    description: 'Metadata generated successfully',
+    description: "Metadata generated successfully",
     type: LinkMetadataResponseDto,
   })
   @ApiResponse({
     status: 400,
-    description: 'Validation failed',
+    description: "Validation failed",
   })
   async generateMetadata(
     @Body() request: LinkMetadataRequestDto,
@@ -36,17 +44,11 @@ export class LinksController {
       };
     } catch (error) {
       if (error instanceof LinkValidationError) {
-        throw new HttpException(
-          {
-            success: false,
-            error: {
-              code: error.code,
-              message: error.message,
-              field: error.field,
-            },
-          },
-          HttpStatus.BAD_REQUEST,
-        );
+        throw new BadRequestException({
+          code: error.code,
+          message: error.message,
+          field: error.field,
+        });
       }
       throw error;
     }

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -1,13 +1,14 @@
 import "reflect-metadata";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { Logger, ValidationPipe, VersioningType } from "@nestjs/common";
+import { BadRequestException, Logger, ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 
 import { AppModule } from "./app.module";
 import { AppConfigService } from "./config";
 import { GlobalHttpExceptionFilter } from "./common/filters/global-http-exception.filter";
+import { mapValidationErrors } from "./common/utils/validation-error.mapper";
 
 async function bootstrap() {
   const logger = new Logger("Bootstrap");
@@ -46,6 +47,15 @@ async function bootstrap() {
       whitelist: true,
       forbidNonWhitelisted: true,
       transform: true,
+      exceptionFactory: (errors) => {
+        const mapped = mapValidationErrors(errors);
+
+        return new BadRequestException({
+          code: "VALIDATION_ERROR",
+          message: mapped.message,
+          fields: mapped.fields,
+        });
+      },
     }),
   );
 

--- a/app/backend/src/transactions/transactions.controller.ts
+++ b/app/backend/src/transactions/transactions.controller.ts
@@ -1,75 +1,56 @@
-import {
-  Controller,
-  Get,
-  Query,
-  UsePipes,
-  ValidationPipe,
-  UseGuards,
-} from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags, ApiHeader } from '@nestjs/swagger';
+import { Controller, Get, Query, UseGuards } from "@nestjs/common";
+import { ApiOperation, ApiResponse, ApiTags, ApiHeader } from "@nestjs/swagger";
 
 import {
   GetTransactionsQueryDto,
   TransactionResponseDto,
-} from './dto/transaction.dto';
-import { HorizonService } from './horizon.service';
+} from "./dto/transaction.dto";
+import { HorizonService } from "./horizon.service";
 
-import { ApiKeyGuard } from '../auth/guards/api-key.guard';
-import { CustomThrottlerGuard } from '../auth/guards/custom-throttler.guard';
+import { ApiKeyGuard } from "../auth/guards/api-key.guard";
+import { CustomThrottlerGuard } from "../auth/guards/custom-throttler.guard";
 
-@ApiTags('transactions')
+@ApiTags("transactions")
 @ApiHeader({
-  name: 'X-API-Key',
-  description: 'Optional API key for higher rate limits',
+  name: "X-API-Key",
+  description: "Optional API key for higher rate limits",
   required: false,
 })
 @UseGuards(ApiKeyGuard, CustomThrottlerGuard)
-@Controller('transactions')
+@Controller("transactions")
 export class TransactionsController {
-  constructor(
-    private readonly horizonService: HorizonService,
-  ) {}
+  constructor(private readonly horizonService: HorizonService) {}
 
   @Get()
   @ApiOperation({
-    summary: 'Fetch recent Stellar transactions (payments)',
+    summary: "Fetch recent Stellar transactions (payments)",
     description:
-      'Fetches recent payment operations for a given account. ' +
-      'Results are cached for 60 seconds and support pagination via cursor. ' +
-      'This endpoint is rate-limited; API keys receive higher limits.',
+      "Fetches recent payment operations for a given account. " +
+      "Results are cached for 60 seconds and support pagination via cursor. " +
+      "This endpoint is rate-limited; API keys receive higher limits.",
   })
   @ApiResponse({
     status: 200,
-    description: 'List of normalized payment items',
+    description: "List of normalized payment items",
     type: TransactionResponseDto,
   })
   @ApiResponse({
     status: 400,
-    description: 'Invalid query parameters',
+    description: "Invalid query parameters",
   })
   @ApiResponse({
     status: 429,
-    description: 'Rate limit exceeded',
+    description: "Rate limit exceeded",
   })
   @ApiResponse({
     status: 503,
-    description: 'Horizon service rate limit exceeded or unavailable',
+    description: "Horizon service rate limit exceeded or unavailable",
   })
-  @UsePipes(
-    new ValidationPipe({
-      transform: true,
-    }),
-  )
   async getTransactions(
     @Query() query: GetTransactionsQueryDto,
   ): Promise<TransactionResponseDto> {
     const { accountId, asset, limit, cursor } = query;
 
-    return this.horizonService.getPayments(
-      accountId,
-      asset,
-      limit,
-      cursor,
-    );
+    return this.horizonService.getPayments(accountId, asset, limit, cursor);
   }
 }


### PR DESCRIPTION
## Closes #63 – Standardize validation and error responses across DTOs

### Overview

This PR enforces strict validation and unifies validation error formatting across the QuickEx backend to ensure consistent API contracts.

### Changes

- Enabled strict global `ValidationPipe`:
  - `whitelist: true`
  - `forbidNonWhitelisted: true`
  - `transform: true`
- Implemented centralized `mapValidationErrors` utility
- Standardized validation failures into:

```json
{
  "success": false,
  "error": {
    "code": "VALIDATION_ERROR",
    "message": "Validation failed",
    "fields": [...]
  }
}