### PR TITLE
feat: implement API key management for developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ reports/*
 !reports/.gitkeep
 kp.json
 .turbo/
+.claude/

--- a/app/backend/src/api-keys/api-keys.controller.ts
+++ b/app/backend/src/api-keys/api-keys.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiKeysService } from './api-keys.service';
+import { CreateApiKeyDto } from './dto/create-api-key.dto';
+
+@Controller('api-keys')
+export class ApiKeysController {
+  constructor(private readonly service: ApiKeysService) {}
+
+  /**
+   * POST /api-keys
+   * Creates a new API key. The raw key is returned ONCE in the response.
+   */
+  @Post()
+  create(@Body() dto: CreateApiKeyDto) {
+    return this.service.create(dto);
+  }
+
+  /**
+   * GET /api-keys
+   * Lists all active keys (masked). Optionally filter by owner_id.
+   */
+  @Get()
+  list(@Query('owner_id') ownerId?: string) {
+    return this.service.list(ownerId);
+  }
+
+  /**
+   * GET /api-keys/usage
+   * Returns aggregated usage/quota stats.
+   */
+  @Get('usage')
+  usage(@Query('owner_id') ownerId?: string) {
+    return this.service.getUsage(ownerId);
+  }
+
+  /**
+   * DELETE /api-keys/:id
+   * Revokes (soft-deletes) a key.
+   */
+  @Delete(':id')
+  revoke(@Param('id', ParseUUIDPipe) id: string) {
+    return this.service.revoke(id);
+  }
+
+  /**
+   * POST /api-keys/:id/rotate
+   * Invalidates the current key and issues a new one.
+   */
+  @Post(':id/rotate')
+  rotate(@Param('id', ParseUUIDPipe) id: string) {
+    return this.service.rotate(id);
+  }
+}

--- a/app/backend/src/api-keys/api-keys.module.ts
+++ b/app/backend/src/api-keys/api-keys.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ApiKeysController } from './api-keys.controller';
+import { ApiKeysService } from './api-keys.service';
+import { ApiKeysRepository } from './api-keys.repository';
+import { SupabaseModule } from '../supabase/supabase.module';
+
+@Module({
+  imports: [SupabaseModule],
+  controllers: [ApiKeysController],
+  providers: [ApiKeysService, ApiKeysRepository],
+  exports: [ApiKeysService],
+})
+export class ApiKeysModule {}

