### PR TITLE
feat: Escrow logic

### DIFF
--- a/app/contract/contracts/quickex/src/commitment_test.rs
+++ b/app/contract/contracts/quickex/src/commitment_test.rs
@@ -1,4 +1,3 @@
-#![cfg(test)]
 //! Commitment Scheme Invariant Tests
 //!
 //! This module provides comprehensive property-based testing for the commitment scheme.

--- a/app/contract/contracts/quickex/src/errors.rs
+++ b/app/contract/contracts/quickex/src/errors.rs
@@ -16,4 +16,10 @@ pub enum QuickexError {
     InvalidCommitment = 10,
     ContractPaused = 11,
     CommitmentAlreadyExists = 12,
+    /// Escrow has passed its expiry; withdrawal is no longer possible.
+    EscrowExpired = 13,
+    /// Escrow has not yet expired; refund is not yet available.
+    EscrowNotExpired = 14,
+    /// Caller is not the original owner of the escrow.
+    InvalidOwner = 15,
 }

--- a/app/contract/contracts/quickex/src/events.rs
+++ b/app/contract/contracts/quickex/src/events.rs
@@ -115,3 +115,23 @@ pub(crate) fn publish_deposit(env: &Env, commitment: BytesN<32>, token: Address,
     }
     .publish(env);
 }
+
+#[contractevent(topics = ["Refunded"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefundedEvent {
+    #[topic]
+    pub owner: Address,
+    pub commitment: BytesN<32>,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+pub(crate) fn publish_refunded(env: &Env, owner: Address, commitment: BytesN<32>, amount: i128) {
+    RefundedEvent {
+        owner,
+        commitment,
+        amount,
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+}

--- a/app/contract/contracts/quickex/src/storage_test.rs
+++ b/app/contract/contracts/quickex/src/storage_test.rs
@@ -1,4 +1,3 @@
-#![cfg(test)]
 use soroban_sdk::{testutils::Address as _, Address, Bytes, Env};
 
 use crate::{
@@ -24,6 +23,7 @@ fn test_escrow_storage() {
             owner: owner.clone(),
             status: EscrowStatus::Pending,
             created_at,
+            expires_at: 0,
         };
 
         // Test put_escrow
@@ -64,6 +64,7 @@ fn test_escrow_status_update() {
             owner: owner.clone(),
             status: EscrowStatus::Pending,
             created_at,
+            expires_at: 0,
         };
 
         put_escrow(&env, &commitment, &entry);


### PR DESCRIPTION
## Add Escrow Timeout & Refund Mechanism to QuickEx Contract

Closes #90 

### Description
Extends the QuickEx escrow system with time-bounded escrows and a `refund` path, completing the escrow state machine. Depositors can now set an expiry on their escrow; if the escrow expires before withdrawal, the original owner can reclaim their funds via `refund`. Withdrawals are blocked after expiry.

### Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes) — escrow logic extracted into dedicated `escrow.rs` module
- [x] Test additions or improvements

### Motivation and Context
Previously, escrowed funds could only ever exit via `withdraw` (proof-of-knowledge). There was no recovery path if the withdrawer lost their salt or never claimed — funds would be locked permanently. This PR introduces optional timeouts on escrows and a `refund` function so depositors can recover funds once a deadline passes.

### Changes

**New `escrow.rs` module** — core deposit, withdraw, and refund logic extracted from `lib.rs` into a dedicated module, improving separation of concerns. `lib.rs` contract methods now delegate directly to these functions.

**`timeout_secs` parameter on `deposit` and `deposit_with_commitment`** — passing `0` preserves the existing non-expiring behaviour. Passing a positive value sets `expires_at = now + timeout_secs` on the escrow entry.

**`refund` function** — allows the original depositor to reclaim funds after `expires_at` is reached. Fails with `EscrowNotExpired` if called too early, `InvalidOwner` if the caller is not the depositor, and `AlreadySpent` if already in a terminal state.

**`withdraw` expiry guard** — withdrawal now fails with `EscrowExpired` if the current ledger timestamp has passed `expires_at`.

**`verify_proof_view` updated** — now also returns `false` for expired escrows, keeping the pre-flight check accurate.

**`EscrowStatus::Refunded`** — new terminal state added alongside `Spent`. `Expired` is retained for backward compatibility with any existing on-chain data.

**`expires_at: u64` field on `EscrowEntry`** — `0` means no expiry; any positive value is the expiry timestamp.

**New error variants** — `EscrowExpired (13)`, `EscrowNotExpired (14)`, `InvalidOwner (15)`.

**`RefundedEvent`** — emitted on successful refund carrying `owner`, `commitment`, `amount`, and `timestamp`.

### How Has This Been Tested?
- [x] Unit tests added/updated
- [x] All tests pass locally

New test cases in `test.rs`:

- **`test_withdrawal_fails_after_expiry`** — verifies withdrawal succeeds before expiry and fails with `EscrowExpired` after.
- **`test_refund_successful`** — verifies early refund fails with `EscrowNotExpired`, refund succeeds at expiry, balance is returned, and status transitions to `Refunded`.
- **`test_refund_unauthorized_fails`** — verifies a non-owner caller is rejected with `InvalidOwner`.
- **`test_double_refund_fails`** — verifies a second refund attempt on an already-refunded escrow fails with `AlreadySpent`.

Existing tests updated throughout to pass `expires_at: 0` to `setup_escrow` and `timeout_secs: 0` to deposit calls, preserving prior behaviour.

## Checklist
### Before Submitting
- [ ] I have run `make pre-commit` and all checks pass
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

### CI Requirements (must pass)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] `cargo build --target wasm32-unknown-unknown --release` succeeds

## Additional Notes
- `timeout_secs: 0` is a safe default — all existing callers passing `0` retain non-expiring escrow behaviour with no functional change.
- `EscrowStatus::Expired` is preserved in the enum for backward compatibility with any already-serialized on-chain data, but is no longer written by new code; `Refunded` is the new terminal state for reclaimed escrows.
- `get_confirmation_hash` and escrow storage helpers annotated with `#[allow(dead_code)]` are available for future settlement or audit integrations.