### PR TITLE
feat: implement username marketplace with bidding (#209)

### DIFF
--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -28,6 +28,7 @@ import { CorrelationIdMiddleware } from "./common/middleware/correlation-id.midd
 import { NotificationsModule } from "./notifications/notifications.module";
 import { IngestionModule } from "./ingestion/ingestion.module";
 import { ApiKeysModule } from "./api-keys/api-keys.module";
+import { MarketplaceModule } from "./marketplace/marketplace.module";
 
 type AppImport =
   | Type<unknown>
@@ -62,6 +63,7 @@ type AppImport =
       PaymentsModule,
       IngestionModule,
       ApiKeysModule,
+      MarketplaceModule,
     ];
 
     // In development, if SUPABASE_URL points to a localhost placeholder (i.e. you don't

--- a/app/backend/src/marketplace/dto/accept-bid.dto.ts
+++ b/app/backend/src/marketplace/dto/accept-bid.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { IsStellarPublicKey } from '../../dto/validators';
+
+export class AcceptBidDto {
+  @ApiProperty({ example: 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR' })
+  @IsString()
+  @IsNotEmpty()
+  @IsStellarPublicKey({ message: 'Public key must be a valid Stellar public key' })
+  sellerPublicKey!: string;
+}

--- a/app/backend/src/marketplace/dto/cancel-listing.dto.ts
+++ b/app/backend/src/marketplace/dto/cancel-listing.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { IsStellarPublicKey } from '../../dto/validators';
+
+export class CancelListingDto {
+  @ApiProperty({ example: 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR' })
+  @IsString()
+  @IsNotEmpty()
+  @IsStellarPublicKey({ message: 'Public key must be a valid Stellar public key' })
+  sellerPublicKey!: string;
+}

--- a/app/backend/src/marketplace/dto/index.ts
+++ b/app/backend/src/marketplace/dto/index.ts
@@ -1,0 +1,4 @@
+export * from './list-username.dto';
+export * from './place-bid.dto';
+export * from './accept-bid.dto';
+export * from './cancel-listing.dto';

--- a/app/backend/src/marketplace/dto/list-username.dto.ts
+++ b/app/backend/src/marketplace/dto/list-username.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
+import { IsStellarPublicKey, IsUsername } from '../../dto/validators';
+
+export class ListUsernameDto {
+  @ApiProperty({ example: 'alice_123' })
+  @IsString()
+  @IsNotEmpty()
+  @IsUsername({ message: 'Username must contain only lowercase letters, numbers, and underscores' })
+  username!: string;
+
+  @ApiProperty({ example: 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR' })
+  @IsString()
+  @IsNotEmpty()
+  @IsStellarPublicKey({ message: 'Public key must be a valid Stellar public key' })
+  sellerPublicKey!: string;
+
+  @ApiProperty({ description: 'Asking price in XLM', example: 100.5 })
+  @IsNumber()
+  @Min(0.0000001)
+  askingPrice!: number;
+}

--- a/app/backend/src/marketplace/dto/place-bid.dto.ts
+++ b/app/backend/src/marketplace/dto/place-bid.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
+import { IsStellarPublicKey } from '../../dto/validators';
+
+export class PlaceBidDto {
+  @ApiProperty({ example: 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR' })
+  @IsString()
+  @IsNotEmpty()
+  @IsStellarPublicKey({ message: 'Public key must be a valid Stellar public key' })
+  bidderPublicKey!: string;
+
+  @ApiProperty({ description: 'Bid amount in XLM', example: 90.0 })
+  @IsNumber()
+  @Min(0.0000001)
+  bidAmount!: number;
+}

--- a/app/backend/src/marketplace/errors/index.ts
+++ b/app/backend/src/marketplace/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './marketplace-errors';

--- a/app/backend/src/marketplace/errors/marketplace-errors.ts
+++ b/app/backend/src/marketplace/errors/marketplace-errors.ts
@@ -1,0 +1,21 @@
+export enum MarketplaceErrorCode {
+  LISTING_NOT_FOUND = 'LISTING_NOT_FOUND',
+  BID_NOT_FOUND = 'BID_NOT_FOUND',
+  LISTING_NOT_ACTIVE = 'LISTING_NOT_ACTIVE',
+  BID_NOT_PENDING = 'BID_NOT_PENDING',
+  UNAUTHORIZED = 'MARKETPLACE_UNAUTHORIZED',
+  USERNAME_NOT_OWNED = 'USERNAME_NOT_OWNED',
+  ALREADY_LISTED = 'USERNAME_ALREADY_LISTED',
+  SELF_BID = 'MARKETPLACE_SELF_BID',
+  INVALID_PRICE = 'MARKETPLACE_INVALID_PRICE',
+}
+
+export class MarketplaceError extends Error {
+  constructor(
+    public readonly code: MarketplaceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'MarketplaceError';
+  }
+}

--- a/app/backend/src/marketplace/marketplace.controller.ts
+++ b/app/backend/src/marketplace/marketplace.controller.ts
@@ -1,0 +1,192 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  BadRequestException,
+  ForbiddenException,
+  ConflictException,
+} from '@nestjs/common';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { MarketplaceService } from './marketplace.service';
+import { ListUsernameDto, PlaceBidDto, AcceptBidDto, CancelListingDto } from './dto';
+import { MarketplaceError, MarketplaceErrorCode } from './errors';
+
+@ApiTags('marketplace')
+@Controller('marketplace')
+export class MarketplaceController {
+  constructor(private readonly marketplaceService: MarketplaceService) {}
+
+  @Post('list')
+  @ApiOperation({ summary: 'List a username for sale' })
+  @ApiBody({ type: ListUsernameDto })
+  @ApiResponse({ status: 201, description: 'Listing created' })
+  @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Username not owned by this wallet' })
+  @ApiResponse({ status: 409, description: 'Username already listed' })
+  async listUsername(@Body() body: ListUsernameDto) {
+    try {
+      const listing = await this.marketplaceService.listUsername(
+        body.username,
+        body.sellerPublicKey,
+        body.askingPrice,
+      );
+      return { listing };
+    } catch (err) {
+      if (err instanceof MarketplaceError) {
+        this.throwHttp(err);
+      }
+      throw err;
+    }
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get all active listings' })
+  @ApiQuery({ name: 'limit', required: false, example: 20 })
+  @ApiQuery({ name: 'offset', required: false, example: 0 })
+  @ApiResponse({ status: 200, description: 'List of active listings' })
+  async getActiveListings(
+    @Query('limit') limit = 20,
+    @Query('offset') offset = 0,
+  ) {
+    const { listings, total } = await this.marketplaceService.getActiveListings(
+      Number(limit),
+      Number(offset),
+    );
+    return { listings, total };
+  }
+
+  @Get(':listingId')
+  @ApiOperation({ summary: 'Get a specific listing' })
+  @ApiParam({ name: 'listingId', description: 'Listing UUID' })
+  @ApiResponse({ status: 200, description: 'Listing details' })
+  @ApiResponse({ status: 404, description: 'Listing not found' })
+  async getListing(@Param('listingId') listingId: string) {
+    try {
+      const listing = await this.marketplaceService.getListing(listingId);
+      return { listing };
+    } catch (err) {
+      if (err instanceof MarketplaceError) {
+        this.throwHttp(err);
+      }
+      throw err;
+    }
+  }
+
+  @Delete(':listingId')
+  @ApiOperation({ summary: 'Cancel a listing' })
+  @ApiParam({ name: 'listingId', description: 'Listing UUID' })
+  @ApiBody({ type: CancelListingDto })
+  @ApiResponse({ status: 200, description: 'Listing cancelled' })
+  @ApiResponse({ status: 403, description: 'Not the seller' })
+  @ApiResponse({ status: 404, description: 'Listing not found' })
+  async cancelListing(
+    @Param('listingId') listingId: string,
+    @Body() body: CancelListingDto,
+  ) {
+    try {
+      await this.marketplaceService.cancelListing(listingId, body.sellerPublicKey);
+      return { ok: true };
+    } catch (err) {
+      if (err instanceof MarketplaceError) {
+        this.throwHttp(err);
+      }
+      throw err;
+    }
+  }
+
+  @Post(':listingId/bid')
+  @ApiOperation({ summary: 'Place a bid on a listing' })
+  @ApiParam({ name: 'listingId', description: 'Listing UUID' })
+  @ApiBody({ type: PlaceBidDto })
+  @ApiResponse({ status: 201, description: 'Bid placed' })
+  @ApiResponse({ status: 400, description: 'Seller cannot bid on own listing' })
+  @ApiResponse({ status: 404, description: 'Listing not found' })
+  async placeBid(
+    @Param('listingId') listingId: string,
+    @Body() body: PlaceBidDto,
+  ) {
+    try {
+      const bid = await this.marketplaceService.placeBid(
+        listingId,
+        body.bidderPublicKey,
+        body.bidAmount,
+      );
+      return { bid };
+    } catch (err) {
+      if (err instanceof MarketplaceError) {
+        this.throwHttp(err);
+      }
+      throw err;
+    }
+  }
+
+  @Get(':listingId/bids')
+  @ApiOperation({ summary: 'Get all bids for a listing' })
+  @ApiParam({ name: 'listingId', description: 'Listing UUID' })
+  @ApiResponse({ status: 200, description: 'List of bids' })
+  @ApiResponse({ status: 404, description: 'Listing not found' })
+  async getBids(@Param('listingId') listingId: string) {
+    try {
+      const bids = await this.marketplaceService.getBids(listingId);
+      return { bids };
+    } catch (err) {
+      if (err instanceof MarketplaceError) {
+        this.throwHttp(err);
+      }
+      throw err;
+    }
+  }
+
+  @Post(':listingId/accept-bid/:bidId')
+  @ApiOperation({ summary: 'Accept a bid — atomically transfers username ownership' })
+  @ApiParam({ name: 'listingId', description: 'Listing UUID' })
+  @ApiParam({ name: 'bidId', description: 'Bid UUID' })
+  @ApiBody({ type: AcceptBidDto })
+  @ApiResponse({ status: 200, description: 'Bid accepted and ownership transferred' })
+  @ApiResponse({ status: 400, description: 'Bid not pending or listing not active' })
+  @ApiResponse({ status: 403, description: 'Not the seller' })
+  @ApiResponse({ status: 404, description: 'Listing or bid not found' })
+  async acceptBid(
+    @Param('listingId') listingId: string,
+    @Param('bidId') bidId: string,
+    @Body() body: AcceptBidDto,
+  ) {
+    try {
+      await this.marketplaceService.acceptBid(listingId, bidId, body.sellerPublicKey);
+      return { ok: true };
+    } catch (err) {
+      if (err instanceof MarketplaceError) {
+        this.throwHttp(err);
+      }
+      throw err;
+    }
+  }
+
+  private throwHttp(err: MarketplaceError): never {
+    switch (err.code) {
+      case MarketplaceErrorCode.LISTING_NOT_FOUND:
+      case MarketplaceErrorCode.BID_NOT_FOUND:
+        throw new NotFoundException({ code: err.code, message: err.message });
+      case MarketplaceErrorCode.UNAUTHORIZED:
+      case MarketplaceErrorCode.USERNAME_NOT_OWNED:
+        throw new ForbiddenException({ code: err.code, message: err.message });
+      case MarketplaceErrorCode.ALREADY_LISTED:
+        throw new ConflictException({ code: err.code, message: err.message });
+      default:
+        throw new BadRequestException({ code: err.code, message: err.message });
+    }
+  }
+}

--- a/app/backend/src/marketplace/marketplace.module.ts
+++ b/app/backend/src/marketplace/marketplace.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { SupabaseModule } from '../supabase/supabase.module';
+import { UsernamesModule } from '../usernames/usernames.module';
+import { MarketplaceController } from './marketplace.controller';
+import { MarketplaceService } from './marketplace.service';
+
+@Module({
+  imports: [SupabaseModule, UsernamesModule],
+  controllers: [MarketplaceController],
+  providers: [MarketplaceService],
+})
+export class MarketplaceModule {}

--- a/app/backend/src/marketplace/marketplace.service.ts
+++ b/app/backend/src/marketplace/marketplace.service.ts
@@ -1,0 +1,155 @@
+import { Injectable } from '@nestjs/common';
+import { SupabaseService, MarketplaceListing, MarketplaceBid } from '../supabase/supabase.service';
+import { SupabaseUniqueConstraintError } from '../supabase/supabase.errors';
+import { UsernamesService } from '../usernames/usernames.service';
+import { MarketplaceError, MarketplaceErrorCode } from './errors';
+
+@Injectable()
+export class MarketplaceService {
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly usernames: UsernamesService,
+  ) {}
+
+  async listUsername(
+    username: string,
+    sellerPublicKey: string,
+    askingPrice: number,
+  ): Promise<MarketplaceListing> {
+    const normalized = username.trim().toLowerCase();
+
+    const owned = await this.usernames.listByPublicKey(sellerPublicKey);
+    if (!owned.find((u) => u.username === normalized)) {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.USERNAME_NOT_OWNED,
+        'Username not found or does not belong to this wallet',
+      );
+    }
+
+    const existing = await this.supabase.getActiveListingByUsername(normalized);
+    if (existing) {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.ALREADY_LISTED,
+        'Username already has an active listing',
+      );
+    }
+
+    try {
+      return await this.supabase.createListing(normalized, sellerPublicKey, askingPrice);
+    } catch (err) {
+      if (err instanceof SupabaseUniqueConstraintError) {
+        throw new MarketplaceError(
+          MarketplaceErrorCode.ALREADY_LISTED,
+          'Username already has an active listing',
+        );
+      }
+      throw err;
+    }
+  }
+
+  async getActiveListings(
+    limit: number = 20,
+    offset: number = 0,
+  ): Promise<{ listings: MarketplaceListing[]; total: number }> {
+    return this.supabase.getActiveListings(limit, offset);
+  }
+
+  async getListing(listingId: string): Promise<MarketplaceListing> {
+    const listing = await this.supabase.getListingById(listingId);
+    if (!listing) {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.LISTING_NOT_FOUND,
+        'Listing not found',
+      );
+    }
+    return listing;
+  }
+
+  async cancelListing(listingId: string, sellerPublicKey: string): Promise<void> {
+    const listing = await this.getListing(listingId);
+
+    if (listing.seller_public_key !== sellerPublicKey) {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.UNAUTHORIZED,
+        'Only the seller can cancel this listing',
+      );
+    }
+
+    if (listing.status !== 'active') {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.LISTING_NOT_ACTIVE,
+        'Only active listings can be cancelled',
+      );
+    }
+
+    await this.supabase.cancelListing(listingId);
+  }
+
+  async placeBid(
+    listingId: string,
+    bidderPublicKey: string,
+    bidAmount: number,
+  ): Promise<MarketplaceBid> {
+    const listing = await this.getListing(listingId);
+
+    if (listing.status !== 'active') {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.LISTING_NOT_ACTIVE,
+        'Listing is no longer active',
+      );
+    }
+
+    if (listing.seller_public_key === bidderPublicKey) {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.SELF_BID,
+        'Seller cannot bid on their own listing',
+      );
+    }
+
+    return this.supabase.placeBid(listingId, bidderPublicKey, bidAmount);
+  }
+
+  async getBids(listingId: string): Promise<MarketplaceBid[]> {
+    await this.getListing(listingId);
+    return this.supabase.getBidsByListingId(listingId);
+  }
+
+  async acceptBid(
+    listingId: string,
+    bidId: string,
+    sellerPublicKey: string,
+  ): Promise<void> {
+    const listing = await this.getListing(listingId);
+
+    if (listing.seller_public_key !== sellerPublicKey) {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.UNAUTHORIZED,
+        'Only the seller can accept a bid',
+      );
+    }
+
+    if (listing.status !== 'active') {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.LISTING_NOT_ACTIVE,
+        'Listing is no longer active',
+      );
+    }
+
+    const bid = await this.supabase.getBidById(bidId);
+    if (!bid || bid.listing_id !== listingId) {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.BID_NOT_FOUND,
+        'Bid not found on this listing',
+      );
+    }
+
+    if (bid.status !== 'pending') {
+      throw new MarketplaceError(
+        MarketplaceErrorCode.BID_NOT_PENDING,
+        'Bid is no longer pending',
+      );
+    }
+
+    await this.supabase.acceptBid(listingId, bidId, sellerPublicKey);
+  }
+}

