### PR TITLE
docs(storage): document schema and centralise key helpers (#97)

### DIFF
--- a/app/contract/contracts/quickex/src/privacy.rs
+++ b/app/contract/contracts/quickex/src/privacy.rs
@@ -1,11 +1,12 @@
 use crate::errors::QuickexError;
 use crate::events::publish_privacy_toggled;
+use crate::storage::PRIVACY_ENABLED_KEY;
 use soroban_sdk::{Address, Env, Symbol};
 
 pub fn set_privacy(env: &Env, owner: Address, enabled: bool) -> Result<(), QuickexError> {
     owner.require_auth();
 
-    let key = Symbol::new(env, "privacy_enabled");
+    let key = Symbol::new(env, PRIVACY_ENABLED_KEY);
     env.storage()
         .persistent()
         .set(&(key, owner.clone()), &enabled);
@@ -17,7 +18,7 @@ pub fn set_privacy(env: &Env, owner: Address, enabled: bool) -> Result<(), Quick
 }
 
 pub fn get_privacy(env: &Env, owner: Address) -> bool {
-    let key = Symbol::new(env, "privacy_enabled");
+    let key = Symbol::new(env, PRIVACY_ENABLED_KEY);
     env.storage()
         .persistent()
         .get(&(key, owner))

--- a/app/contract/contracts/quickex/src/storage.rs
+++ b/app/contract/contracts/quickex/src/storage.rs
@@ -1,46 +1,122 @@
+//! # QuickEx Storage Schema
+//!
+//! This module defines the persistent storage layout for the QuickEx contract.
+//! All long-term data is stored via the [`DataKey`] enum, which centralises key
+//! construction and ensures type-safe storage access.
+//!
+//! ## Key Layout
+//!
+//! | Key Variant            | Value Type     | Description |
+//! |------------------------|----------------|-------------|
+//! | [`Escrow`](DataKey::Escrow) | `EscrowEntry`  | Escrow entry keyed by commitment hash (32 bytes). One entry per unique deposit. |
+//! | [`EscrowCounter`](DataKey::EscrowCounter) | `u64`       | Global monotonic counter for escrow creation. |
+//! | [`Admin`](DataKey::Admin) | `Address`     | Contract admin address. Set during initialisation, transferable by admin. |
+//! | [`Paused`](DataKey::Paused) | `bool`       | Global pause flag. When true, critical operations may be blocked. |
+//! | [`PrivacyLevel`](DataKey::PrivacyLevel) | `u32`  | Numeric privacy level per account (0 = off). Used by `enable_privacy`. |
+//! | [`PrivacyHistory`](DataKey::PrivacyHistory) | `Vec<u32>` | Per-account history of privacy level changes (chronological). |
+//!
+//! ## Related Keys (outside `DataKey`)
+//!
+//! | Key                    | Format                    | Value Type | Description |
+//! |------------------------|---------------------------|------------|-------------|
+//! | `privacy_enabled`      | `(Symbol, Address)`       | `bool`     | Boolean privacy on/off per account. Used by `set_privacy` / `get_privacy`. |
+//!
+//! ## Relations
+//!
+//! - **Escrow ↔ Commitment**: Each `Escrow(Bytes)` key is derived from a 32-byte commitment hash
+//!   (`SHA256(owner || amount || salt)`). The stored [`EscrowEntry`] contains token, amount, owner,
+//!   status, and created_at.
+//! - **Admin ↔ Paused**: Admin can set the paused flag. Both are singleton keys.
+//! - **PrivacyLevel ↔ PrivacyHistory**: Same account may have both; level is current, history is append-only.
+//! - **PrivacyLevel / PrivacyHistory ↔ privacy_enabled**: Separate APIs; level-based vs boolean. Both persist per `Address`.
+//!
+//! ## Backwards Compatibility
+//!
+//! For future upgrades:
+//! - **Do not** remove or change the discriminant of existing [`DataKey`] variants.
+//! - **Add** new variants for new keys; they will not collide with existing ones.
+//! - **Value layout**: Changing `EscrowEntry` fields may require migration logic; adding optional
+//!   fields can be done carefully with defaults.
+
 use soroban_sdk::{contracttype, Address, Bytes, Env, Vec};
 
 use crate::types::EscrowEntry;
 
-/// Storage keys for the contract
+// -----------------------------------------------------------------------------
+// Key constants (for keys not using DataKey)
+// -----------------------------------------------------------------------------
+
+/// Symbol string for the boolean privacy-enabled flag.
+/// Used as `(Symbol::new(env, PRIVACY_ENABLED_KEY), Address)` in persistent storage.
+/// See [`crate::privacy`] module.
+pub const PRIVACY_ENABLED_KEY: &str = "privacy_enabled";
+
+// -----------------------------------------------------------------------------
+// DataKey enum – central key derivation
+// -----------------------------------------------------------------------------
+
+/// Storage keys for the contract.
+///
+/// All persistent storage access should go through the helpers in this module.
+/// Each variant maps to a distinct namespace; the Soroban runtime serialises
+/// the enum discriminant and payload into the actual storage key.
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    /// Escrow entry keyed by commitment hash (`Bytes`, typically 32 bytes).
     Escrow(Bytes),
+    /// Global escrow counter (singleton).
     EscrowCounter,
+    /// Admin address (singleton).
     Admin,
+    /// Paused state (singleton).
     Paused,
+    /// Numeric privacy level per account.
     PrivacyLevel(Address),
+    /// Privacy level change history per account.
     PrivacyHistory(Address),
 }
 
-/// Put an escrow entry into storage
+// -----------------------------------------------------------------------------
+// Escrow helpers
+// -----------------------------------------------------------------------------
+
+/// Put an escrow entry into storage.
+///
+/// **Contract**: Overwrites any existing entry for the same commitment.
+/// The commitment should be the 32-byte `SHA256(owner || amount || salt)` hash.
 pub fn put_escrow(env: &Env, commitment: &Bytes, entry: &EscrowEntry) {
     let key = DataKey::Escrow(commitment.clone());
     env.storage().persistent().set(&key, entry);
 }
 
-/// Get an escrow entry from storage
+/// Get an escrow entry from storage.
+///
+/// **Contract**: Returns `None` if no escrow exists for the commitment.
 pub fn get_escrow(env: &Env, commitment: &Bytes) -> Option<EscrowEntry> {
     let key = DataKey::Escrow(commitment.clone());
     env.storage().persistent().get(&key)
 }
 
-/// Check if an escrow entry exists in storage
+/// Check if an escrow entry exists in storage.
 #[allow(dead_code)]
 pub fn has_escrow(env: &Env, commitment: &Bytes) -> bool {
     let key = DataKey::Escrow(commitment.clone());
     env.storage().persistent().has(&key)
 }
 
-/// Get the next escrow counter value
+/// Get the next escrow counter value.
+///
+/// **Contract**: Returns 0 if never set. Counter is used for `create_escrow`.
 #[allow(dead_code)]
 pub fn get_escrow_counter(env: &Env) -> u64 {
     let key = DataKey::EscrowCounter;
     env.storage().persistent().get(&key).unwrap_or(0)
 }
 
-/// Increment and return the escrow counter
+/// Increment and return the escrow counter.
+///
+/// **Contract**: Atomic increment. Initial value treated as 0.
 pub fn increment_escrow_counter(env: &Env) -> u64 {
     let key = DataKey::EscrowCounter;
     let mut count: u64 = env.storage().persistent().get(&key).unwrap_or(0);
@@ -49,43 +125,54 @@ pub fn increment_escrow_counter(env: &Env) -> u64 {
     count
 }
 
-/// Set admin address
+// -----------------------------------------------------------------------------
+// Admin helpers
+// -----------------------------------------------------------------------------
+
+/// Set admin address.
 pub fn set_admin(env: &Env, admin: &Address) {
     let key = DataKey::Admin;
     env.storage().persistent().set(&key, admin);
 }
 
-/// Get admin address
+/// Get admin address.
 pub fn get_admin(env: &Env) -> Option<Address> {
     let key = DataKey::Admin;
     env.storage().persistent().get(&key)
 }
 
-/// Set paused state
+/// Set paused state.
 pub fn set_paused(env: &Env, paused: bool) {
     let key = DataKey::Paused;
     env.storage().persistent().set(&key, &paused);
 }
 
-/// Get paused state
+/// Get paused state.
 pub fn is_paused(env: &Env) -> bool {
     let key = DataKey::Paused;
     env.storage().persistent().get(&key).unwrap_or(false)
 }
 
-/// Set privacy level for an account
+// -----------------------------------------------------------------------------
+// Privacy helpers (level-based API)
+// -----------------------------------------------------------------------------
+
+/// Set privacy level for an account.
 pub fn set_privacy_level(env: &Env, account: &Address, level: u32) {
     let key = DataKey::PrivacyLevel(account.clone());
     env.storage().persistent().set(&key, &level);
 }
 
-/// Get privacy level for an account
+/// Get privacy level for an account.
 pub fn get_privacy_level(env: &Env, account: &Address) -> Option<u32> {
     let key = DataKey::PrivacyLevel(account.clone());
     env.storage().persistent().get(&key)
 }
 
-/// Add to privacy history for an account
+/// Add to privacy history for an account.
+///
+/// **Contract**: Pushes `level` to the front of the history (newest first).
+/// History is unbounded; consider capping in future if needed.
 pub fn add_privacy_history(env: &Env, account: &Address, level: u32) {
     let key = DataKey::PrivacyHistory(account.clone());
     let mut history: Vec<u32> = env
@@ -97,7 +184,9 @@ pub fn add_privacy_history(env: &Env, account: &Address, level: u32) {
     env.storage().persistent().set(&key, &history);
 }
 
-/// Get privacy history for an account
+/// Get privacy history for an account.
+///
+/// **Contract**: Returns empty vec if never set. Order is newest-first.
 pub fn get_privacy_history(env: &Env, account: &Address) -> Vec<u32> {
     let key = DataKey::PrivacyHistory(account.clone());
     env.storage()

--- a/app/contract/contracts/quickex/src/types.rs
+++ b/app/contract/contracts/quickex/src/types.rs
@@ -1,6 +1,15 @@
+//! Types used in the QuickEx storage layer and contract logic.
+//!
+//! See [`crate::storage`] for the storage schema and key layout.
+
 use soroban_sdk::{contracttype, Address};
 
-/// Escrow entry status
+/// Escrow entry status.
+///
+/// Tracks the lifecycle of a deposited commitment:
+/// - `Pending`: Funds are escrowed, awaiting withdrawal.
+/// - `Spent`: Withdrawal completed; entry kept for audit/state queries.
+/// - `Expired`: No longer withdrawable (reserved for future expiration logic).
 #[contracttype]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum EscrowStatus {
@@ -9,13 +18,22 @@ pub enum EscrowStatus {
     Expired,
 }
 
-/// Escrow entry structure
+/// Escrow entry structure.
+///
+/// Stored under [`DataKey::Escrow`](crate::storage::DataKey::Escrow)(commitment) in persistent storage.
+/// Each entry corresponds to one deposit, keyed by the commitment hash
+/// `SHA256(owner || amount || salt)`.
 #[contracttype]
 #[derive(Clone)]
 pub struct EscrowEntry {
+    /// Token contract address for the escrowed funds.
     pub token: Address,
+    /// Amount in token base units.
     pub amount: i128,
+    /// Owner who can withdraw via proof of ownership (salt + amount).
     pub owner: Address,
+    /// Current status (Pending, Spent, Expired).
     pub status: EscrowStatus,
+    /// Ledger timestamp when the escrow was created.
     pub created_at: u64,
 }


### PR DESCRIPTION
## Summary

Implements #97 – storage schema documentation and refactor for clarity.

## Changes

### Storage schema docs (`storage.rs`)
- Added module-level doc describing the persistent storage layout
- Documented key layout: `DataKey` variants, value types, and purpose
- Documented related keys outside `DataKey` (e.g. `privacy_enabled`)
- Explained relations between keys (Escrow ↔ Commitment, Admin ↔ Paused, PrivacyLevel ↔ PrivacyHistory)
- Added backwards-compatibility notes for future upgrades

### Centralised key construction
- Introduced `PRIVACY_ENABLED_KEY` constant in `storage.rs`
- Updated `privacy.rs` to use this constant instead of the hard-coded `"privacy_enabled"` string

### Doc comments
- Documented `DataKey` enum and each variant
- Added contract/behaviour comments to all storage helpers in `storage.rs`
- Documented `EscrowStatus`, `EscrowEntry`, and fields in `types.rs`
- Linked `types.rs` to the storage schema in the module doc

## Acceptance criteria

- [x] Storage schema described in code comments
- [x] Key derivations use well-named helpers (`DataKey` enum, `PRIVACY_ENABLED_KEY`)
- [x] No change in observable behaviour; all 40 tests pass

closes: #97 