### PR TITLE
feat(mobile): add biometric auth, secure storage, and PIN fallback for sensitive actions

### DIFF
--- a/app/mobile/__tests__/SecurityService.test.ts
+++ b/app/mobile/__tests__/SecurityService.test.ts
@@ -1,0 +1,35 @@
+import {
+  clearSensitiveToken,
+  getSecuritySettings,
+  getSensitiveToken,
+  hasFallbackPin,
+  saveSecuritySettings,
+  saveSensitiveToken,
+  setFallbackPin,
+  verifyFallbackPin,
+} from "../services/security";
+
+describe("security service", () => {
+  it("persists and loads biometric settings", async () => {
+    await saveSecuritySettings({ biometricLockEnabled: true });
+
+    const loaded = await getSecuritySettings();
+    expect(loaded.biometricLockEnabled).toBe(true);
+  });
+
+  it("stores fallback PIN securely and verifies it", async () => {
+    await setFallbackPin("1234");
+
+    expect(await hasFallbackPin()).toBe(true);
+    expect(await verifyFallbackPin("1234")).toBe(true);
+    expect(await verifyFallbackPin("0000")).toBe(false);
+  });
+
+  it("stores sensitive token and can clear it", async () => {
+    await saveSensitiveToken("qex_session_abc123xyz");
+    expect(await getSensitiveToken()).toBe("qex_session_abc123xyz");
+
+    await clearSensitiveToken();
+    expect(await getSensitiveToken()).toBeNull();
+  });
+});