--- a/app/backend/src/supabase/supabase.service.ts
+++ b/app/backend/src/supabase/supabase.service.ts
@@ -29,6 +29,29 @@ export interface TrendingCreatorResult extends SearchProfileResult {
   transaction_count: number;
 }
 
+export interface MarketplaceListing {
+  id: string;
+  username: string;
+  seller_public_key: string;
+  asking_price: number;
+  status: 'active' | 'sold' | 'cancelled';
+  created_at: string;
+  updated_at: string;
+  sold_at: string | null;
+  buyer_public_key: string | null;
+  final_price: number | null;
+}
+
+export interface MarketplaceBid {
+  id: string;
+  listing_id: string;
+  bidder_public_key: string;
+  bid_amount: number;
+  status: 'pending' | 'accepted' | 'rejected' | 'cancelled';
+  created_at: string;
+  updated_at: string;
+}
+
 @Injectable()
 export class SupabaseService {
   private readonly logger = new Logger(SupabaseService.name);
@@ -376,12 +399,105 @@ export class SupabaseService {
   ): Promise<void> {
     const { error } = await this.client
       .from('usernames')
-      .update({ 
+      .update({
         is_public: isPublic,
         last_active_at: new Date().toISOString(),
       })
       .eq('username', username);
-    
+
+    if (error) this.handleError(error);
+  }
+
+  async createListing(
+    username: string,
+    sellerPublicKey: string,
+    askingPrice: number,
+  ): Promise<MarketplaceListing> {
+    const { data, error } = await this.client
+      .from('username_marketplace')
+      .insert({ username, seller_public_key: sellerPublicKey, asking_price: askingPrice })
+      .select()
+      .single();
+    if (error) this.handleError(error);
+    return data as MarketplaceListing;
+  }
+
+  async getActiveListings(limit: number, offset: number): Promise<{ listings: MarketplaceListing[]; total: number }> {
+    const { data, error, count } = await this.client
+      .from('username_marketplace')
+      .select('*', { count: 'exact' })
+      .eq('status', 'active')
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+    if (error) this.handleError(error);
+    return { listings: (data ?? []) as MarketplaceListing[], total: count ?? 0 };
+  }
+
+  async getListingById(listingId: string): Promise<MarketplaceListing | null> {
+    const { data, error } = await this.client
+      .from('username_marketplace')
+      .select('*')
+      .eq('id', listingId)
+      .maybeSingle();
+    if (error) this.handleError(error);
+    return data as MarketplaceListing | null;
+  }
+
+  async getActiveListingByUsername(username: string): Promise<MarketplaceListing | null> {
+    const { data, error } = await this.client
+      .from('username_marketplace')
+      .select('*')
+      .eq('username', username)
+      .eq('status', 'active')
+      .maybeSingle();
+    if (error) this.handleError(error);
+    return data as MarketplaceListing | null;
+  }
+
+  async cancelListing(listingId: string): Promise<void> {
+    const { error } = await this.client
+      .from('username_marketplace')
+      .update({ status: 'cancelled', updated_at: new Date().toISOString() })
+      .eq('id', listingId);
+    if (error) this.handleError(error);
+  }
+
+  async placeBid(listingId: string, bidderPublicKey: string, bidAmount: number): Promise<MarketplaceBid> {
+    const { data, error } = await this.client
+      .from('username_bids')
+      .insert({ listing_id: listingId, bidder_public_key: bidderPublicKey, bid_amount: bidAmount })
+      .select()
+      .single();
+    if (error) this.handleError(error);
+    return data as MarketplaceBid;
+  }
+
+  async getBidsByListingId(listingId: string): Promise<MarketplaceBid[]> {
+    const { data, error } = await this.client
+      .from('username_bids')
+      .select('*')
+      .eq('listing_id', listingId)
+      .order('bid_amount', { ascending: false });
+    if (error) this.handleError(error);
+    return (data ?? []) as MarketplaceBid[];
+  }
+
+  async getBidById(bidId: string): Promise<MarketplaceBid | null> {
+    const { data, error } = await this.client
+      .from('username_bids')
+      .select('*')
+      .eq('id', bidId)
+      .maybeSingle();
+    if (error) this.handleError(error);
+    return data as MarketplaceBid | null;
+  }
+
+  async acceptBid(listingId: string, bidId: string, sellerPublicKey: string): Promise<void> {
+    const { error } = await this.client.rpc('accept_username_bid', {
+      p_listing_id: listingId,
+      p_bid_id: bidId,
+      p_seller_public_key: sellerPublicKey,
+    });
     if (error) this.handleError(error);
   }
 }

--- a/app/backend/src/usernames/usernames.module.ts
+++ b/app/backend/src/usernames/usernames.module.ts
@@ -8,5 +8,6 @@ import { UsernamesService } from './usernames.service';
   imports: [SupabaseModule],
   controllers: [UsernamesController],
   providers: [UsernamesService],
+  exports: [UsernamesService],
 })
 export class UsernamesModule {}