--- a/app/backend/src/api-keys/api-keys.repository.ts
+++ b/app/backend/src/api-keys/api-keys.repository.ts
@@ -1,0 +1,132 @@
+import { Injectable } from '@nestjs/common';
+import { SupabaseService } from '../supabase/supabase.service';
+import { ApiKeyRecord, ApiKeyScope } from './api-keys.types';
+
+@Injectable()
+export class ApiKeysRepository {
+  constructor(private readonly supabase: SupabaseService) {}
+
+  private get client() {
+    return this.supabase.getClient();
+  }
+
+  async insert(data: {
+    name: string;
+    key_hash: string;
+    key_prefix: string;
+    scopes: ApiKeyScope[];
+    owner_id: string | null;
+    monthly_quota: number;
+  }): Promise<ApiKeyRecord> {
+    const { data: row, error } = await this.client
+      .from('api_keys')
+      .insert(data)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return row as ApiKeyRecord;
+  }
+
+  async findAll(owner_id?: string): Promise<ApiKeyRecord[]> {
+    let query = this.client
+      .from('api_keys')
+      .select('*')
+      .eq('is_active', true)
+      .order('created_at', { ascending: false });
+
+    if (owner_id) {
+      query = query.eq('owner_id', owner_id);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+    return (data as ApiKeyRecord[]) ?? [];
+  }
+
+  async findById(id: string): Promise<ApiKeyRecord | null> {
+    const { data, error } = await this.client
+      .from('api_keys')
+      .select('*')
+      .eq('id', id)
+      .eq('is_active', true)
+      .single();
+
+    // PGRST116 = "no rows returned" — treat as not found, not an error
+    if (error?.code === 'PGRST116') return null;
+    if (error) throw error;
+    return data as ApiKeyRecord;
+  }
+
+  async findByPrefix(prefix: string): Promise<ApiKeyRecord[]> {
+    const { data, error } = await this.client
+      .from('api_keys')
+      .select('*')
+      .eq('key_prefix', prefix)
+      .eq('is_active', true);
+
+    if (error) throw error;
+    return (data as ApiKeyRecord[]) ?? [];
+  }
+
+  async revoke(id: string): Promise<void> {
+    const { error } = await this.client
+      .from('api_keys')
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq('id', id);
+
+    if (error) throw error;
+  }
+
+  async updateKey(
+    id: string,
+    data: { key_hash: string; key_prefix: string },
+  ): Promise<ApiKeyRecord> {
+    const { data: row, error } = await this.client
+      .from('api_keys')
+      .update({
+        ...data,
+        request_count: 0,
+        last_used_at: null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return row as ApiKeyRecord;
+  }
+
+  async incrementUsage(id: string): Promise<void> {
+    const { error } = await this.client.rpc('increment_api_key_usage', {
+      key_id: id,
+    });
+    if (error) throw error;
+  }
+
+  async getUsageSummary(owner_id?: string): Promise<{
+    total_keys: number;
+    total_requests: number;
+    quota: number;
+  }> {
+    let query = this.client
+      .from('api_keys')
+      .select('request_count, monthly_quota')
+      .eq('is_active', true);
+
+    if (owner_id) {
+      query = query.eq('owner_id', owner_id);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const rows = (data ?? []) as { request_count: number; monthly_quota: number }[];
+    return {
+      total_keys: rows.length,
+      total_requests: rows.reduce((s, r) => s + r.request_count, 0),
+      quota: rows.reduce((s, r) => s + r.monthly_quota, 0),
+    };
+  }
+}

--- a/app/backend/src/api-keys/api-keys.service.ts
+++ b/app/backend/src/api-keys/api-keys.service.ts
@@ -1,0 +1,145 @@
+import {
+  Injectable,
+  NotFoundException,
+  Logger,
+} from '@nestjs/common';
+import * as crypto from 'crypto';
+import * as bcrypt from 'bcrypt';
+import { ApiKeysRepository } from './api-keys.repository';
+import { CreateApiKeyDto } from './dto/create-api-key.dto';
+import {
+  ApiKeyCreated,
+  ApiKeyPublic,
+  ApiKeyRecord,
+  ApiKeyScope,
+} from './api-keys.types';
+
+const BCRYPT_ROUNDS = 10;
+const DEFAULT_QUOTA = 10_000;
+const KEY_PREFIX_LENGTH = 8; // chars used for prefix display / lookup
+
+@Injectable()
+export class ApiKeysService {
+  private readonly logger = new Logger(ApiKeysService.name);
+
+  constructor(private readonly repo: ApiKeysRepository) {}
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  async create(dto: CreateApiKeyDto): Promise<ApiKeyCreated> {
+    const rawKey = this.generateRawKey();
+    const prefix = rawKey.slice(0, KEY_PREFIX_LENGTH + 3); // "qx_" + 8 chars
+    const hash = await bcrypt.hash(rawKey, BCRYPT_ROUNDS);
+
+    const record = await this.repo.insert({
+      name: dto.name,
+      key_hash: hash,
+      key_prefix: prefix,
+      scopes: dto.scopes,
+      owner_id: dto.owner_id ?? null,
+      monthly_quota: DEFAULT_QUOTA,
+    });
+
+    this.logger.log(`API key created: id=${record.id} name="${record.name}"`);
+
+    return { ...this.toPublic(record), key: rawKey };
+  }
+
+  async list(owner_id?: string): Promise<ApiKeyPublic[]> {
+    const records = await this.repo.findAll(owner_id);
+    return records.map((r) => this.toPublic(r));
+  }
+
+  async revoke(id: string): Promise<void> {
+    const record = await this.repo.findById(id);
+    if (!record) throw new NotFoundException('API key not found');
+
+    await this.repo.revoke(id);
+    this.logger.log(`API key revoked: id=${id}`);
+  }
+
+  async rotate(id: string): Promise<ApiKeyCreated> {
+    const record = await this.repo.findById(id);
+    if (!record) throw new NotFoundException('API key not found');
+
+    const rawKey = this.generateRawKey();
+    const prefix = rawKey.slice(0, KEY_PREFIX_LENGTH + 3);
+    const hash = await bcrypt.hash(rawKey, BCRYPT_ROUNDS);
+
+    const updated = await this.repo.updateKey(id, {
+      key_hash: hash,
+      key_prefix: prefix,
+    });
+
+    this.logger.log(`API key rotated: id=${id}`);
+
+    return { ...this.toPublic(updated), key: rawKey };
+  }
+
+  async getUsage(owner_id?: string) {
+    return this.repo.getUsageSummary(owner_id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Guard-facing: validate an incoming raw key and return its record
+  // ---------------------------------------------------------------------------
+
+  async validateKey(
+    rawKey: string,
+  ): Promise<{ record: ApiKeyRecord; hasScope: (s: ApiKeyScope) => boolean } | null> {
+    const prefix = rawKey.slice(0, KEY_PREFIX_LENGTH + 3);
+    const candidates = await this.repo.findByPrefix(prefix);
+
+    for (const record of candidates) {
+      const match = await bcrypt.compare(rawKey, record.key_hash);
+      if (match) {
+        // Fire-and-forget usage increment — don't block the request
+        this.repo
+          .incrementUsage(record.id)
+          .catch((err) =>
+            this.logger.warn(`Failed to increment usage for ${record.id}: ${err}`),
+          );
+
+        return {
+          record,
+          hasScope: (scope: ApiKeyScope) => record.scopes.includes(scope),
+        };
+      }
+    }
+
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Quota check
+  // ---------------------------------------------------------------------------
+
+  isOverQuota(record: ApiKeyRecord): boolean {
+    return record.request_count >= record.monthly_quota;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private generateRawKey(): string {
+    const bytes = crypto.randomBytes(24).toString('hex');
+    return `qx_live_${bytes}`;
+  }
+
+  private toPublic(record: ApiKeyRecord): ApiKeyPublic {
+    return {
+      id: record.id,
+      name: record.name,
+      key_prefix: record.key_prefix,
+      scopes: record.scopes,
+      is_active: record.is_active,
+      request_count: record.request_count,
+      monthly_quota: record.monthly_quota,
+      last_used_at: record.last_used_at,
+      created_at: record.created_at,
+    };
+  }
+}

--- a/app/backend/src/api-keys/api-keys.service.unit.spec.ts
+++ b/app/backend/src/api-keys/api-keys.service.unit.spec.ts
@@ -1,0 +1,229 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ApiKeysService } from './api-keys.service';
+import { ApiKeysRepository } from './api-keys.repository';
+import { ApiKeyRecord } from './api-keys.types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeRecord = (overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord => ({
+  id: 'test-uuid-1234',
+  name: 'Test Key',
+  key_hash: '$2b$10$hashedvalue',
+  key_prefix: 'qx_live_abc',
+  scopes: ['links:read'],
+  owner_id: null,
+  is_active: true,
+  request_count: 0,
+  monthly_quota: 10000,
+  last_used_at: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ApiKeysService', () => {
+  let service: ApiKeysService;
+  let repo: jest.Mocked<ApiKeysRepository>;
+
+  beforeEach(async () => {
+    const mockRepo: jest.Mocked<Partial<ApiKeysRepository>> = {
+      insert: jest.fn(),
+      findAll: jest.fn(),
+      findById: jest.fn(),
+      findByPrefix: jest.fn(),
+      revoke: jest.fn(),
+      updateKey: jest.fn(),
+      incrementUsage: jest.fn(),
+      getUsageSummary: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiKeysService,
+        { provide: ApiKeysRepository, useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<ApiKeysService>(ApiKeysService);
+    repo = module.get(ApiKeysRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // create
+  // -------------------------------------------------------------------------
+
+  describe('create', () => {
+    it('returns a public record with the raw key', async () => {
+      const record = makeRecord();
+      repo.insert.mockResolvedValue(record);
+
+      const result = await service.create({
+        name: 'Test Key',
+        scopes: ['links:read'],
+      });
+
+      expect(result.key).toMatch(/^qx_live_[a-f0-9]+$/);
+      expect(result.id).toBe(record.id);
+      expect(result.name).toBe(record.name);
+      expect(result.scopes).toEqual(['links:read']);
+      // raw key must NOT be stored in key_hash directly
+      expect(result.key).not.toBe(result.key_prefix);
+    });
+
+    it('stores a bcrypt hash, not the raw key', async () => {
+      const record = makeRecord();
+      repo.insert.mockResolvedValue(record);
+
+      await service.create({ name: 'Test Key', scopes: ['links:read'] });
+
+      const insertedHash = repo.insert.mock.calls[0][0].key_hash;
+      expect(insertedHash).toMatch(/^\$2b\$/); // bcrypt prefix
+    });
+
+    it('generates a prefix matching the stored key_prefix format', async () => {
+      const record = makeRecord();
+      repo.insert.mockResolvedValue(record);
+
+      await service.create({ name: 'Test Key', scopes: ['links:read'] });
+
+      const insertedPrefix = repo.insert.mock.calls[0][0].key_prefix;
+      expect(insertedPrefix).toMatch(/^qx_live_/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // list
+  // -------------------------------------------------------------------------
+
+  describe('list', () => {
+    it('returns mapped public records without key_hash', async () => {
+      const record = makeRecord();
+      repo.findAll.mockResolvedValue([record]);
+
+      const result = await service.list();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).not.toHaveProperty('key_hash');
+      expect(result[0]).not.toHaveProperty('updated_at');
+      expect(result[0].id).toBe(record.id);
+    });
+
+    it('forwards owner_id filter to repository', async () => {
+      repo.findAll.mockResolvedValue([]);
+      await service.list('wallet-abc');
+      expect(repo.findAll).toHaveBeenCalledWith('wallet-abc');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // revoke
+  // -------------------------------------------------------------------------
+
+  describe('revoke', () => {
+    it('calls repo.revoke when key exists', async () => {
+      repo.findById.mockResolvedValue(makeRecord());
+      repo.revoke.mockResolvedValue(undefined);
+
+      await service.revoke('test-uuid-1234');
+
+      expect(repo.revoke).toHaveBeenCalledWith('test-uuid-1234');
+    });
+
+    it('throws NotFoundException when key does not exist', async () => {
+      repo.findById.mockResolvedValue(null);
+
+      await expect(service.revoke('missing-id')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(repo.revoke).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // rotate
+  // -------------------------------------------------------------------------
+
+  describe('rotate', () => {
+    it('returns a new raw key and updated record', async () => {
+      const original = makeRecord({ key_prefix: 'qx_live_old' });
+      const updated = makeRecord({ key_prefix: 'qx_live_new' });
+      repo.findById.mockResolvedValue(original);
+      repo.updateKey.mockResolvedValue(updated);
+
+      const result = await service.rotate('test-uuid-1234');
+
+      expect(result.key).toMatch(/^qx_live_[a-f0-9]+$/);
+      expect(repo.updateKey).toHaveBeenCalledWith(
+        'test-uuid-1234',
+        expect.objectContaining({ key_hash: expect.stringMatching(/^\$2b\$/) }),
+      );
+    });
+
+    it('throws NotFoundException when key does not exist', async () => {
+      repo.findById.mockResolvedValue(null);
+
+      await expect(service.rotate('missing-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // validateKey
+  // -------------------------------------------------------------------------
+
+  describe('validateKey', () => {
+    it('returns null when no candidates match the prefix', async () => {
+      repo.findByPrefix.mockResolvedValue([]);
+
+      const result = await service.validateKey('qx_live_abc123fakekeyvalue');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when prefix matches but bcrypt compare fails', async () => {
+      // Store a hash for a different key so compare will fail
+      const record = makeRecord({
+        key_hash: '$2b$10$invalidhashvalue000000000000000000000000000000000000000',
+      });
+      repo.findByPrefix.mockResolvedValue([record]);
+      repo.incrementUsage.mockResolvedValue(undefined);
+
+      const result = await service.validateKey('qx_live_wrongkey12345678901234567890123456789012345678');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isOverQuota
+  // -------------------------------------------------------------------------
+
+  describe('isOverQuota', () => {
+    it('returns false when usage is below quota', () => {
+      const record = makeRecord({ request_count: 5000, monthly_quota: 10000 });
+      expect(service.isOverQuota(record)).toBe(false);
+    });
+
+    it('returns true when usage equals quota', () => {
+      const record = makeRecord({ request_count: 10000, monthly_quota: 10000 });
+      expect(service.isOverQuota(record)).toBe(true);
+    });
+
+    it('returns true when usage exceeds quota', () => {
+      const record = makeRecord({ request_count: 10001, monthly_quota: 10000 });
+      expect(service.isOverQuota(record)).toBe(true);
+    });
+  });
+});

--- a/app/backend/src/api-keys/api-keys.types.ts
+++ b/app/backend/src/api-keys/api-keys.types.ts
@@ -1,0 +1,40 @@
+export const API_KEY_SCOPES = [
+  'links:read',
+  'links:write',
+  'transactions:read',
+  'usernames:read',
+] as const;
+
+export type ApiKeyScope = (typeof API_KEY_SCOPES)[number];
+
+export interface ApiKeyRecord {
+  id: string;
+  name: string;
+  key_hash: string;
+  key_prefix: string;
+  scopes: ApiKeyScope[];
+  owner_id: string | null;
+  is_active: boolean;
+  request_count: number;
+  monthly_quota: number;
+  last_used_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ApiKeyPublic {
+  id: string;
+  name: string;
+  key_prefix: string;
+  scopes: ApiKeyScope[];
+  is_active: boolean;
+  request_count: number;
+  monthly_quota: number;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+/** Returned once at creation / rotation — contains the raw key. */
+export interface ApiKeyCreated extends ApiKeyPublic {
+  key: string;
+}

--- a/app/backend/src/api-keys/dto/create-api-key.dto.ts
+++ b/app/backend/src/api-keys/dto/create-api-key.dto.ts
@@ -1,0 +1,26 @@
+import {
+  IsArray,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ArrayMinSize,
+  MaxLength,
+} from 'class-validator';
+import { API_KEY_SCOPES, ApiKeyScope } from '../api-keys.types';
+
+export class CreateApiKeyDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsIn(API_KEY_SCOPES, { each: true })
+  scopes: ApiKeyScope[];
+
+  @IsOptional()
+  @IsString()
+  owner_id?: string;
+}

--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { MetricsInterceptor } from "./metrics/metrics.interceptor";
 import { CorrelationIdMiddleware } from "./common/middleware/correlation-id.middleware";
 import { NotificationsModule } from "./notifications/notifications.module";
 import { IngestionModule } from "./ingestion/ingestion.module";
+import { ApiKeysModule } from "./api-keys/api-keys.module";
 
 type AppImport =
   | Type<unknown>
@@ -60,6 +61,7 @@ type AppImport =
       TransactionsModule,
       PaymentsModule,
       IngestionModule,
+      ApiKeysModule,
     ];
 
     // In development, if SUPABASE_URL points to a localhost placeholder (i.e. you don't

--- a/app/backend/src/auth/decorators/require-scopes.decorator.ts
+++ b/app/backend/src/auth/decorators/require-scopes.decorator.ts
@@ -1,0 +1,15 @@
+import { SetMetadata } from '@nestjs/common';
+import { ApiKeyScope } from '../../api-keys/api-keys.types';
+
+export const REQUIRED_SCOPES_KEY = 'requiredScopes';
+
+/**
+ * Declare which API key scopes are required to access a route.
+ *
+ * @example
+ * \@RequireScopes('links:write')
+ * \@Post()
+ * createLink() {}
+ */
+export const RequireScopes = (...scopes: ApiKeyScope[]) =>
+  SetMetadata(REQUIRED_SCOPES_KEY, scopes);

--- a/app/backend/src/auth/guards/api-key.guard.ts
+++ b/app/backend/src/auth/guards/api-key.guard.ts
@@ -1,34 +1,70 @@
 import {
   CanActivate,
   ExecutionContext,
+  ForbiddenException,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
-import * as bcrypt from 'bcrypt';
+import { Reflector } from '@nestjs/core';
+import { ApiKeysService } from '../../api-keys/api-keys.service';
+import { ApiKeyScope } from '../../api-keys/api-keys.types';
 import { RATE_LIMITS } from '../../common/constants/rate-limit.constants';
+import { REQUIRED_SCOPES_KEY } from '../decorators/require-scopes.decorator';
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
+  constructor(
+    private readonly apiKeysService: ApiKeysService,
+    private readonly reflector: Reflector,
+  ) {}
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-    const apiKey = request.headers['x-api-key'];
+    const rawKey: string | undefined = request.headers['x-api-key'];
 
-    if (!apiKey) return true; // public access allowed
+    if (!rawKey) return true; // public access allowed
 
-    const hashedKeys = (process.env.API_KEYS || '').split(',');
+    const result = await this.apiKeysService.validateKey(rawKey);
 
-    for (const hash of hashedKeys) {
-      if (await bcrypt.compare(apiKey, hash)) {
-        request.apiKey = {
-          rateLimit: RATE_LIMITS.API_KEY.limit,
-        };
-        return true;
+    if (!result) {
+      throw new UnauthorizedException({
+        error: 'INVALID_API_KEY',
+        message: 'API key is invalid',
+      });
+    }
+
+    const { record, hasScope } = result;
+
+    if (this.apiKeysService.isOverQuota(record)) {
+      throw new ForbiddenException({
+        error: 'QUOTA_EXCEEDED',
+        message: 'Monthly request quota exceeded',
+      });
+    }
+
+    // Check required scopes declared on the handler/controller via @RequireScopes()
+    const requiredScopes =
+      this.reflector.getAllAndOverride<ApiKeyScope[]>(REQUIRED_SCOPES_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]) ?? [];
+
+    for (const scope of requiredScopes) {
+      if (!hasScope(scope)) {
+        throw new ForbiddenException({
+          error: 'INSUFFICIENT_SCOPE',
+          message: `API key missing required scope: ${scope}`,
+        });
       }
     }
 
-    throw new UnauthorizedException({
-      error: 'INVALID_API_KEY',
-      message: 'API key is invalid',
-    });
+    request.apiKey = {
+      id: record.id,
+      name: record.name,
+      scopes: record.scopes,
+      rateLimit: RATE_LIMITS.API_KEY.limit,
+    };
+
+    return true;
   }
 }

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -53,7 +53,7 @@ async function bootstrap() {
       },
       credentials: true,
       methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-      allowedHeaders: ["Content-Type", "Authorization", "x-correlation-id"],
+      allowedHeaders: ["Content-Type", "Authorization", "x-correlation-id", "x-api-key"],
     });
   }
 

--- a/app/backend/src/stellar/stellar.module.ts
+++ b/app/backend/src/stellar/stellar.module.ts
@@ -5,11 +5,13 @@ import { HorizonService } from "./horizon.service";
 import { LinkService } from "./link.service";
 import { PathPreviewService } from "./path-preview.service";
 import { StellarController } from "./stellar.controller";
+import { ApiKeysModule } from "../api-keys/api-keys.module";
+import { ApiKeyGuard } from "../auth/guards/api-key.guard";
 
 @Module({
-  imports: [TransactionsModule],
+  imports: [TransactionsModule, ApiKeysModule],
   controllers: [StellarController],
-  providers: [LinkService, HorizonService, PathPreviewService],
+  providers: [LinkService, HorizonService, PathPreviewService, ApiKeyGuard],
   exports: [LinkService, HorizonService, PathPreviewService],
 })
 export class StellarModule {}

--- a/app/backend/src/transactions/transactions.module.ts
+++ b/app/backend/src/transactions/transactions.module.ts
@@ -4,11 +4,13 @@ import { HorizonService } from "./horizon.service";
 import { AppConfigModule } from "../config";
 import { TransactionsService } from "./transaction.service";
 import { SorobanRpcService } from "./soroban-rpc.service";
+import { ApiKeysModule } from "../api-keys/api-keys.module";
+import { ApiKeyGuard } from "../auth/guards/api-key.guard";
 
 @Module({
-  imports: [AppConfigModule],
+  imports: [AppConfigModule, ApiKeysModule],
   controllers: [TransactionsController],
-  providers: [HorizonService, TransactionsService, SorobanRpcService],
+  providers: [HorizonService, TransactionsService, SorobanRpcService, ApiKeyGuard],
   exports: [HorizonService, TransactionsService],
 })
 export class TransactionsModule {}

--- a/app/backend/supabase/migrations/20260328000000_create_api_keys_table.sql
+++ b/app/backend/supabase/migrations/20260328000000_create_api_keys_table.sql
@@ -1,0 +1,54 @@
+-- =============================================================================
+-- API Keys Management
+-- =============================================================================
+-- Supports developer API key lifecycle: create, revoke, rotate.
+-- Granular scopes: links:read, links:write, transactions:read, usernames:read
+-- Usage tracking and monthly quota enforcement.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- api_keys
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            TEXT         NOT NULL,
+  key_hash        TEXT         NOT NULL,           -- bcrypt hash of the raw key
+  key_prefix      TEXT         NOT NULL,           -- first ~11 chars for fast lookup
+  scopes          TEXT[]       NOT NULL DEFAULT '{}',
+  owner_id        TEXT,                            -- wallet address or user identifier
+  is_active       BOOLEAN      NOT NULL DEFAULT true,
+  request_count   INTEGER      NOT NULL DEFAULT 0,
+  monthly_quota   INTEGER      NOT NULL DEFAULT 10000,
+  last_used_at    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- Index for guard validation (prefix-based candidate lookup)
+CREATE INDEX IF NOT EXISTS idx_api_keys_prefix
+  ON api_keys (key_prefix)
+  WHERE is_active = true;
+
+-- Index for listing keys by owner
+CREATE INDEX IF NOT EXISTS idx_api_keys_owner_id
+  ON api_keys (owner_id)
+  WHERE is_active = true;
+
+-- ---------------------------------------------------------------------------
+-- Helper: increment usage atomically without a SELECT + UPDATE race
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION increment_api_key_usage(key_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE api_keys
+  SET
+    request_count = request_count + 1,
+    last_used_at  = now(),
+    updated_at    = now()
+  WHERE id = key_id AND is_active = true;
+END;
+$$;

--- a/app/frontend/src/app/settings/developer/page.tsx
+++ b/app/frontend/src/app/settings/developer/page.tsx
@@ -1,57 +1,108 @@
 "use client";
 
 import CreateAPIKeyModal from "@/components/CreateAPIKeyModal";
+import { getQuickexApiBase } from "@/lib/api";
 import Link from "next/link";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-export type Scope = "read" | "write";
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export const AVAILABLE_SCOPES = [
+  "links:read",
+  "links:write",
+  "transactions:read",
+  "usernames:read",
+] as const;
+
+export type ApiKeyScope = (typeof AVAILABLE_SCOPES)[number];
 
 export type ApiKey = {
   id: string;
   name: string;
-  key: string;
-  scope: Scope;
-  createdAt: string;
-  revealed: boolean;
-  copyLabel: string;
+  key_prefix: string;
+  scopes: ApiKeyScope[];
+  is_active: boolean;
+  request_count: number;
+  monthly_quota: number;
+  last_used_at: string | null;
+  created_at: string;
+  // client-only UI state
+  revealed?: boolean;
+  copyLabel?: string;
+  /** Set only immediately after creation / rotation */
+  rawKey?: string;
 };
 
 export type NewKeyForm = {
   name: string;
-  scope: Scope;
+  scopes: ApiKeyScope[];
 };
 
-const MOCK_KEYS: ApiKey[] = [
-  {
-    id: "1",
-    name: "Production App",
-    key: "sk-prod-a1b2c3d4e5f6g7h8i9j0klmnopqrstu",
-    scope: "write",
-    createdAt: "Jan 12, 2026",
-    revealed: false,
-    copyLabel: "Copy",
-  },
-  {
-    id: "2",
-    name: "Analytics Service",
-    key: "sk-read-z9y8x7w6v5u4t3s2r1q0ponmlkjihg",
-    scope: "read",
-    createdAt: "Feb 3, 2026",
-    revealed: false,
-    copyLabel: "Copy",
-  },
-];
-
-const USAGE = {
-  used: 7340,
-  limit: 10000,
+type UsageSummary = {
+  total_keys: number;
+  total_requests: number;
+  quota: number;
 };
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${getQuickexApiBase()}${path}`, {
+    ...init,
+    headers: { "Content-Type": "application/json", ...init?.headers },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message ?? `Request failed: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
 
 export default function DeveloperSettings() {
-  const [keys, setKeys] = useState<ApiKey[]>(MOCK_KEYS);
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [usage, setUsage] = useState<UsageSummary>({ total_keys: 0, total_requests: 0, quota: 0 });
+  const [loadingKeys, setLoadingKeys] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
   const [revokeId, setRevokeId] = useState<string | null>(null);
-  const [newKey, setNewKey] = useState<NewKeyForm>({ name: "", scope: "read" });
+  const [rotatingId, setRotatingId] = useState<string | null>(null);
+  const [newKey, setNewKey] = useState<NewKeyForm>({ name: "", scopes: [] });
+  const [error, setError] = useState<string | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Data fetching
+  // ---------------------------------------------------------------------------
+
+  const loadKeys = useCallback(async () => {
+    try {
+      const [fetchedKeys, fetchedUsage] = await Promise.all([
+        apiFetch<ApiKey[]>("/api-keys"),
+        apiFetch<UsageSummary>("/api-keys/usage"),
+      ]);
+      setKeys(fetchedKeys.map((k) => ({ ...k, revealed: false, copyLabel: "Copy" })));
+      setUsage(fetchedUsage);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoadingKeys(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadKeys();
+  }, [loadKeys]);
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
 
   const toggleReveal = (id: string) => {
     setKeys((prev) =>
@@ -59,8 +110,8 @@ export default function DeveloperSettings() {
     );
   };
 
-  const copyKey = (id: string, key: string) => {
-    navigator.clipboard.writeText(key);
+  const copyKey = (id: string, text: string) => {
+    navigator.clipboard.writeText(text);
     setKeys((prev) =>
       prev.map((k) => (k.id === id ? { ...k, copyLabel: "Copied!" } : k)),
     );
@@ -71,40 +122,91 @@ export default function DeveloperSettings() {
     }, 2000);
   };
 
-  const revokeKey = (id: string) => {
-    setKeys((prev) => prev.filter((k) => k.id !== id));
-    setRevokeId(null);
+  const revokeKey = async (id: string) => {
+    try {
+      await apiFetch(`/api-keys/${id}`, { method: "DELETE" });
+      setKeys((prev) => prev.filter((k) => k.id !== id));
+      setUsage((u) => ({ ...u, total_keys: u.total_keys - 1 }));
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setRevokeId(null);
+    }
   };
 
-  const generateKey = () => {
-    if (!newKey.name.trim()) return;
-    const prefix = newKey.scope === "write" ? "sk-prod" : "sk-read";
-    const random = Math.random().toString(36).slice(2, 34).padEnd(32, "0");
-    const created: ApiKey = {
-      id: Date.now().toString(),
-      name: newKey.name.trim(),
-      key: `${prefix}-${random}`,
-      scope: newKey.scope,
-      createdAt: new Date().toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      }),
-      revealed: false,
-      copyLabel: "Copy",
-    };
-    setKeys((prev) => [created, ...prev]);
-    setNewKey({ name: "", scope: "read" });
-    setModalOpen(false);
+  const rotateKey = async (id: string) => {
+    setRotatingId(id);
+    try {
+      const rotated = await apiFetch<ApiKey & { key: string }>(`/api-keys/${id}/rotate`, {
+        method: "POST",
+      });
+      setKeys((prev) =>
+        prev.map((k) =>
+          k.id === id
+            ? {
+                ...rotated,
+                revealed: true,
+                rawKey: rotated.key,
+                copyLabel: "Copy",
+              }
+            : k,
+        ),
+      );
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setRotatingId(null);
+    }
   };
 
-  const usagePercent = Math.round((USAGE.used / USAGE.limit) * 100);
+  const generateKey = async () => {
+    if (!newKey.name.trim() || newKey.scopes.length === 0) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const created = await apiFetch<ApiKey & { key: string }>("/api-keys", {
+        method: "POST",
+        body: JSON.stringify({ name: newKey.name.trim(), scopes: newKey.scopes }),
+      });
+      setKeys((prev) => [
+        { ...created, revealed: true, rawKey: created.key, copyLabel: "Copy" },
+        ...prev,
+      ]);
+      setUsage((u) => ({ ...u, total_keys: u.total_keys + 1 }));
+      setNewKey({ name: "", scopes: [] });
+      setModalOpen(false);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Derived UI values
+  // ---------------------------------------------------------------------------
+
+  const usedRequests = usage.total_requests;
+  const quota = usage.quota || 10000;
+  const usagePercent = Math.min(100, Math.round((usedRequests / quota) * 100));
   const usageColor =
     usagePercent >= 90
       ? "bg-red-500"
       : usagePercent >= 70
         ? "bg-amber-500"
         : "bg-indigo-500";
+
+  const resetDate = new Date();
+  resetDate.setMonth(resetDate.getMonth() + 1, 1);
+  const resetLabel = resetDate.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
 
   return (
     <div className="relative min-h-screen text-white selection:bg-indigo-500/30 overflow-x-hidden">
@@ -132,6 +234,16 @@ export default function DeveloperSettings() {
           </Link>
         </nav>
 
+        {/* Error banner */}
+        {error && (
+          <div className="mb-6 px-4 py-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm flex items-center justify-between">
+            <span>{error}</span>
+            <button onClick={() => setError(null)} className="ml-4 text-red-300 hover:text-white text-xs font-bold">
+              Dismiss
+            </button>
+          </div>
+        )}
+
         <div className="space-y-6">
           {/* API Keys section */}
           <section className="p-6 rounded-3xl bg-neutral-900/40 border border-white/5 space-y-6">
@@ -152,81 +264,127 @@ export default function DeveloperSettings() {
 
             {/* Key list */}
             <div className="space-y-3">
-              {keys.length === 0 && (
+              {loadingKeys && (
+                <div className="text-center py-10 text-neutral-600 text-sm">
+                  Loading keys…
+                </div>
+              )}
+
+              {!loadingKeys && keys.length === 0 && (
                 <div className="text-center py-10 text-neutral-600 text-sm">
                   No API keys yet. Create one to get started.
                 </div>
               )}
 
-              {keys.map((key) => (
-                <div
-                  key={key.id}
-                  className="flex flex-col sm:flex-row sm:items-center gap-4 p-4 rounded-2xl bg-black/30 border border-white/5"
-                >
-                  {/* Key info */}
-                  <div className="flex-1 min-w-0 space-y-1">
-                    <div className="flex items-center gap-2">
-                      <span className="font-bold text-sm">{key.name}</span>
-                      <span
-                        className={`text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border ${
-                          key.scope === "write"
-                            ? "text-purple-300 border-purple-500/30 bg-purple-500/10"
-                            : "text-indigo-300 border-indigo-500/30 bg-indigo-500/10"
-                        }`}
-                      >
-                        {key.scope}
-                      </span>
-                    </div>
-                    <div className="font-mono text-sm text-neutral-400 truncate">
-                      {key.revealed ? key.key : "sk-" + "•".repeat(28)}
-                    </div>
-                    <div className="text-xs text-neutral-600">
-                      Created {key.createdAt}
-                    </div>
-                  </div>
+              {keys.map((key) => {
+                const displayKey = key.rawKey
+                  ? key.rawKey
+                  : key.revealed
+                    ? key.key_prefix + "•".repeat(20)
+                    : "qx_live_" + "•".repeat(20);
 
-                  {/* Actions */}
-                  <div className="flex items-center gap-2 shrink-0">
-                    <button
-                      onClick={() => toggleReveal(key.id)}
-                      className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-300 hover:bg-white/10 hover:text-white transition"
-                    >
-                      {key.revealed ? "Hide" : "Reveal"}
-                    </button>
-
-                    <button
-                      onClick={() => copyKey(key.id, key.key)}
-                      className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-300 hover:bg-white/10 hover:text-white transition"
-                    >
-                      {key.copyLabel === "Copied!" ? "✓ Copied!" : "⧉ Copy"}
-                    </button>
-
-                    {revokeId === key.id ? (
-                      <div className="flex items-center gap-1">
-                        <button
-                          onClick={() => revokeKey(key.id)}
-                          className="px-3 py-2 rounded-xl bg-red-500/20 border border-red-500/30 text-xs font-bold text-red-400 hover:bg-red-500/30 transition"
-                        >
-                          Confirm
-                        </button>
-                        <button
-                          onClick={() => setRevokeId(null)}
-                          className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-400 hover:text-white transition"
-                        >
-                          Cancel
-                        </button>
+                return (
+                  <div
+                    key={key.id}
+                    className="flex flex-col sm:flex-row sm:items-start gap-4 p-4 rounded-2xl bg-black/30 border border-white/5"
+                  >
+                    {/* Key info */}
+                    <div className="flex-1 min-w-0 space-y-2">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-bold text-sm">{key.name}</span>
+                        {key.scopes.map((scope) => (
+                          <span
+                            key={scope}
+                            className="text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border text-indigo-300 border-indigo-500/30 bg-indigo-500/10"
+                          >
+                            {scope}
+                          </span>
+                        ))}
                       </div>
-                    ) : (
+                      <div className="font-mono text-sm text-neutral-400 truncate">
+                        {displayKey}
+                      </div>
+                      {key.rawKey && (
+                        <p className="text-xs text-amber-400">
+                          Save this key now — it won&apos;t be shown again.
+                        </p>
+                      )}
+                      <div className="text-xs text-neutral-600">
+                        Created{" "}
+                        {new Date(key.created_at).toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                        {key.last_used_at && (
+                          <span>
+                            {" · "}Last used{" "}
+                            {new Date(key.last_used_at).toLocaleDateString("en-US", {
+                              month: "short",
+                              day: "numeric",
+                              year: "numeric",
+                            })}
+                          </span>
+                        )}
+                        <span className="ml-2 text-neutral-700">
+                          {key.request_count.toLocaleString()} requests
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Actions */}
+                    <div className="flex items-center gap-2 shrink-0 flex-wrap">
+                      {!key.rawKey && (
+                        <button
+                          onClick={() => toggleReveal(key.id)}
+                          className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-300 hover:bg-white/10 hover:text-white transition"
+                        >
+                          {key.revealed ? "Hide" : "Reveal"}
+                        </button>
+                      )}
+
                       <button
-                        onClick={() => setRevokeId(key.id)}
-                        className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-red-400 hover:bg-red-500/10 hover:border-red-500/20 transition"
+                        onClick={() => copyKey(key.id, key.rawKey ?? key.key_prefix)}
+                        className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-300 hover:bg-white/10 hover:text-white transition"
                       >
-                        Revoke
+                        {key.copyLabel === "Copied!" ? "✓ Copied!" : "⧉ Copy"}
                       </button>
-                    )}
+
+                      <button
+                        onClick={() => rotateKey(key.id)}
+                        disabled={rotatingId === key.id}
+                        className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-300 hover:bg-white/10 hover:text-white disabled:opacity-40 transition"
+                      >
+                        {rotatingId === key.id ? "Rotating…" : "↻ Rotate"}
+                      </button>
+
+                      {revokeId === key.id ? (
+                        <div className="flex items-center gap-1">
+                          <button
+                            onClick={() => revokeKey(key.id)}
+                            className="px-3 py-2 rounded-xl bg-red-500/20 border border-red-500/30 text-xs font-bold text-red-400 hover:bg-red-500/30 transition"
+                          >
+                            Confirm
+                          </button>
+                          <button
+                            onClick={() => setRevokeId(null)}
+                            className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-400 hover:text-white transition"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setRevokeId(key.id)}
+                          className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-red-400 hover:bg-red-500/10 hover:border-red-500/20 transition"
+                        >
+                          Revoke
+                        </button>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </section>
 
@@ -235,16 +393,16 @@ export default function DeveloperSettings() {
             <div>
               <h2 className="text-xl font-bold">Monthly Usage</h2>
               <p className="text-sm text-neutral-500 mt-1">
-                API requests used this billing period.
+                API requests used this billing period across all keys.
               </p>
             </div>
 
             <div className="space-y-3">
               <div className="flex justify-between items-end">
                 <span className="text-3xl font-black">
-                  {USAGE.used.toLocaleString()}
+                  {usedRequests.toLocaleString()}
                   <span className="text-lg text-neutral-500 font-semibold ml-1">
-                    / {USAGE.limit.toLocaleString()}
+                    / {quota.toLocaleString()}
                   </span>
                 </span>
                 <span className="text-sm font-bold text-neutral-400">
@@ -261,8 +419,8 @@ export default function DeveloperSettings() {
               </div>
 
               <p className="text-xs text-neutral-600">
-                {(USAGE.limit - USAGE.used).toLocaleString()} requests
-                remaining. Resets on Apr 1, 2026.
+                {(quota - usedRequests).toLocaleString()} requests remaining.
+                Resets on {resetLabel}.
               </p>
             </div>
           </section>
@@ -271,28 +429,22 @@ export default function DeveloperSettings() {
           <section className="p-6 rounded-3xl bg-neutral-900/40 border border-white/5 space-y-4">
             <h2 className="text-xl font-bold">Scope Reference</h2>
             <div className="grid sm:grid-cols-2 gap-4">
-              <div className="p-4 rounded-2xl bg-indigo-500/5 border border-indigo-500/20 space-y-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full text-indigo-300 border border-indigo-500/30 bg-indigo-500/10">
-                    Read
+              {[
+                { scope: "links:read",        desc: "Fetch and query payment links. Cannot create or modify." },
+                { scope: "links:write",       desc: "Create and update payment links. Includes links:read." },
+                { scope: "transactions:read", desc: "Read transaction history from the Horizon API." },
+                { scope: "usernames:read",    desc: "Look up registered QuickEx usernames." },
+              ].map(({ scope, desc }) => (
+                <div
+                  key={scope}
+                  className="p-4 rounded-2xl bg-indigo-500/5 border border-indigo-500/20 space-y-1"
+                >
+                  <span className="text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full text-indigo-300 border border-indigo-500/30 bg-indigo-500/10 font-mono">
+                    {scope}
                   </span>
+                  <p className="text-sm text-neutral-400 mt-2">{desc}</p>
                 </div>
-                <p className="text-sm text-neutral-400 mt-2">
-                  Can fetch data, retrieve payment links, and query account
-                  info. Cannot create or modify any resources.
-                </p>
-              </div>
-              <div className="p-4 rounded-2xl bg-purple-500/5 border border-purple-500/20 space-y-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full text-purple-300 border border-purple-500/30 bg-purple-500/10">
-                    Write
-                  </span>
-                </div>
-                <p className="text-sm text-neutral-400 mt-2">
-                  Full access — can generate payment links, update settings, and
-                  perform all Read actions. Use with care.
-                </p>
-              </div>
+              ))}
             </div>
           </section>
         </div>
@@ -305,6 +457,7 @@ export default function DeveloperSettings() {
           newKey={newKey}
           setNewKey={setNewKey}
           generateKey={generateKey}
+          loading={creating}
         />
       )}
     </div>

--- a/app/frontend/src/components/CreateAPIKeyModal.tsx
+++ b/app/frontend/src/components/CreateAPIKeyModal.tsx
@@ -1,4 +1,4 @@
-import { NewKeyForm, Scope } from "@/app/Settings/developer/page";
+import { NewKeyForm, AVAILABLE_SCOPES, ApiKeyScope } from "@/app/settings/developer/page";
 import React from "react";
 
 type Props = {
@@ -6,6 +6,14 @@ type Props = {
   newKey: NewKeyForm;
   setNewKey: React.Dispatch<React.SetStateAction<NewKeyForm>>;
   generateKey: () => void;
+  loading: boolean;
+};
+
+const SCOPE_LABELS: Record<ApiKeyScope, { label: string; description: string }> = {
+  "links:read":       { label: "links:read",       description: "Fetch and query payment links" },
+  "links:write":      { label: "links:write",       description: "Create and update payment links" },
+  "transactions:read":{ label: "transactions:read", description: "Read transaction history" },
+  "usernames:read":   { label: "usernames:read",    description: "Look up registered usernames" },
 };
 
 export default function CreateAPIKeyModal({
@@ -13,13 +21,23 @@ export default function CreateAPIKeyModal({
   newKey,
   setNewKey,
   generateKey,
+  loading,
 }: Props) {
+  const toggleScope = (scope: ApiKeyScope) => {
+    setNewKey((prev) => ({
+      ...prev,
+      scopes: prev.scopes.includes(scope)
+        ? prev.scopes.filter((s) => s !== scope)
+        : [...prev.scopes, scope],
+    }));
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        onClick={() => setModalOpen(false)}
+        onClick={() => !loading && setModalOpen(false)}
       />
 
       {/* Modal */}
@@ -45,39 +63,41 @@ export default function CreateAPIKeyModal({
         {/* Scope selection */}
         <div className="space-y-2">
           <label className="text-xs font-black uppercase tracking-widest text-neutral-500">
-            Scope
+            Scopes
           </label>
-          <div className="grid grid-cols-2 gap-3">
-            {(["read", "write"] as Scope[]).map((s) => (
-              <button
-                key={s}
-                onClick={() => setNewKey((prev) => ({ ...prev, scope: s }))}
-                className={`p-4 rounded-2xl border text-left transition ${
-                  newKey.scope === s
-                    ? s === "write"
-                      ? "border-purple-500/40 bg-purple-500/10"
-                      : "border-indigo-500/40 bg-indigo-500/10"
-                    : "border-white/10 bg-white/5 hover:bg-white/10"
-                }`}
-              >
-                <div
-                  className={`text-xs font-black uppercase tracking-widest mb-1 ${
-                    newKey.scope === s
-                      ? s === "write"
-                        ? "text-purple-300"
-                        : "text-indigo-300"
-                      : "text-neutral-400"
+          <div className="space-y-2">
+            {AVAILABLE_SCOPES.map((scope) => {
+              const active = newKey.scopes.includes(scope);
+              return (
+                <button
+                  key={scope}
+                  onClick={() => toggleScope(scope)}
+                  className={`w-full p-3 rounded-xl border text-left transition flex items-center gap-3 ${
+                    active
+                      ? "border-indigo-500/40 bg-indigo-500/10"
+                      : "border-white/10 bg-white/5 hover:bg-white/10"
                   }`}
                 >
-                  {s}
-                </div>
-                <div className="text-xs text-neutral-500">
-                  {s === "read"
-                    ? "Fetch & query only"
-                    : "Full read & write access"}
-                </div>
-              </button>
-            ))}
+                  <div
+                    className={`w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center text-[10px] ${
+                      active
+                        ? "border-indigo-500 bg-indigo-500 text-white"
+                        : "border-white/20"
+                    }`}
+                  >
+                    {active && "✓"}
+                  </div>
+                  <div>
+                    <div className={`text-xs font-bold font-mono ${active ? "text-indigo-300" : "text-neutral-400"}`}>
+                      {SCOPE_LABELS[scope].label}
+                    </div>
+                    <div className="text-xs text-neutral-600 mt-0.5">
+                      {SCOPE_LABELS[scope].description}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
           </div>
         </div>
 
@@ -85,16 +105,17 @@ export default function CreateAPIKeyModal({
         <div className="flex gap-3 pt-2">
           <button
             onClick={() => setModalOpen(false)}
-            className="flex-1 py-3 rounded-xl border border-white/10 text-sm font-semibold text-neutral-400 hover:text-white hover:bg-white/5 transition"
+            disabled={loading}
+            className="flex-1 py-3 rounded-xl border border-white/10 text-sm font-semibold text-neutral-400 hover:text-white hover:bg-white/5 disabled:opacity-40 transition"
           >
             Cancel
           </button>
           <button
             onClick={generateKey}
-            disabled={!newKey.name.trim()}
+            disabled={!newKey.name.trim() || newKey.scopes.length === 0 || loading}
             className="flex-1 py-3 rounded-xl bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-bold transition active:scale-95"
           >
-            Generate Key
+            {loading ? "Creating…" : "Generate Key"}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Full API key lifecycle: create, revoke, and rotate keys via UI and REST API
- Granular scopes: `links:read`, `links:write`, `transactions:read`, `usernames:read`
- Usage tracking and monthly quota enforcement per key
- Updated `ApiKeyGuard` to validate against Supabase DB instead of env vars
- Frontend developer settings page wired to real API (replaced all mock data)

## Changes

**Backend**
- New `api-keys` module — controller, service, repository, types, DTO
- Keys are stored as bcrypt hashes; raw key returned once on creation/rotation
- `@RequireScopes()` decorator for route-level scope enforcement
- Atomic usage increment via Postgres RPC function (no race conditions)
- Supabase migration: `api_keys` table with prefix index for fast guard lookups
- Fixed `x-api-key` missing from CORS `allowedHeaders` in production config

**Frontend**
- `/settings/developer` — live API calls replacing all mock data
- Multi-select granular scope picker in create modal
- Rotate key action with one-time raw key display and save warning
- Real usage/quota stats and per-key request counts

## Test plan

- [ ] Apply migration: `supabase/migrations/20260328000000_create_api_keys_table.sql`
- [ ] Run unit tests: `cd app/backend && pnpm test:unit` (15/15 passing)
- [ ] Create a key via UI at `/settings/developer` and verify raw key shown once
- [ ] Revoke a key and confirm it no longer authenticates
- [ ] Rotate a key and confirm old key is invalid, new key works
- [ ] Pass `x-api-key` header to a protected endpoint and verify scope enforcement
- [ ] Exceed quota and confirm `QUOTA_EXCEEDED` error is returned

Closes #212