--- a/app/mobile/app.json
+++ b/app/mobile/app.json
@@ -10,9 +10,7 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "associatedDomains": [
-        "applinks:quickex.to"
-      ]
+      "associatedDomains": ["applinks:quickex.to"]
     },
     "android": {
       "adaptiveIcon": {
@@ -44,6 +42,12 @@
     },
     "plugins": [
       "expo-router",
+      [
+        "expo-local-authentication",
+        {
+          "faceIDPermission": "QuickEx uses Face ID to protect payments and sensitive wallet data."
+        }
+      ],
       [
         "expo-camera",
         {

--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -1,12 +1,18 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import * as Linking from 'expo-linking';
-import { Stack, useRouter } from 'expo-router';
-import { StatusBar } from 'expo-status-bar';
-import { useEffect } from 'react';
-import { useColorScheme } from 'react-native';
-import { OfflineBanner } from '../components/resilience/offline-banner';
+import {
+    DarkTheme,
+    DefaultTheme,
+    ThemeProvider,
+} from "@react-navigation/native";
+import * as Linking from "expo-linking";
+import { Stack, useRouter } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import { useEffect } from "react";
+import { useColorScheme } from "react-native";
+import { OfflineBanner } from "../components/resilience/offline-banner";
+import { AppLockOverlay } from "../components/security/app-lock-overlay";
+import { SecurityProvider, useSecurity } from "../hooks/use-security";
 
-import { parsePaymentLink } from '@/utils/parse-payment-link';
+import { parsePaymentLink } from "@/utils/parse-payment-link";
 
 function useDeepLinkHandler() {
   const router = useRouter();
@@ -18,7 +24,7 @@ function useDeepLinkHandler() {
 
       const { username, amount, asset, memo, privacy } = result.data;
       router.replace({
-        pathname: '/payment-confirmation',
+        pathname: "/payment-confirmation",
         params: {
           username,
           amount,
@@ -29,7 +35,7 @@ function useDeepLinkHandler() {
       });
     }
 
-    const subscription = Linking.addEventListener('url', handleURL);
+    const subscription = Linking.addEventListener("url", handleURL);
 
     // Handle cold-start deep link
     Linking.getInitialURL().then((url) => {
@@ -42,19 +48,35 @@ function useDeepLinkHandler() {
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+
+  return (
+    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+      <SecurityProvider>
+        <AppShell />
+      </SecurityProvider>
+      <StatusBar style="auto" />
+    </ThemeProvider>
+  );
+}
+
+function AppShell() {
+  const { isAppLocked, isReady, settings, unlockApp } = useSecurity();
   useDeepLinkHandler();
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    <>
       <OfflineBanner />
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="index" />
+        <Stack.Screen name="security" />
         <Stack.Screen name="wallet-connect" />
         <Stack.Screen name="scan-to-pay" />
         <Stack.Screen name="payment-confirmation" />
         <Stack.Screen name="transactions" />
       </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+      {isReady && settings.biometricLockEnabled ? (
+        <AppLockOverlay visible={isAppLocked} onUnlock={unlockApp} />
+      ) : null}
+    </>
   );
 }

--- a/app/mobile/app/index.tsx
+++ b/app/mobile/app/index.tsx
@@ -1,145 +1,148 @@
-import { Link } from 'expo-router';
-import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Link } from "expo-router";
+import React from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function HomeScreen() {
-    return (
-        <SafeAreaView style={styles.container}>
-            <View style={styles.content}>
-                <Text style={styles.title}>QuickEx</Text>
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>QuickEx</Text>
 
-                <Text style={styles.subtitle}>
-                    Fast, privacy-focused payment link platform built on Stellar.
-                </Text>
+        <Text style={styles.subtitle}>
+          Fast, privacy-focused payment link platform built on Stellar.
+        </Text>
 
-                <View style={styles.card}>
-                    <Text style={styles.cardTitle}>Instant Payments</Text>
-                    <Text style={styles.cardText}>
-                        Receive USDC, XLM, or any Stellar asset directly to your self-custody wallet.
-                    </Text>
-                </View>
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Instant Payments</Text>
+          <Text style={styles.cardText}>
+            Receive USDC, XLM, or any Stellar asset directly to your
+            self-custody wallet.
+          </Text>
+        </View>
 
-                <Link href="/scan-to-pay" asChild>
-                    <TouchableOpacity style={styles.primaryButton}>
-                        <Text style={styles.primaryButtonText}>Scan to Pay</Text>
-                    </TouchableOpacity>
-                </Link>
+        <Link href="/scan-to-pay" asChild>
+          <TouchableOpacity style={styles.primaryButton}>
+            <Text style={styles.primaryButtonText}>Scan to Pay</Text>
+          </TouchableOpacity>
+        </Link>
 
-                <Link href="/wallet-connect" asChild>
-                    <TouchableOpacity style={styles.primaryButton}>
-                        <Text style={styles.primaryButtonText}>Connect Wallet</Text>
-                    </TouchableOpacity>
-                </Link>
+        <Link href="/wallet-connect" asChild>
+          <TouchableOpacity style={styles.primaryButton}>
+            <Text style={styles.primaryButtonText}>Connect Wallet</Text>
+          </TouchableOpacity>
+        </Link>
 
-                {/* Quick Receive */}
-                <Link href="/quick-receive" asChild>
-                    <TouchableOpacity style={styles.quickReceiveButton}>
-                        <Text style={styles.quickReceiveButtonText}>
-                            Quick Receive
-                        </Text>
-                    </TouchableOpacity>
-                </Link>
+        <Link href="/security" asChild>
+          <TouchableOpacity style={styles.secondaryButton}>
+            <Text style={styles.secondaryButtonText}>Security Settings</Text>
+          </TouchableOpacity>
+        </Link>
 
-                {/* Transaction History */}
-                <Link href="/transactions" asChild>
-                    <TouchableOpacity style={styles.secondaryButton}>
-                        <Text style={styles.secondaryButtonText}>
-                            Transaction History
-                        </Text>
-                    </TouchableOpacity>
-                </Link>
-            </View>
-        </SafeAreaView>
-    );
+        {/* Quick Receive */}
+        <Link href="/quick-receive" asChild>
+          <TouchableOpacity style={styles.quickReceiveButton}>
+            <Text style={styles.quickReceiveButtonText}>Quick Receive</Text>
+          </TouchableOpacity>
+        </Link>
+
+        {/* Transaction History */}
+        <Link href="/transactions" asChild>
+          <TouchableOpacity style={styles.secondaryButton}>
+            <Text style={styles.secondaryButtonText}>Transaction History</Text>
+          </TouchableOpacity>
+        </Link>
+      </View>
+    </SafeAreaView>
+  );
 }
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: '#ffffff',
-    },
-    content: {
-        flex: 1,
-        padding: 24,
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    title: {
-        fontSize: 42,
-        fontWeight: 'bold',
-        color: '#000',
-        marginBottom: 8,
-    },
-    subtitle: {
-        fontSize: 18,
-        color: '#666',
-        textAlign: 'center',
-        marginBottom: 40,
-    },
-    card: {
-        width: '100%',
-        padding: 20,
-        borderRadius: 12,
-        backgroundColor: '#f5f5f5',
-        marginBottom: 30,
-    },
-    cardTitle: {
-        fontSize: 20,
-        fontWeight: '600',
-        color: '#333',
-        marginBottom: 8,
-    },
-    cardText: {
-        fontSize: 16,
-        color: '#555',
-        lineHeight: 22,
-    },
+  container: {
+    flex: 1,
+    backgroundColor: "#ffffff",
+  },
+  content: {
+    flex: 1,
+    padding: 24,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 42,
+    fontWeight: "bold",
+    color: "#000",
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 18,
+    color: "#666",
+    textAlign: "center",
+    marginBottom: 40,
+  },
+  card: {
+    width: "100%",
+    padding: 20,
+    borderRadius: 12,
+    backgroundColor: "#f5f5f5",
+    marginBottom: 30,
+  },
+  cardTitle: {
+    fontSize: 20,
+    fontWeight: "600",
+    color: "#333",
+    marginBottom: 8,
+  },
+  cardText: {
+    fontSize: 16,
+    color: "#555",
+    lineHeight: 22,
+  },
 
-    /* Primary Button */
-    primaryButton: {
-        backgroundColor: '#000',
-        paddingVertical: 16,
-        paddingHorizontal: 32,
-        borderRadius: 8,
-        width: '100%',
-        alignItems: 'center',
-        marginBottom: 12,
-    },
-    primaryButtonText: {
-        color: '#fff',
-        fontSize: 18,
-        fontWeight: 'bold',
-    },
-    /* Quick Receive Button */
-    quickReceiveButton: {
-        backgroundColor: '#10B981',
-        paddingVertical: 16,
-        paddingHorizontal: 32,
-        borderRadius: 8,
-        width: '100%',
-        alignItems: 'center',
-        marginBottom: 12,
-    },
-    quickReceiveButtonText: {
-        color: '#fff',
-        fontSize: 18,
-        fontWeight: '600',
-    },
+  /* Primary Button */
+  primaryButton: {
+    backgroundColor: "#000",
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+    width: "100%",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  primaryButtonText: {
+    color: "#fff",
+    fontSize: 18,
+    fontWeight: "bold",
+  },
+  /* Quick Receive Button */
+  quickReceiveButton: {
+    backgroundColor: "#10B981",
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+    width: "100%",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  quickReceiveButtonText: {
+    color: "#fff",
+    fontSize: 18,
+    fontWeight: "600",
+  },
 
-    /* Secondary Button */
-    secondaryButton: {
-        paddingVertical: 16,
-        paddingHorizontal: 32,
-        borderRadius: 8,
-        width: '100%',
-        alignItems: 'center',
-        borderWidth: 1,
-        borderColor: '#000',
-    },
-    secondaryButtonText: {
-        color: '#000',
-        fontSize: 18,
-        fontWeight: '600',
-    },
+  /* Secondary Button */
+  secondaryButton: {
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+    width: "100%",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#000",
+  },
+  secondaryButtonText: {
+    color: "#000",
+    fontSize: 18,
+    fontWeight: "600",
+  },
 });

--- a/app/mobile/app/payment-confirmation.tsx
+++ b/app/mobile/app/payment-confirmation.tsx
@@ -1,17 +1,14 @@
-import * as Linking from 'expo-linking';
-import { useLocalSearchParams, useRouter } from 'expo-router';
-import React from 'react';
-import {
-  Alert,
-  Pressable,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import * as Linking from "expo-linking";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import React from "react";
+import { Alert, Pressable, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { useSecurity } from "@/hooks/use-security";
 
 export default function PaymentConfirmationScreen() {
   const router = useRouter();
+  const { authenticateForSensitiveAction } = useSecurity();
   const params = useLocalSearchParams<{
     username: string;
     amount: string;
@@ -21,19 +18,30 @@ export default function PaymentConfirmationScreen() {
   }>();
 
   const { username, amount, asset, memo, privacy } = params;
-  const isPrivate = privacy === 'true';
+  const isPrivate = privacy === "true";
   const isValid = username && amount && asset;
 
   const handlePayWithWallet = async () => {
-    const stellarUri = `web+stellar:pay?destination=${username}&amount=${amount}&asset_code=${asset}${memo ? `&memo=${encodeURIComponent(memo)}` : ''}`;
+    const authorized = await authenticateForSensitiveAction(
+      "payment_authorization",
+    );
+    if (!authorized) {
+      Alert.alert(
+        "Authentication Required",
+        "You must authenticate with biometrics or PIN before sending payment.",
+      );
+      return;
+    }
+
+    const stellarUri = `web+stellar:pay?destination=${username}&amount=${amount}&asset_code=${asset}${memo ? `&memo=${encodeURIComponent(memo)}` : ""}`;
     const canOpen = await Linking.canOpenURL(stellarUri);
     if (canOpen) {
       await Linking.openURL(stellarUri);
     } else {
       Alert.alert(
-        'No Wallet Found',
-        'Install a Stellar-compatible wallet to complete this payment.',
-        [{ text: 'OK' }],
+        "No Wallet Found",
+        "Install a Stellar-compatible wallet to complete this payment.",
+        [{ text: "OK" }],
       );
     }
   };
@@ -46,10 +54,14 @@ export default function PaymentConfirmationScreen() {
             <Text style={styles.errorIcon}>!</Text>
             <Text style={styles.errorTitle}>Invalid Payment Link</Text>
             <Text style={styles.errorBody}>
-              This payment link is missing required information. Please try scanning again or check the link.
+              This payment link is missing required information. Please try
+              scanning again or check the link.
             </Text>
           </View>
-          <Pressable style={styles.secondaryBtn} onPress={() => router.replace('/')}>
+          <Pressable
+            style={styles.secondaryBtn}
+            onPress={() => router.replace("/")}
+          >
             <Text style={styles.secondaryBtnText}>Go Back</Text>
           </Pressable>
         </View>
@@ -61,7 +73,9 @@ export default function PaymentConfirmationScreen() {
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
         <Text style={styles.heading}>Confirm Payment</Text>
-        <Text style={styles.subheading}>Review the details below before paying</Text>
+        <Text style={styles.subheading}>
+          Review the details below before paying
+        </Text>
 
         <View style={styles.card}>
           <Row label="Recipient" value={`@${username}`} />
@@ -85,7 +99,10 @@ export default function PaymentConfirmationScreen() {
           <Pressable style={styles.primaryBtn} onPress={handlePayWithWallet}>
             <Text style={styles.primaryBtnText}>Pay with Wallet</Text>
           </Pressable>
-          <Pressable style={styles.secondaryBtn} onPress={() => router.replace('/')}>
+          <Pressable
+            style={styles.secondaryBtn}
+            onPress={() => router.replace("/")}
+          >
             <Text style={styles.secondaryBtnText}>Cancel</Text>
           </Pressable>
         </View>
@@ -114,72 +131,88 @@ function Row({
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#fff' },
+  container: { flex: 1, backgroundColor: "#fff" },
   content: {
     flex: 1,
     padding: 24,
-    justifyContent: 'center',
+    justifyContent: "center",
   },
   heading: {
     fontSize: 32,
-    fontWeight: 'bold',
-    color: '#000',
+    fontWeight: "bold",
+    color: "#000",
     marginBottom: 4,
   },
   subheading: {
     fontSize: 16,
-    color: '#888',
+    color: "#888",
     marginBottom: 32,
   },
   card: {
-    backgroundColor: '#F5F5F5',
+    backgroundColor: "#F5F5F5",
     borderRadius: 16,
     padding: 20,
     marginBottom: 40,
   },
   row: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     paddingVertical: 14,
   },
-  rowLabel: { fontSize: 15, color: '#888' },
-  rowValue: { fontSize: 16, fontWeight: '500', color: '#222', flexShrink: 1, textAlign: 'right' },
-  rowValueHighlight: { fontSize: 20, fontWeight: '700', color: '#000' },
-  divider: { height: 1, backgroundColor: '#E5E5E5' },
+  rowLabel: { fontSize: 15, color: "#888" },
+  rowValue: {
+    fontSize: 16,
+    fontWeight: "500",
+    color: "#222",
+    flexShrink: 1,
+    textAlign: "right",
+  },
+  rowValueHighlight: { fontSize: 20, fontWeight: "700", color: "#000" },
+  divider: { height: 1, backgroundColor: "#E5E5E5" },
   actions: { gap: 12 },
   primaryBtn: {
-    backgroundColor: '#000',
+    backgroundColor: "#000",
     paddingVertical: 16,
     borderRadius: 12,
-    alignItems: 'center',
+    alignItems: "center",
   },
-  primaryBtnText: { color: '#fff', fontSize: 18, fontWeight: '700' },
+  primaryBtnText: { color: "#fff", fontSize: 18, fontWeight: "700" },
   secondaryBtn: {
     paddingVertical: 14,
-    alignItems: 'center',
+    alignItems: "center",
   },
-  secondaryBtnText: { color: '#888', fontSize: 16, fontWeight: '500' },
+  secondaryBtnText: { color: "#888", fontSize: 16, fontWeight: "500" },
   errorCard: {
-    backgroundColor: '#FFF3F3',
+    backgroundColor: "#FFF3F3",
     borderRadius: 16,
     padding: 32,
-    alignItems: 'center',
+    alignItems: "center",
     marginBottom: 24,
   },
   errorIcon: {
     fontSize: 36,
-    fontWeight: 'bold',
-    color: '#FF3B30',
-    backgroundColor: '#FFE5E5',
+    fontWeight: "bold",
+    color: "#FF3B30",
+    backgroundColor: "#FFE5E5",
     width: 56,
     height: 56,
     lineHeight: 56,
     borderRadius: 28,
-    textAlign: 'center',
+    textAlign: "center",
     marginBottom: 16,
-    overflow: 'hidden',
+    overflow: "hidden",
   },
-  errorTitle: { fontSize: 22, fontWeight: '700', color: '#222', marginBottom: 8 },
-  errorBody: { fontSize: 15, color: '#888', textAlign: 'center', lineHeight: 22 },
+  errorTitle: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: "#222",
+    marginBottom: 8,
+  },
+  errorBody: {
+    fontSize: 15,
+    color: "#888",
+    textAlign: "center",
+    lineHeight: 22,
+  },
 });

--- a/app/mobile/app/security.tsx
+++ b/app/mobile/app/security.tsx
@@ -1,0 +1,228 @@
+import React, { useState } from "react";
+import {
+    Alert,
+    Pressable,
+    StyleSheet,
+    Switch,
+    Text,
+    TextInput,
+    View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { useSecurity } from "@/hooks/use-security";
+
+export default function SecurityScreen() {
+  const {
+    settings,
+    isBiometricAvailable,
+    hasPinConfigured,
+    setBiometricLockEnabled,
+    savePin,
+  } = useSecurity();
+
+  const [pin, setPin] = useState("");
+  const [confirmPin, setConfirmPin] = useState("");
+  const [savingPin, setSavingPin] = useState(false);
+
+  const submitPin = async () => {
+    if (pin !== confirmPin) {
+      Alert.alert("PIN mismatch", "PIN and confirmation must match.");
+      return;
+    }
+
+    setSavingPin(true);
+    const result = await savePin(pin);
+    setSavingPin(false);
+
+    if (!result.ok) {
+      Alert.alert(
+        "Invalid PIN",
+        result.error ?? "Please check the PIN format.",
+      );
+      return;
+    }
+
+    setPin("");
+    setConfirmPin("");
+    Alert.alert("PIN saved", "Fallback PIN is now configured securely.");
+  };
+
+  const onToggle = async (enabled: boolean) => {
+    const result = await setBiometricLockEnabled(enabled);
+    if (!result.ok) {
+      Alert.alert(
+        "Security setup required",
+        result.error ?? "Could not update setting.",
+      );
+      return;
+    }
+
+    Alert.alert(
+      enabled ? "Biometric lock enabled" : "Biometric lock disabled",
+      enabled
+        ? "QuickEx will require biometrics or fallback PIN when opening and before sensitive actions."
+        : "Biometric lock has been turned off.",
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Security</Text>
+        <Text style={styles.subtitle}>
+          Protect sensitive flows with biometrics and a fallback PIN.
+        </Text>
+
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <View style={styles.rowTextWrap}>
+              <Text style={styles.rowTitle}>Enable Biometric Lock</Text>
+              <Text style={styles.rowBody}>
+                Prompt on app open and before critical transactions.
+              </Text>
+            </View>
+            <Switch
+              value={settings.biometricLockEnabled}
+              onValueChange={onToggle}
+              disabled={!isBiometricAvailable}
+            />
+          </View>
+
+          <View style={styles.divider} />
+
+          <Text style={styles.supportText}>
+            {isBiometricAvailable
+              ? "Biometric hardware is available on this device."
+              : "Biometrics unavailable. You can still set fallback PIN now and enable biometrics when available."}
+          </Text>
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.rowTitle}>
+            {hasPinConfigured ? "Change Fallback PIN" : "Set Fallback PIN"}
+          </Text>
+          <Text style={styles.rowBody}>
+            PIN is stored as a hash in secure storage and used when biometrics
+            fail or are unavailable.
+          </Text>
+
+          <TextInput
+            style={styles.input}
+            placeholder="Enter 4-6 digit PIN"
+            placeholderTextColor="#9CA3AF"
+            value={pin}
+            onChangeText={(value) => setPin(value.replace(/[^0-9]/g, ""))}
+            secureTextEntry
+            keyboardType="number-pad"
+            maxLength={6}
+          />
+          <TextInput
+            style={styles.input}
+            placeholder="Confirm PIN"
+            placeholderTextColor="#9CA3AF"
+            value={confirmPin}
+            onChangeText={(value) =>
+              setConfirmPin(value.replace(/[^0-9]/g, ""))
+            }
+            secureTextEntry
+            keyboardType="number-pad"
+            maxLength={6}
+          />
+
+          <Pressable
+            style={styles.saveBtn}
+            onPress={submitPin}
+            disabled={savingPin}
+          >
+            <Text style={styles.saveBtnText}>
+              {savingPin ? "Saving..." : "Save PIN"}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#FFFFFF",
+  },
+  content: {
+    flex: 1,
+    padding: 24,
+  },
+  title: {
+    fontSize: 34,
+    fontWeight: "800",
+    color: "#111827",
+  },
+  subtitle: {
+    marginTop: 8,
+    fontSize: 16,
+    color: "#6B7280",
+    marginBottom: 26,
+    lineHeight: 22,
+  },
+  card: {
+    backgroundColor: "#F9FAFB",
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 16,
+  },
+  rowTextWrap: {
+    flex: 1,
+  },
+  rowTitle: {
+    fontSize: 17,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 4,
+  },
+  rowBody: {
+    color: "#6B7280",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  supportText: {
+    color: "#4B5563",
+    fontSize: 13,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: "#E5E7EB",
+    marginVertical: 14,
+  },
+  input: {
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    marginTop: 12,
+    fontSize: 15,
+  },
+  saveBtn: {
+    marginTop: 14,
+    backgroundColor: "#111827",
+    borderRadius: 12,
+    alignItems: "center",
+    paddingVertical: 14,
+  },
+  saveBtnText: {
+    color: "#fff",
+    fontWeight: "700",
+    fontSize: 16,
+  },
+});

--- a/app/mobile/app/wallet-connect.tsx
+++ b/app/mobile/app/wallet-connect.tsx
@@ -1,33 +1,79 @@
+import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import React, { useState } from "react";
-import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+import { Alert, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+
 import { useNetworkStatus } from "../hooks/use-network-status";
-import { Ionicons } from "@expo/vector-icons";
+import { useSecurity } from "../hooks/use-security";
 
 type Network = "testnet" | "mainnet";
+
+function generateMockSessionToken() {
+  const random = Math.random().toString(36).slice(2, 14);
+  return `qex_session_${random}`;
+}
 
 export default function WalletConnectScreen() {
   const router = useRouter();
   const { isConnected } = useNetworkStatus();
+  const {
+    authenticateForSensitiveAction,
+    clearSensitiveSessionToken,
+    getSensitiveSessionToken,
+    saveSensitiveSessionToken,
+  } = useSecurity();
 
   const [connected, setConnected] = useState(false);
   const [network, setNetwork] = useState<Network>("testnet");
   const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [sessionTokenPreview, setSessionTokenPreview] = useState<string | null>(
+    null,
+  );
 
-  const handleConnect = () => {
-    // Mock connection (replace later with real wallet integration)
+  const handleConnect = async () => {
+    const mockPublicKey = "GABCD1234MOCKPUBLICKEY5678XYZ";
     setConnected(true);
-    setPublicKey("GABCD1234MOCKPUBLICKEY5678XYZ");
+    setPublicKey(mockPublicKey);
+
+    // Store wallet session token in secure storage, never in AsyncStorage/plain files.
+    await saveSensitiveSessionToken(generateMockSessionToken());
+    setSessionTokenPreview(null);
   };
 
-  const handleDisconnect = () => {
+  const handleDisconnect = async () => {
     setConnected(false);
     setPublicKey(null);
+    setSessionTokenPreview(null);
+    await clearSensitiveSessionToken();
   };
 
   const toggleNetwork = () => {
     setNetwork((prev) => (prev === "testnet" ? "mainnet" : "testnet"));
+  };
+
+  const revealSessionToken = async () => {
+    const authorized = await authenticateForSensitiveAction(
+      "sensitive_data_access",
+    );
+    if (!authorized) {
+      Alert.alert(
+        "Authentication Required",
+        "Use biometrics or fallback PIN to reveal secure session data.",
+      );
+      return;
+    }
+
+    const token = await getSensitiveSessionToken();
+    if (!token) {
+      Alert.alert(
+        "No token found",
+        "No secure session token is currently stored.",
+      );
+      return;
+    }
+
+    setSessionTokenPreview(`${token.slice(0, 8)}...${token.slice(-4)}`);
   };
 
   return (
@@ -35,50 +81,32 @@ export default function WalletConnectScreen() {
       <View style={styles.content}>
         <Text style={styles.title}>Wallet Connection</Text>
         <Text style={styles.subtitle}>
-          Securely connect your Stellar wallet to manage your payments.
+          Connect your Stellar wallet and protect sensitive wallet data with
+          biometric security.
         </Text>
 
-        {/* Network Indicator */}
-        <View style={styles.row}>
-          <Text style={styles.label}>Network:</Text>
-          <TouchableOpacity
-            style={[
-              styles.networkBadge,
-              network === "mainnet" ? styles.mainnet : styles.testnet,
-            ]}
-            onPress={toggleNetwork}
-          >
-            <Text style={styles.networkText}>{network.toUpperCase()}</Text>
-          </TouchableOpacity>
-        </View>
-
-        {/* Connection Status */}
-        <View style={styles.row}>
-          <Text style={styles.label}>Status:</Text>
-          <Text style={connected ? styles.connected : styles.disconnected}>
-            {connected ? "Connected" : "Not Connected"}
-          </Text>
-          {isConnected === false && (
-            <View style={styles.offlineAdvice}>
-              <Ionicons
-                name="information-circle-outline"
-                size={18}
-                color="#991B1B"
-              />
-              <Text style={styles.offlineAdviceText}>
-                Connection required to link a new wallet.
-              </Text>
-            </View>
-          )}
-          {/* Connection Status */}
+        <View style={styles.card}>
           <View style={styles.row}>
-            <Text style={styles.label}>Status:</Text>
+            <Text style={styles.label}>Network</Text>
+            <Pressable
+              style={[
+                styles.networkBadge,
+                network === "mainnet" ? styles.mainnet : styles.testnet,
+              ]}
+              onPress={toggleNetwork}
+            >
+              <Text style={styles.networkText}>{network.toUpperCase()}</Text>
+            </Pressable>
+          </View>
+
+          <View style={styles.row}>
+            <Text style={styles.label}>Status</Text>
             <Text style={connected ? styles.connected : styles.disconnected}>
               {connected ? "Connected" : "Not Connected"}
             </Text>
-          </View>{" "}
-          {/* ← close the row here */}
-          {isConnected === false && (
+          </View>
+
+          {!isConnected ? (
             <View style={styles.offlineAdvice}>
               <Ionicons
                 name="information-circle-outline"
@@ -86,37 +114,48 @@ export default function WalletConnectScreen() {
                 color="#991B1B"
               />
               <Text style={styles.offlineAdviceText}>
-                Connection required to link a new wallet.
+                Internet connection is required to link a new wallet.
               </Text>
             </View>
-          )}
-          {/* Public Key */}
-          {connected && publicKey && (
+          ) : null}
+
+          {connected && publicKey ? (
             <Text style={styles.address}>{publicKey}</Text>
-          )}
-          {/* Connect / Disconnect Button */}
+          ) : null}
+
           {!connected ? (
-            <TouchableOpacity
-              style={styles.connectButton}
-              onPress={handleConnect}
-            >
+            <Pressable style={styles.connectButton} onPress={handleConnect}>
               <Text style={styles.buttonText}>Connect Wallet</Text>
-            </TouchableOpacity>
+            </Pressable>
           ) : (
-            <TouchableOpacity
-              style={styles.disconnectButton}
-              onPress={handleDisconnect}
-            >
-              <Text style={styles.buttonText}>Disconnect</Text>
-            </TouchableOpacity>
+            <>
+              <Pressable
+                style={styles.secondaryButton}
+                onPress={revealSessionToken}
+              >
+                <Text style={styles.secondaryButtonText}>
+                  Reveal Secure Session Token
+                </Text>
+              </Pressable>
+              {sessionTokenPreview ? (
+                <Text style={styles.tokenPreview}>
+                  Token: {sessionTokenPreview}
+                </Text>
+              ) : null}
+
+              <Pressable
+                style={styles.disconnectButton}
+                onPress={handleDisconnect}
+              >
+                <Text style={styles.buttonText}>Disconnect</Text>
+              </Pressable>
+            </>
           )}
-          <TouchableOpacity
-            style={styles.backButton}
-            onPress={() => router.back()}
-          >
-            <Text style={styles.backButtonText}>Go Back</Text>
-          </TouchableOpacity>
         </View>
+
+        <Pressable style={styles.backButton} onPress={() => router.back()}>
+          <Text style={styles.backButtonText}>Go Back</Text>
+        </Pressable>
       </View>
     </SafeAreaView>
   );
@@ -136,21 +175,31 @@ const styles = StyleSheet.create({
     fontWeight: "bold",
     marginTop: 40,
     marginBottom: 12,
+    color: "#111827",
   },
   subtitle: {
     fontSize: 16,
-    color: "#666",
-    marginBottom: 40,
+    color: "#6B7280",
+    marginBottom: 28,
+    lineHeight: 22,
+  },
+  card: {
+    backgroundColor: "#F9FAFB",
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    padding: 16,
   },
   row: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 16,
+    marginBottom: 14,
   },
   label: {
     fontSize: 16,
-    fontWeight: "600",
+    fontWeight: "700",
+    color: "#111827",
   },
   networkBadge: {
     paddingHorizontal: 12,
@@ -165,55 +214,24 @@ const styles = StyleSheet.create({
   },
   networkText: {
     color: "#fff",
-    fontWeight: "600",
+    fontWeight: "700",
   },
   connected: {
     color: "#10B981",
-    fontWeight: "600",
+    fontWeight: "700",
   },
   disconnected: {
     color: "#EF4444",
-    fontWeight: "600",
-  },
-  address: {
-    fontSize: 12,
-    marginBottom: 20,
-  },
-  connectButton: {
-    backgroundColor: "#000",
-    padding: 16,
-    borderRadius: 8,
-    alignItems: "center",
-    marginBottom: 12,
-  },
-  disconnectButton: {
-    backgroundColor: "#EF4444",
-    padding: 16,
-    borderRadius: 8,
-    alignItems: "center",
-    marginBottom: 12,
-  },
-  buttonText: {
-    color: "#fff",
-    fontWeight: "600",
-    fontSize: 16,
-  },
-  backButton: {
-    marginTop: 30,
-    alignItems: "center",
-  },
-  backButtonText: {
-    color: "#666",
-    fontSize: 16,
+    fontWeight: "700",
   },
   offlineAdvice: {
     flexDirection: "row",
     alignItems: "center",
     backgroundColor: "#FEF2F2",
-    paddingVertical: 8,
-    paddingHorizontal: 16,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
     borderRadius: 8,
-    marginBottom: 20,
+    marginBottom: 16,
     gap: 8,
     borderWidth: 1,
     borderColor: "#FECACA",
@@ -222,14 +240,53 @@ const styles = StyleSheet.create({
     color: "#991B1B",
     fontSize: 13,
     fontWeight: "500",
+    flex: 1,
   },
-  disabledButton: {
-    backgroundColor: "#E5E7EB",
+  address: {
+    fontSize: 12,
+    color: "#374151",
+    marginBottom: 16,
   },
-  disabledSecondaryButton: {
-    borderColor: "#E5E7EB",
+  connectButton: {
+    backgroundColor: "#111827",
+    padding: 16,
+    borderRadius: 10,
+    alignItems: "center",
   },
-  disabledText: {
-    color: "#9CA3AF",
+  disconnectButton: {
+    backgroundColor: "#EF4444",
+    padding: 16,
+    borderRadius: 10,
+    alignItems: "center",
+    marginTop: 12,
+  },
+  secondaryButton: {
+    borderColor: "#111827",
+    borderWidth: 1,
+    padding: 14,
+    borderRadius: 10,
+    alignItems: "center",
+  },
+  secondaryButtonText: {
+    color: "#111827",
+    fontWeight: "700",
+  },
+  tokenPreview: {
+    marginTop: 10,
+    fontSize: 13,
+    color: "#4B5563",
+  },
+  buttonText: {
+    color: "#fff",
+    fontWeight: "700",
+    fontSize: 16,
+  },
+  backButton: {
+    marginTop: 22,
+    alignItems: "center",
+  },
+  backButtonText: {
+    color: "#6B7280",
+    fontSize: 16,
   },
 });

--- a/app/mobile/components/security/app-lock-overlay.tsx
+++ b/app/mobile/components/security/app-lock-overlay.tsx
@@ -1,0 +1,116 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+interface AppLockOverlayProps {
+  visible: boolean;
+  onUnlock: () => Promise<boolean>;
+}
+
+export function AppLockOverlay({ visible, onUnlock }: AppLockOverlayProps) {
+  const [unlocking, setUnlocking] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const attemptedAutoUnlock = useRef(false);
+
+  const unlock = useCallback(async () => {
+    setUnlocking(true);
+    setErrorMessage(null);
+
+    const authenticated = await onUnlock();
+    if (!authenticated) {
+      setErrorMessage("Authentication was not completed. Please try again.");
+    }
+
+    setUnlocking(false);
+  }, [onUnlock]);
+
+  useEffect(() => {
+    if (!visible) {
+      attemptedAutoUnlock.current = false;
+      setErrorMessage(null);
+      return;
+    }
+
+    if (attemptedAutoUnlock.current) return;
+    attemptedAutoUnlock.current = true;
+
+    unlock();
+  }, [unlock, visible]);
+
+  if (!visible) return null;
+
+  return (
+    <View style={styles.overlay}>
+      <View style={styles.card}>
+        <Text style={styles.title}>QuickEx Security Lock</Text>
+        <Text style={styles.body}>
+          Use biometrics or your fallback PIN to continue.
+        </Text>
+
+        {unlocking ? <ActivityIndicator size="small" color="#111827" /> : null}
+        {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
+
+        <Pressable style={styles.button} onPress={unlock} disabled={unlocking}>
+          <Text style={styles.buttonText}>Unlock App</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(17, 24, 39, 0.74)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+    zIndex: 30,
+  },
+  card: {
+    width: "100%",
+    maxWidth: 380,
+    borderRadius: 20,
+    backgroundColor: "#fff",
+    padding: 24,
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "800",
+    color: "#111827",
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  body: {
+    color: "#6B7280",
+    fontSize: 15,
+    textAlign: "center",
+    lineHeight: 22,
+    marginBottom: 16,
+  },
+  error: {
+    color: "#B91C1C",
+    marginTop: 10,
+    marginBottom: 8,
+    fontSize: 13,
+  },
+  button: {
+    marginTop: 8,
+    backgroundColor: "#111827",
+    borderRadius: 12,
+    width: "100%",
+    alignItems: "center",
+    paddingVertical: 14,
+  },
+  buttonText: {
+    color: "#fff",
+    fontWeight: "700",
+    fontSize: 16,
+  },
+});

--- a/app/mobile/components/security/pin-auth-modal.tsx
+++ b/app/mobile/components/security/pin-auth-modal.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import {
+    ActivityIndicator,
+    Modal,
+    Pressable,
+    StyleSheet,
+    Text,
+    TextInput,
+    View,
+} from "react-native";
+
+interface PinAuthModalProps {
+  visible: boolean;
+  title: string;
+  description: string;
+  pin: string;
+  errorMessage: string | null;
+  submitting: boolean;
+  onPinChange: (value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+export function PinAuthModal({
+  visible,
+  title,
+  description,
+  pin,
+  errorMessage,
+  submitting,
+  onPinChange,
+  onSubmit,
+  onCancel,
+}: PinAuthModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.card}>
+          <Text style={styles.title}>{title}</Text>
+          <Text style={styles.description}>{description}</Text>
+
+          <TextInput
+            value={pin}
+            onChangeText={onPinChange}
+            style={styles.input}
+            maxLength={6}
+            keyboardType="number-pad"
+            secureTextEntry
+            placeholder="Enter 4-6 digit PIN"
+            placeholderTextColor="#9CA3AF"
+            autoFocus
+          />
+
+          {errorMessage ? (
+            <Text style={styles.errorText}>{errorMessage}</Text>
+          ) : null}
+
+          <View style={styles.actions}>
+            <Pressable
+              style={styles.cancelBtn}
+              onPress={onCancel}
+              disabled={submitting}
+            >
+              <Text style={styles.cancelText}>Cancel</Text>
+            </Pressable>
+            <Pressable
+              style={styles.confirmBtn}
+              onPress={onSubmit}
+              disabled={submitting}
+            >
+              {submitting ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={styles.confirmText}>Verify PIN</Text>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.45)",
+    justifyContent: "center",
+    padding: 24,
+  },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 20,
+    padding: 24,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 8,
+  },
+  description: {
+    fontSize: 14,
+    color: "#6B7280",
+    lineHeight: 20,
+    marginBottom: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+    marginBottom: 10,
+  },
+  errorText: {
+    color: "#B91C1C",
+    fontSize: 13,
+    marginBottom: 8,
+  },
+  actions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 10,
+    marginTop: 4,
+  },
+  cancelBtn: {
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    backgroundColor: "#F3F4F6",
+  },
+  cancelText: {
+    color: "#374151",
+    fontWeight: "600",
+  },
+  confirmBtn: {
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    backgroundColor: "#111827",
+    minWidth: 100,
+    alignItems: "center",
+  },
+  confirmText: {
+    color: "#fff",
+    fontWeight: "700",
+  },
+});

--- a/app/mobile/hooks/use-security.tsx
+++ b/app/mobile/hooks/use-security.tsx
@@ -1,0 +1,349 @@
+import * as LocalAuthentication from "expo-local-authentication";
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import { AppState, Platform } from "react-native";
+
+import { PinAuthModal } from "@/components/security/pin-auth-modal";
+import {
+    clearSensitiveToken,
+    getSecuritySettings,
+    getSensitiveToken,
+    hasFallbackPin,
+    saveSecuritySettings,
+    saveSensitiveToken,
+    setFallbackPin,
+    verifyFallbackPin,
+} from "@/services/security";
+import type { SecurityAuthReason, SecuritySettings } from "@/types/security";
+
+interface ToggleResult {
+  ok: boolean;
+  error?: string;
+}
+
+interface SavePinResult {
+  ok: boolean;
+  error?: string;
+}
+
+interface SecurityContextValue {
+  isReady: boolean;
+  isAppLocked: boolean;
+  isBiometricAvailable: boolean;
+  hasPinConfigured: boolean;
+  settings: SecuritySettings;
+  setBiometricLockEnabled: (enabled: boolean) => Promise<ToggleResult>;
+  savePin: (pin: string) => Promise<SavePinResult>;
+  unlockApp: () => Promise<boolean>;
+  authenticateForSensitiveAction: (
+    reason: SecurityAuthReason,
+  ) => Promise<boolean>;
+  saveSensitiveSessionToken: (token: string) => Promise<void>;
+  getSensitiveSessionToken: () => Promise<string | null>;
+  clearSensitiveSessionToken: () => Promise<void>;
+}
+
+const SecurityContext = createContext<SecurityContextValue | null>(null);
+
+const DEFAULT_SETTINGS: SecuritySettings = {
+  biometricLockEnabled: false,
+};
+
+const PIN_DESCRIPTION_BY_REASON: Record<SecurityAuthReason, string> = {
+  app_unlock: "Enter your fallback PIN to unlock QuickEx.",
+  payment_authorization: "Enter your fallback PIN to authorize this payment.",
+  sensitive_data_access: "Enter your fallback PIN to reveal sensitive data.",
+};
+
+function isValidPin(pin: string) {
+  return /^\d{4,6}$/.test(pin);
+}
+
+async function checkBiometricAvailability() {
+  if (Platform.OS === "web") return false;
+
+  try {
+    const hasHardware = await LocalAuthentication.hasHardwareAsync();
+    const enrolled = await LocalAuthentication.isEnrolledAsync();
+    return hasHardware && enrolled;
+  } catch {
+    return false;
+  }
+}
+
+export function SecurityProvider({ children }: { children: React.ReactNode }) {
+  const [settings, setSettings] = useState<SecuritySettings>(DEFAULT_SETTINGS);
+  const [isReady, setIsReady] = useState(false);
+  const [isBiometricAvailable, setIsBiometricAvailable] = useState(false);
+  const [hasPinConfigured, setHasPinConfigured] = useState(false);
+  const [isAppLocked, setIsAppLocked] = useState(false);
+
+  const [pinPromptVisible, setPinPromptVisible] = useState(false);
+  const [pinPromptDescription, setPinPromptDescription] = useState(
+    PIN_DESCRIPTION_BY_REASON.app_unlock,
+  );
+  const [pinInput, setPinInput] = useState("");
+  const [pinError, setPinError] = useState<string | null>(null);
+  const [verifyingPin, setVerifyingPin] = useState(false);
+
+  const pinResolverRef = useRef<((result: boolean) => void) | null>(null);
+  const shouldLockOnNextActiveRef = useRef(false);
+
+  const initialize = useCallback(async () => {
+    const [storedSettings, biometricAvailable, pinConfigured] =
+      await Promise.all([
+        getSecuritySettings(),
+        checkBiometricAvailability(),
+        hasFallbackPin(),
+      ]);
+
+    setSettings(storedSettings);
+    setIsBiometricAvailable(biometricAvailable);
+    setHasPinConfigured(pinConfigured);
+    setIsAppLocked(storedSettings.biometricLockEnabled);
+    setIsReady(true);
+  }, []);
+
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState !== "active") {
+        shouldLockOnNextActiveRef.current = true;
+        return;
+      }
+
+      if (
+        nextState === "active" &&
+        shouldLockOnNextActiveRef.current &&
+        settings.biometricLockEnabled
+      ) {
+        setIsAppLocked(true);
+      }
+      shouldLockOnNextActiveRef.current = false;
+    });
+
+    return () => subscription.remove();
+  }, [settings.biometricLockEnabled]);
+
+  const openPinPrompt = useCallback((reason: SecurityAuthReason) => {
+    return new Promise<boolean>((resolve) => {
+      pinResolverRef.current = resolve;
+      setPinPromptDescription(PIN_DESCRIPTION_BY_REASON[reason]);
+      setPinInput("");
+      setPinError(null);
+      setPinPromptVisible(true);
+    });
+  }, []);
+
+  const resolvePinPrompt = useCallback((result: boolean) => {
+    if (pinResolverRef.current) {
+      pinResolverRef.current(result);
+      pinResolverRef.current = null;
+    }
+    setPinPromptVisible(false);
+    setPinInput("");
+    setPinError(null);
+  }, []);
+
+  const tryBiometricAuth = useCallback(
+    async (reason: SecurityAuthReason) => {
+      if (!settings.biometricLockEnabled || !isBiometricAvailable) {
+        return false;
+      }
+
+      const promptMessage =
+        reason === "payment_authorization"
+          ? "Authenticate to approve payment"
+          : reason === "sensitive_data_access"
+            ? "Authenticate to access sensitive data"
+            : "Authenticate to unlock QuickEx";
+
+      try {
+        const result = await LocalAuthentication.authenticateAsync({
+          promptMessage,
+          disableDeviceFallback: true,
+          cancelLabel: "Use PIN",
+        });
+
+        return result.success;
+      } catch {
+        return false;
+      }
+    },
+    [isBiometricAvailable, settings.biometricLockEnabled],
+  );
+
+  const authenticateForSensitiveAction = useCallback(
+    async (reason: SecurityAuthReason) => {
+      if (!settings.biometricLockEnabled) return true;
+
+      const biometricOk = await tryBiometricAuth(reason);
+      if (biometricOk) return true;
+
+      if (!hasPinConfigured) return false;
+
+      return openPinPrompt(reason);
+    },
+    [
+      hasPinConfigured,
+      openPinPrompt,
+      settings.biometricLockEnabled,
+      tryBiometricAuth,
+    ],
+  );
+
+  const unlockApp = useCallback(async () => {
+    const authenticated = await authenticateForSensitiveAction("app_unlock");
+    if (authenticated) {
+      setIsAppLocked(false);
+    }
+
+    return authenticated;
+  }, [authenticateForSensitiveAction]);
+
+  const setBiometricLockEnabled = useCallback(
+    async (enabled: boolean) => {
+      if (enabled && !hasPinConfigured) {
+        return {
+          ok: false,
+          error: "Set a fallback PIN first before enabling biometric lock.",
+        };
+      }
+
+      const nextSettings: SecuritySettings = {
+        ...settings,
+        biometricLockEnabled: enabled,
+      };
+
+      await saveSecuritySettings(nextSettings);
+      setSettings(nextSettings);
+
+      if (!enabled) {
+        setIsAppLocked(false);
+      } else {
+        setIsAppLocked(true);
+      }
+
+      return { ok: true };
+    },
+    [hasPinConfigured, settings],
+  );
+
+  const savePin = useCallback(async (pin: string) => {
+    if (!isValidPin(pin)) {
+      return {
+        ok: false,
+        error: "PIN must be 4 to 6 digits.",
+      };
+    }
+
+    await setFallbackPin(pin);
+    setHasPinConfigured(true);
+
+    return { ok: true };
+  }, []);
+
+  const saveSensitiveSessionToken = useCallback(async (token: string) => {
+    await saveSensitiveToken(token);
+  }, []);
+
+  const getSensitiveSessionToken = useCallback(async () => {
+    return getSensitiveToken();
+  }, []);
+
+  const clearSensitiveSessionToken = useCallback(async () => {
+    await clearSensitiveToken();
+  }, []);
+
+  const contextValue = useMemo<SecurityContextValue>(
+    () => ({
+      isReady,
+      isAppLocked,
+      isBiometricAvailable,
+      hasPinConfigured,
+      settings,
+      setBiometricLockEnabled,
+      savePin,
+      unlockApp,
+      authenticateForSensitiveAction,
+      saveSensitiveSessionToken,
+      getSensitiveSessionToken,
+      clearSensitiveSessionToken,
+    }),
+    [
+      authenticateForSensitiveAction,
+      clearSensitiveSessionToken,
+      getSensitiveSessionToken,
+      hasPinConfigured,
+      isAppLocked,
+      isBiometricAvailable,
+      isReady,
+      savePin,
+      saveSensitiveSessionToken,
+      setBiometricLockEnabled,
+      settings,
+      unlockApp,
+    ],
+  );
+
+  const onSubmitPin = useCallback(async () => {
+    if (!isValidPin(pinInput)) {
+      setPinError("PIN must contain 4 to 6 digits.");
+      return;
+    }
+
+    setVerifyingPin(true);
+    const valid = await verifyFallbackPin(pinInput);
+    setVerifyingPin(false);
+
+    if (!valid) {
+      setPinError("Incorrect PIN. Please try again.");
+      return;
+    }
+
+    resolvePinPrompt(true);
+  }, [pinInput, resolvePinPrompt]);
+
+  const onCancelPin = useCallback(() => {
+    resolvePinPrompt(false);
+  }, [resolvePinPrompt]);
+
+  return (
+    <SecurityContext.Provider value={contextValue}>
+      {children}
+      <PinAuthModal
+        visible={pinPromptVisible}
+        title="PIN Required"
+        description={pinPromptDescription}
+        pin={pinInput}
+        errorMessage={pinError}
+        submitting={verifyingPin}
+        onPinChange={(value) => {
+          setPinInput(value.replace(/[^0-9]/g, ""));
+          if (pinError) setPinError(null);
+        }}
+        onSubmit={onSubmitPin}
+        onCancel={onCancelPin}
+      />
+    </SecurityContext.Provider>
+  );
+}
+
+export function useSecurity() {
+  const ctx = useContext(SecurityContext);
+  if (!ctx) {
+    throw new Error("useSecurity must be used within SecurityProvider");
+  }
+
+  return ctx;
+}

--- a/app/mobile/jest.setup.js
+++ b/app/mobile/jest.setup.js
@@ -1,21 +1,47 @@
 // Mock react-native-safe-area-context: replace SafeAreaView with a plain View
-jest.mock('react-native-safe-area-context', () => ({
-    SafeAreaView: ({ children, ...props }) => {
-        const React = require('react');
-        const { View } = require('react-native');
-        return React.createElement(View, props, children);
-    },
-    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-    SafeAreaProvider: ({ children }) => children,
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: ({ children, ...props }) => {
+    const React = require("react");
+    const { View } = require("react-native");
+    return React.createElement(View, props, children);
+  },
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  SafeAreaProvider: ({ children }) => children,
 }));
 
 // Mock vector icons to avoid async font loading in tests
-jest.mock('@expo/vector-icons', () => {
-    return {
-        Ionicons: ({ name, ...props }) => {
-            const React = require('react');
-            const { Text } = require('react-native');
-            return React.createElement(Text, props, name);
-        },
-    };
+jest.mock("@expo/vector-icons", () => {
+  return {
+    Ionicons: ({ name, ...props }) => {
+      const React = require("react");
+      const { Text } = require("react-native");
+      return React.createElement(Text, props, name);
+    },
+  };
+});
+
+jest.mock("expo-local-authentication", () => ({
+  hasHardwareAsync: jest.fn(async () => true),
+  isEnrolledAsync: jest.fn(async () => true),
+  authenticateAsync: jest.fn(async () => ({ success: true })),
+}));
+
+jest.mock("expo-crypto", () => ({
+  CryptoDigestAlgorithm: { SHA256: "SHA-256" },
+  digestStringAsync: jest.fn(async (_algorithm, value) => `hashed:${value}`),
+}));
+
+jest.mock("expo-secure-store", () => {
+  const store = {};
+  return {
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: "WHEN_UNLOCKED_THIS_DEVICE_ONLY",
+    isAvailableAsync: jest.fn(async () => true),
+    getItemAsync: jest.fn(async (key) => store[key] ?? null),
+    setItemAsync: jest.fn(async (key, value) => {
+      store[key] = value;
+    }),
+    deleteItemAsync: jest.fn(async (key) => {
+      delete store[key];
+    }),
+  };
 });

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
+    "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
@@ -22,11 +23,14 @@
     "expo-camera": "~17.0.10",
     "expo-clipboard": "^8.0.8",
     "expo-constants": "~18.0.13",
+    "expo-crypto": "^55.0.10",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-linking": "~8.0.11",
+    "expo-local-authentication": "^55.0.9",
     "expo-router": "~6.0.22",
+    "expo-secure-store": "^55.0.9",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-symbols": "~1.0.8",
@@ -41,8 +45,7 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0",
-    "react-native-worklets": "0.5.1",
-    "@react-native-community/netinfo": "11.4.1"
+    "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/app/mobile/services/security.ts
+++ b/app/mobile/services/security.ts
@@ -1,0 +1,102 @@
+import * as Crypto from "expo-crypto";
+import * as SecureStore from "expo-secure-store";
+
+import type { SecuritySettings } from "@/types/security";
+
+const SECURITY_SETTINGS_KEY = "quickex.security.settings";
+const FALLBACK_PIN_HASH_KEY = "quickex.security.pinHash";
+const SENSITIVE_TOKEN_KEY = "quickex.security.sensitiveToken";
+const PIN_HASH_SALT = "quickex.v2.pin.salt";
+
+const DEFAULT_SETTINGS: SecuritySettings = {
+  biometricLockEnabled: false,
+};
+
+async function isSecureStoreAvailable() {
+  try {
+    return await SecureStore.isAvailableAsync();
+  } catch {
+    return false;
+  }
+}
+
+async function getItem(key: string) {
+  if (!(await isSecureStoreAvailable())) {
+    return null;
+  }
+
+  return SecureStore.getItemAsync(key);
+}
+
+async function setItem(key: string, value: string) {
+  if (!(await isSecureStoreAvailable())) {
+    return;
+  }
+
+  await SecureStore.setItemAsync(key, value, {
+    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  });
+}
+
+async function deleteItem(key: string) {
+  if (!(await isSecureStoreAvailable())) {
+    return;
+  }
+
+  await SecureStore.deleteItemAsync(key);
+}
+
+export async function getSecuritySettings(): Promise<SecuritySettings> {
+  const raw = await getItem(SECURITY_SETTINGS_KEY);
+  if (!raw) return DEFAULT_SETTINGS;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<SecuritySettings>;
+    return {
+      biometricLockEnabled: Boolean(parsed.biometricLockEnabled),
+    };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+export async function saveSecuritySettings(settings: SecuritySettings) {
+  await setItem(SECURITY_SETTINGS_KEY, JSON.stringify(settings));
+}
+
+async function hashPin(pin: string) {
+  return Crypto.digestStringAsync(
+    Crypto.CryptoDigestAlgorithm.SHA256,
+    `${PIN_HASH_SALT}:${pin}`,
+  );
+}
+
+export async function setFallbackPin(pin: string) {
+  const pinHash = await hashPin(pin);
+  await setItem(FALLBACK_PIN_HASH_KEY, pinHash);
+}
+
+export async function hasFallbackPin() {
+  const pinHash = await getItem(FALLBACK_PIN_HASH_KEY);
+  return Boolean(pinHash);
+}
+
+export async function verifyFallbackPin(pin: string) {
+  const storedHash = await getItem(FALLBACK_PIN_HASH_KEY);
+  if (!storedHash) return false;
+
+  const incomingHash = await hashPin(pin);
+  return storedHash === incomingHash;
+}
+
+export async function saveSensitiveToken(token: string) {
+  await setItem(SENSITIVE_TOKEN_KEY, token);
+}
+
+export async function getSensitiveToken() {
+  return getItem(SENSITIVE_TOKEN_KEY);
+}
+
+export async function clearSensitiveToken() {
+  await deleteItem(SENSITIVE_TOKEN_KEY);
+}

--- a/app/mobile/types/security.ts
+++ b/app/mobile/types/security.ts
@@ -1,0 +1,8 @@
+export interface SecuritySettings {
+  biometricLockEnabled: boolean;
+}
+
+export type SecurityAuthReason =
+  | "app_unlock"
+  | "payment_authorization"
+  | "sensitive_data_access";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       expo-constants:
         specifier: ~18.0.13
         version: 18.0.13(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))
+      expo-crypto:
+        specifier: ^55.0.10
+        version: 55.0.10(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
       expo-font:
         specifier: ~14.0.11
         version: 14.0.11(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -215,9 +218,15 @@ importers:
       expo-linking:
         specifier: ~8.0.11
         version: 8.0.11(expo@54.0.31)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-local-authentication:
+        specifier: ^55.0.9
+        version: 55.0.9(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
       expo-router:
         specifier: ~6.0.22
         version: 6.0.22(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.31)(react-dom@19.1.0(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.28.6)(react-native-worklets@0.5.1(@babel/core@7.28.6)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-secure-store:
+        specifier: ^55.0.9
+        version: 55.0.9(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
       expo-splash-screen:
         specifier: ~31.0.13
         version: 31.0.13(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
@@ -3805,6 +3814,11 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-crypto@55.0.10:
+    resolution: {integrity: sha512-3emt67pWch07F7DPQutn7CUpaiCJI8OOFxCGiwmzeSqSjuWP9upGOXkLQNVWf+29KZQRTVgf88LhDC2GFshMNA==}
+    peerDependencies:
+      expo: '*'
+
   expo-file-system@19.0.21:
     resolution: {integrity: sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==}
     peerDependencies:
@@ -3845,6 +3859,11 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-local-authentication@55.0.9:
+    resolution: {integrity: sha512-WeFmISIOpq3VOg1DkUf2J9xtj7FJuFOjSN5z+z+fNFCjCuFY1vw20UMApbiEz7bOvE2w6tDYpTF4GJhaatKJ/Q==}
+    peerDependencies:
+      expo: '*'
 
   expo-modules-autolinking@3.0.24:
     resolution: {integrity: sha512-TP+6HTwhL7orDvsz2VzauyQlXJcAWyU3ANsZ7JGL4DQu8XaZv/A41ZchbtAYLfozNA2Ya1Hzmhx65hXryBMjaQ==}
@@ -3889,6 +3908,11 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
+
+  expo-secure-store@55.0.9:
+    resolution: {integrity: sha512-TIPGjM73LKlebpXwgAu/yL7lNWr6RQYmFw3vgYHOqLFYQMpsBqkQmopovbNX3c/0+RCE9KZlLAkcz8r6detILQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-server@1.0.5:
     resolution: {integrity: sha512-IGR++flYH70rhLyeXF0Phle56/k4cee87WeQ4mamS+MkVAVP+dDlOHf2nN06Z9Y2KhU0Gp1k+y61KkghF7HdhA==}
@@ -11574,6 +11598,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-crypto@55.0.10(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      expo: 54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
   expo-file-system@19.0.21(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       expo: 54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -11612,6 +11640,11 @@ snapshots:
     transitivePeerDependencies:
       - expo
       - supports-color
+
+  expo-local-authentication@55.0.9(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      expo: 54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      invariant: 2.2.4
 
   expo-modules-autolinking@3.0.24:
     dependencies:
@@ -11669,6 +11702,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - supports-color
+
+  expo-secure-store@55.0.9(expo@54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      expo: 54.0.31(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.6))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   expo-server@1.0.5: {}
 


### PR DESCRIPTION
## Biometric Authentication & Secure Key Storage

### Description
Adds biometric authentication (FaceID/TouchID) with PIN fallback for sensitive actions like payments and key viewing, with secure storage for user preferences and session data.

### Changes
- Integrated `expo-local-authentication` for biometric verification
- Added `expo-secure-store` for encrypted storage of security settings and session tokens
- Implemented hashed PIN fallback (4-6 digits) using `expo-crypto`
- Created Security settings screen with biometric lock toggle and PIN management
- Enforced authentication before payment confirmation and wallet key reveal
- Added app lock overlay and PIN modal components
- Created `use-security` hook and `SecurityService` for centralized auth logic
- Added Jest tests for security service with native module mocks
- Configured Face ID permission text in `app.json`

### Files Added
- `app/mobile/app/security.tsx` - Security settings screen
- `app/mobile/services/security.ts` - Core security service
- `app/mobile/hooks/use-security.tsx` - React hook for auth state
- `app/mobile/components/security/app-lock-overlay.tsx`
- `app/mobile/components/security/pin-auth-modal.tsx`
- `app/mobile/__tests__/SecurityService.test.ts`
- `app/mobile/types/security.ts`

### Acceptance Criteria
- [x] App prompts for biometrics before sensitive actions (when enabled)
- [x] Sensitive data stored in SecureStore, never plain text
- [x] PIN fallback works when biometrics unavailable/fail
- [x] Security settings toggle enables/disables biometric lock

Closes #144