### PR TITLE
docs: add developer-focused documentation for QuickEx contract interface (#99)

### DIFF
--- a/app/contract/README.md
+++ b/app/contract/README.md
@@ -115,6 +115,33 @@ soroban contract deploy \
 4. Build and test deployment locally: `soroban dev`
 5. Create PR with changes
 
+## Main Flows
+
+### 1. Deployment & initialisation
+1. Deploy the contract WASM.
+2. Call `initialize(admin)` once to set the admin (required for pause, upgrade, admin transfer).
+
+### 2. Deposit → Withdraw (escrow)
+1. **Deposit**: Call `deposit(token, amount, owner, salt)` or `deposit_with_commitment(from, token, amount, commitment)`. The owner/from must authorize the token transfer.
+2. Store the returned commitment (or the one you provided) securely; it is required to withdraw.
+3. **Withdraw**: Call `withdraw(_token, amount, _commitment, to, salt)` with `to` as the recipient. The commitment is recomputed from `to`, `amount`, and `salt`; it must match an existing pending escrow. `to` must authorize.
+
+### 3. Privacy
+- **Boolean**: `set_privacy(owner, enabled)` and `get_privacy(owner)` for on/off privacy.
+- **Level-based**: `enable_privacy(account, level)`, `privacy_status(account)`, `privacy_history(account)` for numeric levels.
+
+### 4. Admin
+- `set_paused(caller, new_state)` – pause/unpause (caller must be admin).
+- `set_admin(caller, new_admin)` – transfer admin.
+- `upgrade(caller, new_wasm_hash)` – upgrade contract (caller must authorize).
+
+### 5. Read-only queries
+- `get_commitment_state(commitment)` – escrow status (Pending/Spent/Expired).
+- `verify_proof_view(amount, salt, owner)` – verify withdrawal params without submitting a tx.
+- `get_escrow_details(commitment)` – full escrow entry.
+
+---
+
 ## Contract Interface
 
 The contract exposes the following functions:

--- a/app/contract/contracts/quickex/src/lib.rs
+++ b/app/contract/contracts/quickex/src/lib.rs
@@ -14,13 +14,33 @@ use events::publish_withdraw_toggled;
 use storage::*;
 use types::{EscrowEntry, EscrowStatus};
 
-/// Main contract structure
+/// QuickEx Privacy Contract
+///
+/// Soroban smart contract providing escrow, privacy controls, and X-Ray-style amount
+/// commitments for the QuickEx platform. See the contract README for main flows.
 #[contract]
 pub struct QuickexContract;
 
 #[contractimpl]
 impl QuickexContract {
-    /// Withdraw funds by proving commitment ownership
+    /// Withdraw escrowed funds by proving commitment ownership.
+    ///
+    /// The caller (`to`) must authorize; the commitment is recomputed from `to`, `amount`, and `salt`
+    /// and must match an existing pending escrow entry.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `_token` - Reserved; token is stored in the escrow entry
+    /// * `amount` - Amount to withdraw; must be positive and match the escrow amount
+    /// * `_commitment` - Reserved; commitment is derived from `to`, `amount`, `salt`
+    /// * `to` - Recipient address (must authorize the call)
+    /// * `salt` - Salt used when creating the original deposit commitment
+    ///
+    /// # Errors
+    /// * `InvalidAmount` - Amount is zero or negative
+    /// * `CommitmentNotFound` - No escrow exists for the computed commitment
+    /// * `AlreadySpent` - Escrow has already been withdrawn or marked spent
+    /// * `InvalidCommitment` - Escrow amount does not match the requested amount
     pub fn withdraw(
         env: Env,
         _token: &Address,
@@ -61,29 +81,53 @@ impl QuickexContract {
         Ok(true)
     }
 
+    /// Set a numeric privacy level for an account (legacy/level-based API).
+    ///
+    /// Records the level in storage and appends it to the account's privacy history.
+    /// For boolean on/off privacy, prefer [`set_privacy`](QuickexContract::set_privacy).
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `account` - The account to configure
+    /// * `privacy_level` - Numeric level (0 = off, higher = more privacy; interpretation is application-specific)
     pub fn enable_privacy(env: Env, account: Address, privacy_level: u32) -> bool {
         set_privacy_level(&env, &account, privacy_level);
         add_privacy_history(&env, &account, privacy_level);
         true
     }
 
+    /// Get the current numeric privacy level for an account.
+    ///
+    /// Returns `None` if no level has been set.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `account` - The account to query
     pub fn privacy_status(env: Env, account: Address) -> Option<u32> {
         get_privacy_level(&env, &account)
     }
 
+    /// Get the history of privacy level changes for an account.
+    ///
+    /// Returns a vector of levels in chronological order (oldest first).
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `account` - The account to query
     pub fn privacy_history(env: Env, account: Address) -> Vec<u32> {
         get_privacy_history(&env, &account)
     }
 
-    /// Enable or disable privacy for an account
+    /// Enable or disable privacy for an account.
     ///
     /// # Arguments
     /// * `env` - The contract environment
     /// * `owner` - The account address to configure
-    /// * `enabled` - True to enable privacy, False to disable
+    /// * `enabled` - `true` to enable privacy, `false` to disable
     ///
-    /// # Returns
-    /// * `Result<(), QuickexError>` - Ok if successful, Error otherwise
+    /// # Errors
+    /// * `PrivacyAlreadySet` - Privacy state is already at the requested value
+    /// * `InvalidPrivacyLevel` - Invalid internal state (e.g. invalid level transition)
     pub fn set_privacy(env: Env, owner: Address, enabled: bool) -> Result<(), QuickexError> {
         privacy::set_privacy(&env, owner, enabled)
     }
@@ -100,17 +144,21 @@ impl QuickexContract {
         privacy::get_privacy(&env, owner)
     }
 
-    /// Deposit funds and create an escrow entry
+    /// Deposit funds and create an escrow entry keyed by a commitment hash.
+    ///
+    /// Transfers `amount` from `owner` to the contract and stores an escrow keyed by
+    /// `SHA256(owner || amount || salt)`. The owner must authorize the transfer.
     ///
     /// # Arguments
     /// * `env` - The contract environment
-    /// * `token` - The token address
-    /// * `amount` - The amount to deposit
-    /// * `owner` - The owner of the funds
-    /// * `salt` - Random salt for privacy
+    /// * `token` - The token contract address
+    /// * `amount` - Amount to deposit; must be positive
+    /// * `owner` - Owner of the funds (must authorize)
+    /// * `salt` - Random salt (0–1024 bytes) for uniqueness; same inputs = same commitment
     ///
-    /// # Returns
-    /// * `Result<BytesN<32>, QuickexError>` - The commitment hash
+    /// # Errors
+    /// * `InvalidAmount` - Amount is zero or negative
+    /// * `InvalidSalt` - Salt length exceeds 1024 bytes
     pub fn deposit(
         env: Env,
         token: Address,
@@ -142,16 +190,20 @@ impl QuickexContract {
         Ok(commitment)
     }
 
-    /// Create a commitment for a hidden amount
+    /// Create a deterministic commitment hash for an amount (off-chain / pre-deposit use).
+    ///
+    /// Computes `SHA256(owner || amount || salt)`. Not a zero-knowledge proof; same inputs
+    /// always yield the same hash. Use for API shape validation and audit trails.
     ///
     /// # Arguments
     /// * `env` - The contract environment
-    /// * `owner` - The owner of the funds
-    /// * `amount` - The amount to commit
-    /// * `salt` - Random salt for privacy
+    /// * `owner` - The owner address
+    /// * `amount` - Non-negative amount in token base units
+    /// * `salt` - Random bytes (0–1024 bytes) for uniqueness
     ///
-    /// # Returns
-    /// * `Result<BytesN<32>, QuickexError>` - The commitment hash
+    /// # Errors
+    /// * `InvalidAmount` - Amount is negative
+    /// * `InvalidSalt` - Salt length exceeds 1024 bytes
     pub fn create_amount_commitment(
         env: Env,
         owner: Address,
@@ -161,17 +213,16 @@ impl QuickexContract {
         commitment::create_amount_commitment(&env, owner, amount, salt)
     }
 
-    /// Verify a commitment matches the provided values
+    /// Verify that a commitment hash matches the given `owner`, `amount`, and `salt`.
+    ///
+    /// Recomputes the commitment and compares. Returns `false` if inputs are invalid or don't match.
     ///
     /// # Arguments
     /// * `env` - The contract environment
-    /// * `commitment` - The commitment hash to verify
-    /// * `owner` - The owner of the funds
-    /// * `amount` - The amount to verify
-    /// * `salt` - The salt used for the commitment
-    ///
-    /// # Returns
-    /// * `bool` - True if valid
+    /// * `commitment` - 32-byte commitment hash to verify
+    /// * `owner` - Claimed owner
+    /// * `amount` - Claimed amount (must be non-negative)
+    /// * `salt` - Salt used when creating the commitment
     pub fn verify_amount_commitment(
         env: Env,
         commitment: BytesN<32>,
@@ -182,25 +233,43 @@ impl QuickexContract {
         commitment::verify_amount_commitment(&env, commitment, owner, amount, salt)
     }
 
+    /// Create an escrow record and increment the global escrow counter.
+    ///
+    /// Returns the new counter value. Parameters `_from`, `_to`, `_amount` are reserved for
+    /// future use; the implementation only increments the counter.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `_from` - Reserved (depositor address for future use)
+    /// * `_to` - Reserved (recipient address for future use)
+    /// * `_amount` - Reserved (amount for future use)
     pub fn create_escrow(env: Env, _from: Address, _to: Address, _amount: u64) -> u64 {
         increment_escrow_counter(&env)
     }
 
+    /// Health check for deployment and monitoring.
+    ///
+    /// Returns `true` if the contract is deployed and callable. No state or auth required.
     pub fn health_check() -> bool {
         true
     }
 
-    /// Deposit funds and create an escrow entry using a pre-generated commitment
+    /// Deposit funds using a pre-generated 32-byte commitment hash.
+    ///
+    /// Transfers `amount` from `from` to the contract and stores an escrow keyed by
+    /// `commitment`. The depositor must authorize. Use when the commitment was created
+    /// off-chain or via [`create_amount_commitment`](QuickexContract::create_amount_commitment).
     ///
     /// # Arguments
     /// * `env` - The contract environment
-    /// * `from` - The address depositing the funds
-    /// * `token` - The token address
-    /// * `amount` - The amount to deposit
-    /// * `commitment` - The pre-generated commitment hash
+    /// * `from` - Depositor (must authorize the token transfer)
+    /// * `token` - Token contract address
+    /// * `amount` - Amount to deposit; must be positive
+    /// * `commitment` - 32-byte commitment hash (must be unique)
     ///
-    /// # Returns
-    /// * `Result<(), QuickexError>` - Ok if successful, Error otherwise
+    /// # Errors
+    /// * `InvalidAmount` - Amount is zero or negative
+    /// * `CommitmentAlreadyExists` - An escrow for this commitment already exists
     pub fn deposit_with_commitment(
         env: Env,
         from: Address,
@@ -236,14 +305,16 @@ impl QuickexContract {
         Ok(())
     }
 
-    /// Initialize the contract with an admin address
+    /// Initialize the contract with an admin address (one-time only).
+    ///
+    /// Sets the admin who can pause/unpause, transfer admin, and upgrade the contract.
     ///
     /// # Arguments
     /// * `env` - The contract environment
     /// * `admin` - The admin address to set
     ///
-    /// # Returns
-    /// * `Result<(), QuickexError>` - Ok if successful, Error if already initialized
+    /// # Errors
+    /// * `AlreadyInitialized` - Contract has already been initialized
     pub fn initialize(env: Env, admin: Address) -> Result<(), QuickexError> {
         if get_admin(&env).is_some() {
             return Err(QuickexError::AlreadyInitialized);
@@ -252,15 +323,17 @@ impl QuickexContract {
         Ok(())
     }
 
-    /// Set the paused state of the contract (Admin only)
+    /// Pause or unpause the contract (**Admin only**).
+    ///
+    /// When paused, certain operations may be blocked. Caller must equal the stored admin.
     ///
     /// # Arguments
     /// * `env` - The contract environment
-    /// * `caller` - The caller address (must be admin)
-    /// * `new_state` - True to pause, False to unpause
+    /// * `caller` - Caller address (must equal admin)
+    /// * `new_state` - `true` to pause, `false` to unpause
     ///
-    /// # Returns
-    /// * `Result<(), QuickexError>` - Ok if successful, Error if unauthorized or other issue
+    /// # Errors
+    /// * `Unauthorized` - Caller is not the admin, or admin not set
     pub fn set_paused(env: Env, caller: Address, new_state: bool) -> Result<(), QuickexError> {
         let admin = get_admin(&env).ok_or(QuickexError::Unauthorized)?;
         if caller != admin {
@@ -270,15 +343,17 @@ impl QuickexContract {
         Ok(())
     }
 
-    /// Transfer admin rights to a new address (Admin only)
+    /// Transfer admin rights to a new address (**Admin only**).
+    ///
+    /// Caller must equal the current admin. The new admin can later transfer again.
     ///
     /// # Arguments
     /// * `env` - The contract environment
-    /// * `caller` - The caller address (must be admin)
-    /// * `new_admin` - The new admin address
+    /// * `caller` - Caller address (must equal current admin)
+    /// * `new_admin` - New admin address
     ///
-    /// # Returns
-    /// * `Result<(), QuickexError>` - Ok if successful, Error if unauthorized or other issue
+    /// # Errors
+    /// * `Unauthorized` - Caller is not the admin, or admin not set
     pub fn set_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), QuickexError> {
         let admin = get_admin(&env).ok_or(QuickexError::Unauthorized)?;
         if caller != admin {
@@ -288,28 +363,27 @@ impl QuickexContract {
         Ok(())
     }
 
-    /// Check if the contract is currently paused
+    /// Check if the contract is currently paused.
     ///
-    /// # Arguments
-    /// * `env` - The contract environment
-    ///
-    /// # Returns
-    /// * `bool` - True if paused, False otherwise
+    /// Returns `true` if paused, `false` otherwise.
     pub fn is_paused(env: Env) -> bool {
         is_paused(&env)
     }
 
-    /// Get the current admin address
+    /// Get the current admin address.
     ///
-    /// # Arguments
-    /// * `env` - The contract environment
-    ///
-    /// # Returns
-    /// * `Option<Address>` - The admin address if set, None otherwise
+    /// Returns `None` if the contract has not been initialized.
     pub fn get_admin(env: Env) -> Option<Address> {
         get_admin(&env)
     }
 
+    /// Get the status of an escrow by its commitment hash (read-only).
+    ///
+    /// Returns `Pending`, `Spent`, or `Expired` if an escrow exists; `None` otherwise.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `commitment` - 32-byte commitment hash used as the escrow key
     pub fn get_commitment_state(env: Env, commitment: BytesN<32>) -> Option<EscrowStatus> {
         let commitment_bytes: Bytes = commitment.into();
         let entry: Option<EscrowEntry> = get_escrow(&env, &commitment_bytes);
@@ -317,7 +391,16 @@ impl QuickexContract {
         entry.map(|e| e.status)
     }
 
-    // Verify proof parameters without submitting a transaction
+    /// Verify withdrawal parameters without submitting a transaction (read-only).
+    ///
+    /// Recomputes the commitment from `amount`, `salt`, and `owner`, then checks that an
+    /// escrow exists with status `Pending` and matching amount. Use before calling `withdraw`.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `amount` - Amount to verify (non-negative)
+    /// * `salt` - Salt used when creating the deposit
+    /// * `owner` - Owner of the escrow
     pub fn verify_proof_view(env: Env, amount: i128, salt: Bytes, owner: Address) -> bool {
         let commitment_result =
             commitment::create_amount_commitment(&env, owner.clone(), amount, salt);
@@ -338,24 +421,32 @@ impl QuickexContract {
         }
     }
 
-    // Get detailed escrow information for a commitment
+    /// Get full escrow details for a commitment hash (read-only).
+    ///
+    /// Returns the full `EscrowEntry` (token, amount, owner, status, created_at) if it exists.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `commitment` - 32-byte commitment hash
     pub fn get_escrow_details(env: Env, commitment: BytesN<32>) -> Option<EscrowEntry> {
         let commitment_bytes: Bytes = commitment.into();
         get_escrow(&env, &commitment_bytes)
     }
-    /// Upgrade the contract to a new WASM implementation (Admin only)
+    /// Upgrade the contract to a new WASM implementation (**Admin only**).
+    ///
+    /// Caller must equal admin and authorize. The new WASM must be pre-uploaded to the network.
+    /// Emits an upgrade event for audit.
     ///
     /// # Arguments
     /// * `env` - The contract environment
-    /// * `caller` - The caller address (must be admin)
-    /// * `new_wasm_hash` - The hash of the new WASM code to upgrade to
+    /// * `caller` - Caller address (must equal admin; must authorize)
+    /// * `new_wasm_hash` - 32-byte hash of the new WASM code
     ///
-    /// # Returns
-    /// * `Result<(), QuickexError>` - Ok if successful, Error if unauthorized
+    /// # Errors
+    /// * `Unauthorized` - Caller is not the admin, or admin not set
     ///
     /// # Security
-    /// This function requires admin authorization and will update the contract's
-    /// executable code. The new WASM must be pre-uploaded to the network.
+    /// Updates the contract's executable code. Use with care in production.
     pub fn upgrade(
         env: Env,
         caller: Address,


### PR DESCRIPTION
## Summary

Adds developer-focused documentation for the QuickEx contract interface per #99.

## Changes

### lib.rs
- Added Rustdoc-style comments to all 22 public entrypoints covering:
  - Purpose and behavior
  - Parameters and valid input ranges (e.g. amount > 0, salt 0–1024 bytes)
  - Possible errors (`InvalidAmount`, `Unauthorized`, `CommitmentNotFound`, etc.)
  - Admin-only restrictions for `initialize`, `set_paused`, `set_admin`, and `upgrade`
- Added module-level doc for the contract

### app/contract/README.md
- Added **Main Flows** section summarizing:
  1. Deployment & initialisation
  2. Deposit → Withdraw (escrow)
  3. Privacy (boolean and level-based)
  4. Admin (pause, transfer, upgrade)
  5. Read-only queries

## Acceptance criteria
- [x] Each public entrypoint has at least a concise Rustdoc comment
- [x] Developers can read the docs to understand how to call the contract safely
- [x] No behavior changes; 40 tests pass

## Complexity
150 points (DX and onboarding)

closes: #99 