--- a/app/backend/supabase/migrations/20250328000000_username_marketplace.sql
+++ b/app/backend/supabase/migrations/20250328000000_username_marketplace.sql
@@ -1,0 +1,102 @@
+CREATE TABLE username_marketplace (
+  id                UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  username          TEXT          NOT NULL REFERENCES usernames(username) ON DELETE CASCADE,
+  seller_public_key TEXT          NOT NULL,
+  asking_price      NUMERIC(20,7) NOT NULL CHECK (asking_price > 0),
+  status            TEXT          NOT NULL DEFAULT 'active'
+                                  CHECK (status IN ('active', 'sold', 'cancelled')),
+  created_at        TIMESTAMPTZ   NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ   NOT NULL DEFAULT now(),
+  sold_at           TIMESTAMPTZ,
+  buyer_public_key  TEXT,
+  final_price       NUMERIC(20,7)
+);
+
+CREATE UNIQUE INDEX username_marketplace_active_unique
+  ON username_marketplace (username)
+  WHERE status = 'active';
+
+CREATE INDEX username_marketplace_seller_idx   ON username_marketplace (seller_public_key);
+CREATE INDEX username_marketplace_status_idx   ON username_marketplace (status);
+CREATE INDEX username_marketplace_username_idx ON username_marketplace (username);
+
+CREATE TABLE username_bids (
+  id                UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  listing_id        UUID          NOT NULL REFERENCES username_marketplace(id) ON DELETE CASCADE,
+  bidder_public_key TEXT          NOT NULL,
+  bid_amount        NUMERIC(20,7) NOT NULL CHECK (bid_amount > 0),
+  status            TEXT          NOT NULL DEFAULT 'pending'
+                                  CHECK (status IN ('pending', 'accepted', 'rejected', 'cancelled')),
+  created_at        TIMESTAMPTZ   NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX username_bids_listing_idx ON username_bids (listing_id);
+CREATE INDEX username_bids_bidder_idx  ON username_bids (bidder_public_key);
+CREATE INDEX username_bids_status_idx  ON username_bids (status);
+
+CREATE OR REPLACE FUNCTION accept_username_bid(
+  p_listing_id        UUID,
+  p_bid_id            UUID,
+  p_seller_public_key TEXT
+) RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_listing username_marketplace%ROWTYPE;
+  v_bid     username_bids%ROWTYPE;
+BEGIN
+  SELECT * INTO v_listing
+    FROM username_marketplace
+   WHERE id = p_listing_id
+     FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'LISTING_NOT_FOUND: Listing % does not exist', p_listing_id;
+  END IF;
+
+  IF v_listing.status != 'active' THEN
+    RAISE EXCEPTION 'LISTING_NOT_ACTIVE: Listing is in status "%"', v_listing.status;
+  END IF;
+
+  IF v_listing.seller_public_key != p_seller_public_key THEN
+    RAISE EXCEPTION 'UNAUTHORIZED: Caller is not the seller of this listing';
+  END IF;
+
+  SELECT * INTO v_bid
+    FROM username_bids
+   WHERE id = p_bid_id
+     AND listing_id = p_listing_id
+     FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'BID_NOT_FOUND: Bid % does not exist on this listing', p_bid_id;
+  END IF;
+
+  IF v_bid.status != 'pending' THEN
+    RAISE EXCEPTION 'BID_NOT_PENDING: Bid is in status "%"', v_bid.status;
+  END IF;
+
+  UPDATE username_bids
+     SET status = 'accepted', updated_at = now()
+   WHERE id = p_bid_id;
+
+  UPDATE username_bids
+     SET status = 'rejected', updated_at = now()
+   WHERE listing_id = p_listing_id
+     AND id != p_bid_id
+     AND status = 'pending';
+
+  UPDATE username_marketplace
+     SET status           = 'sold',
+         sold_at          = now(),
+         buyer_public_key = v_bid.bidder_public_key,
+         final_price      = v_bid.bid_amount,
+         updated_at       = now()
+   WHERE id = p_listing_id;
+
+  UPDATE usernames
+     SET public_key = v_bid.bidder_public_key
+   WHERE username = v_listing.username;
+END;
+$$;


### PR DESCRIPTION
## Summary

- Adds `username_marketplace` and `username_bids` tables via Supabase migration
- Implements `accept_username_bid` PostgreSQL RPC for atomic, race-safe ownership transfer in a single transaction
- Introduces `MarketplaceModule` with 6 REST endpoints covering the full buy/sell lifecycle
- Verifies seller ownership before listing and prevents self-bidding

## Endpoints

| Method | Route | Description |
|--------|-------|-------------|
| `POST` | `/marketplace/list` | List a username for sale |
| `GET` | `/marketplace` | Browse active listings (paginated) |
| `GET` | `/marketplace/:listingId` | Get a single listing |
| `DELETE` | `/marketplace/:listingId` | Cancel a listing (seller only) |
| `POST` | `/marketplace/:listingId/bid` | Place a bid |
| `GET` | `/marketplace/:listingId/bids` | View bids for a listing |
| `POST` | `/marketplace/:listingId/accept-bid/:bidId` | Accept a bid — atomically transfers ownership |

## How the atomic transfer works

`accept_username_bid` is a single PL/pgSQL function that:
1. Locks the listing and bid rows with `FOR UPDATE`
2. Validates status and seller identity
3. Marks the winning bid `accepted`, all others `rejected`
4. Sets the listing to `sold` with buyer and final price
5. Updates `usernames.public_key` to the buyer's key

All four steps commit or roll back together — no partial state is possible.

## Test plan

- [ ] `POST /marketplace/list` — rejects if caller doesn't own the username
- [ ] `POST /marketplace/list` — rejects duplicate active listing (409)
- [ ] `POST /marketplace/:id/bid` — rejects seller self-bid (400)
- [ ] `POST /marketplace/:id/accept-bid/:bidId` — rejects non-seller (403)
- [ ] `POST /marketplace/:id/accept-bid/:bidId` — ownership transfers atomically; competing bids rejected
- [ ] `DELETE /marketplace/:id` — only seller can cancel

Closes #209