### PR TITLE
feat(contract): deterministic escrow-id derivation (#304)

### DIFF
--- a/app/contract/contracts/quickex/src/escrow.rs
+++ b/app/contract/contracts/quickex/src/escrow.rs
@@ -65,10 +65,10 @@ use soroban_sdk::{token, Address, Bytes, BytesN, Env};
 use crate::{
     commitment,
     errors::QuickexError,
-    events, fee,
+    escrow_id, events, fee,
     storage::{
-        get_escrow, get_platform_wallet, has_escrow, put_escrow, remove_escrow, LEDGER_THRESHOLD,
-        SIX_MONTHS_IN_LEDGERS,
+        get_escrow, get_escrow_id_mapping, get_platform_wallet, has_escrow, put_escrow,
+        put_escrow_id_mapping, remove_escrow, LEDGER_THRESHOLD, SIX_MONTHS_IN_LEDGERS,
     },
     types::{EscrowEntry, EscrowStatus},
 };
@@ -158,6 +158,15 @@ pub fn deposit(
     // INV-3: validated, overflow-safe expiry computation
     let expires_at = compute_expires_at(env, timeout_secs)?;
 
+    // Issue #304: deterministic escrow id over the full creation payload.
+    // If an identical request has already been recorded, return the
+    // existing commitment instead of creating a duplicate escrow.
+    let escrow_id =
+        escrow_id::derive_escrow_id(env, &token, amount, &owner, &salt, timeout_secs, &arbiter)?;
+    if let Some(existing) = get_escrow_id_mapping(env, &escrow_id) {
+        return Ok(existing);
+    }
+
     let commitment = commitment::create_amount_commitment(env, owner.clone(), amount, salt)?;
     let now = env.ledger().timestamp();
 
@@ -196,6 +205,7 @@ pub fn deposit(
     };
 
     put_escrow(env, &commitment_bytes, &entry);
+    put_escrow_id_mapping(env, &escrow_id, &commitment);
     token_client.transfer(&owner, env.current_contract_address(), &amount);
 
     events::publish_escrow_deposited(

--- a/app/contract/contracts/quickex/src/escrow_id.rs
+++ b/app/contract/contracts/quickex/src/escrow_id.rs
@@ -1,0 +1,137 @@
+//! Deterministic Escrow ID derivation (Issue #304).
+//!
+//! # Purpose
+//!
+//! Derive a stable `escrow_id` from a canonical hash of the full escrow
+//! creation payload. This enables deduplication of identical creation
+//! requests and improves UX when the same request is re-submitted.
+//!
+//! # Design
+//!
+//! ```text
+//! escrow_id = SHA-256(
+//!     DOMAIN_TAG
+//!     || be32(len(token_xdr))    || token_xdr
+//!     || be128(amount)
+//!     || be32(len(owner_xdr))    || owner_xdr
+//!     || be64(timeout_secs)
+//!     || arbiter_tag_u8          // 0 = None, 1 = Some
+//!     || [ be32(len(arbiter_xdr)) || arbiter_xdr ]   // only if Some
+//!     || be32(len(salt))         || salt
+//! )
+//! ```
+//!
+//! ## Invariants
+//!
+//! 1. **Determinism**: identical inputs always yield the same `escrow_id`.
+//! 2. **Collision resistance**: different inputs yield different `escrow_id`
+//!    with negligible probability (SHA-256).
+//! 3. **Domain separation**: `DOMAIN_TAG` prevents cross-protocol collisions
+//!    with the amount-commitment hash ([`crate::commitment`]) and the
+//!    stealth-address hash ([`crate::stealth`]). Neither scheme uses this
+//!    tag, so an `escrow_id` cannot equal any commitment or stealth address
+//!    under a chosen-input attack.
+//! 4. **Unambiguous boundaries**: every variable-length field (addresses,
+//!    salt) carries a 4-byte big-endian length prefix, so no two distinct
+//!    parameter tuples can produce the same byte stream.
+//! 5. **Salt length cap**: enforced at 1024 bytes (matches
+//!    [`crate::commitment`]) to guard against DoS-by-hashing.
+//!
+//! # What this is NOT
+//!
+//! - Not a privacy commitment. The `escrow_id` binds ALL creation params
+//!   (token, timeout, arbiter) and is intended to be public, not hiding.
+//! - Not a replacement for [`crate::commitment::create_amount_commitment`],
+//!   which remains the privacy-preserving storage key for escrow entries.
+
+use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env};
+
+use crate::errors::QuickexError;
+
+/// Domain separation tag for escrow-id derivation.
+///
+/// Bump the version suffix (`v1` → `v2`) if the canonical encoding ever
+/// changes; this guarantees that clients and storage from different
+/// versions cannot collide.
+pub const ESCROW_ID_DOMAIN_TAG: &[u8] = b"QUICKEX::ESCROW_ID::v1";
+
+/// Arbiter presence tag for canonical serialization.
+const ARBITER_TAG_NONE: u8 = 0;
+const ARBITER_TAG_SOME: u8 = 1;
+
+/// Salt length cap (matches `commitment::create_amount_commitment`).
+const MAX_SALT_LEN: u32 = 1024;
+
+/// Append a variable-length byte field with a 4-byte big-endian length prefix.
+///
+/// The prefix makes field boundaries unambiguous, so two distinct parameter
+/// tuples cannot produce the same serialized payload (INV-4).
+fn append_len_prefixed(env: &Env, payload: &mut Bytes, field: &Bytes) {
+    let len = field.len();
+    payload.append(&Bytes::from_array(env, &len.to_be_bytes()));
+    payload.append(field);
+}
+
+/// Derive a deterministic 32-byte escrow id from the full creation payload.
+///
+/// See the module doc for the exact canonical serialization and the
+/// invariants it guarantees.
+///
+/// # Errors
+///
+/// - [`QuickexError::InvalidAmount`] if `amount < 0`.
+/// - [`QuickexError::InvalidSalt`] if `salt.len() > 1024`.
+pub fn derive_escrow_id(
+    env: &Env,
+    token: &Address,
+    amount: i128,
+    owner: &Address,
+    salt: &Bytes,
+    timeout_secs: u64,
+    arbiter: &Option<Address>,
+) -> Result<BytesN<32>, QuickexError> {
+    if amount < 0 {
+        return Err(QuickexError::InvalidAmount);
+    }
+    if salt.len() > MAX_SALT_LEN {
+        return Err(QuickexError::InvalidSalt);
+    }
+
+    let mut payload = Bytes::new(env);
+
+    // 1. Domain-separation tag.
+    payload.append(&Bytes::from_slice(env, ESCROW_ID_DOMAIN_TAG));
+
+    // 2. Token address (length-prefixed XDR).
+    let token_xdr = token.to_xdr(env);
+    append_len_prefixed(env, &mut payload, &token_xdr);
+
+    // 3. Amount as big-endian i128 (16 bytes, fixed width → no prefix needed).
+    let amount_bytes: [u8; 16] = amount.to_be_bytes();
+    payload.append(&Bytes::from_array(env, &amount_bytes));
+
+    // 4. Owner address (length-prefixed XDR).
+    let owner_xdr = owner.to_xdr(env);
+    append_len_prefixed(env, &mut payload, &owner_xdr);
+
+    // 5. Timeout as big-endian u64 (8 bytes, fixed width).
+    let timeout_bytes: [u8; 8] = timeout_secs.to_be_bytes();
+    payload.append(&Bytes::from_array(env, &timeout_bytes));
+
+    // 6. Optional arbiter: 1-byte tag + (length-prefixed XDR if Some).
+    match arbiter {
+        None => {
+            payload.append(&Bytes::from_array(env, &[ARBITER_TAG_NONE]));
+        }
+        Some(arb) => {
+            payload.append(&Bytes::from_array(env, &[ARBITER_TAG_SOME]));
+            let arb_xdr = arb.to_xdr(env);
+            append_len_prefixed(env, &mut payload, &arb_xdr);
+        }
+    }
+
+    // 7. Salt (length-prefixed).
+    append_len_prefixed(env, &mut payload, salt);
+
+    Ok(env.crypto().sha256(&payload).into())
+}

--- a/app/contract/contracts/quickex/src/escrow_id_test.rs
+++ b/app/contract/contracts/quickex/src/escrow_id_test.rs
@@ -1,0 +1,364 @@
+//! Tests for deterministic escrow-id derivation (Issue #304).
+//!
+//! These tests validate the four invariants documented in
+//! [`crate::escrow_id`]:
+//!
+//! 1. **Determinism** — identical inputs always yield the same id.
+//! 2. **Collision resistance** — changing any single field changes the id.
+//! 3. **Domain separation** — the escrow id cannot collide with a
+//!    commitment hash over the same `(owner, amount, salt)` tuple.
+//! 4. **Unambiguous boundaries** — length-prefixing prevents two distinct
+//!    parameter tuples from producing the same serialized payload.
+//!
+//! It also verifies the idempotent-deposit behavior required by the
+//! acceptance criteria: "Duplicate creates are rejected or return existing
+//! escrow deterministically."
+
+use crate::{QuickexContract, QuickexContractClient};
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{StellarAssetClient, TokenClient},
+    Address, Bytes, Env,
+};
+
+extern crate std;
+
+fn setup<'a>() -> (Env, QuickexContractClient<'a>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+/// Register a SAC test token and return (token_address, admin).
+fn register_token<'a>(env: &'a Env) -> (Address, StellarAssetClient<'a>, TokenClient<'a>) {
+    let admin = Address::generate(env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_address = sac.address();
+    let mint_client = StellarAssetClient::new(env, &token_address);
+    let token_client = TokenClient::new(env, &token_address);
+    (token_address, mint_client, token_client)
+}
+
+// ============================================================================
+// Invariant 1: Determinism — same inputs yield the same escrow_id.
+// ============================================================================
+
+#[test]
+fn test_escrow_id_deterministic() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"canonical_salt");
+
+    let id1 = client.derive_escrow_id(
+        &token,
+        &1_000i128,
+        &owner,
+        &salt,
+        &3600u64,
+        &Some(arbiter.clone()),
+    );
+    let id2 = client.derive_escrow_id(&token, &1_000i128, &owner, &salt, &3600u64, &Some(arbiter));
+
+    assert_eq!(id1, id2);
+    assert_eq!(id1.len(), 32);
+}
+
+#[test]
+fn test_escrow_id_stable_across_many_calls() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"repeat");
+
+    let mut ids = std::vec::Vec::new();
+    for _ in 0..16 {
+        ids.push(client.derive_escrow_id(&token, &42i128, &owner, &salt, &0u64, &None));
+    }
+    for i in 1..ids.len() {
+        assert_eq!(ids[0], ids[i]);
+    }
+}
+
+// ============================================================================
+// Invariant 2: Collision resistance — any input change flips the id.
+// ============================================================================
+
+#[test]
+fn test_escrow_id_changes_with_amount() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"amt");
+
+    let id_a = client.derive_escrow_id(&token, &100i128, &owner, &salt, &0u64, &None);
+    let id_b = client.derive_escrow_id(&token, &101i128, &owner, &salt, &0u64, &None);
+    assert_ne!(id_a, id_b);
+}
+
+#[test]
+fn test_escrow_id_changes_with_token() {
+    let (env, client) = setup();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"tok");
+
+    let id_a = client.derive_escrow_id(&token_a, &100i128, &owner, &salt, &0u64, &None);
+    let id_b = client.derive_escrow_id(&token_b, &100i128, &owner, &salt, &0u64, &None);
+    assert_ne!(id_a, id_b);
+}
+
+#[test]
+fn test_escrow_id_changes_with_owner() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner_a = Address::generate(&env);
+    let owner_b = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"own");
+
+    let id_a = client.derive_escrow_id(&token, &100i128, &owner_a, &salt, &0u64, &None);
+    let id_b = client.derive_escrow_id(&token, &100i128, &owner_b, &salt, &0u64, &None);
+    assert_ne!(id_a, id_b);
+}
+
+#[test]
+fn test_escrow_id_changes_with_salt() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    let id_a = client.derive_escrow_id(
+        &token,
+        &100i128,
+        &owner,
+        &Bytes::from_slice(&env, b"alpha"),
+        &0u64,
+        &None,
+    );
+    let id_b = client.derive_escrow_id(
+        &token,
+        &100i128,
+        &owner,
+        &Bytes::from_slice(&env, b"beta"),
+        &0u64,
+        &None,
+    );
+    assert_ne!(id_a, id_b);
+}
+
+#[test]
+fn test_escrow_id_changes_with_timeout() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"to");
+
+    let id_a = client.derive_escrow_id(&token, &100i128, &owner, &salt, &0u64, &None);
+    let id_b = client.derive_escrow_id(&token, &100i128, &owner, &salt, &3600u64, &None);
+    assert_ne!(id_a, id_b);
+}
+
+#[test]
+fn test_escrow_id_changes_with_arbiter_presence() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"arb");
+
+    let id_none = client.derive_escrow_id(&token, &100i128, &owner, &salt, &0u64, &None);
+    let id_some = client.derive_escrow_id(&token, &100i128, &owner, &salt, &0u64, &Some(arbiter));
+    assert_ne!(id_none, id_some);
+}
+
+#[test]
+fn test_escrow_id_changes_with_arbiter_identity() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let arb_a = Address::generate(&env);
+    let arb_b = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"arb_id");
+
+    let id_a = client.derive_escrow_id(&token, &100i128, &owner, &salt, &0u64, &Some(arb_a));
+    let id_b = client.derive_escrow_id(&token, &100i128, &owner, &salt, &0u64, &Some(arb_b));
+    assert_ne!(id_a, id_b);
+}
+
+// ============================================================================
+// Invariant 3: Domain separation — escrow_id ≠ commitment for same inputs.
+// ============================================================================
+
+#[test]
+fn test_escrow_id_domain_separated_from_commitment() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let amount = 1_000i128;
+    let salt = Bytes::from_slice(&env, b"separate");
+
+    let commitment = client.create_amount_commitment(&owner, &amount, &salt);
+    let id = client.derive_escrow_id(&token, &amount, &owner, &salt, &0u64, &None);
+
+    // Different hashes over overlapping inputs MUST differ thanks to the
+    // domain tag and additional fields.
+    assert_ne!(commitment, id);
+}
+
+// ============================================================================
+// Invariant 4: Unambiguous boundaries — length-prefixing prevents ambiguity.
+// ============================================================================
+
+#[test]
+fn test_escrow_id_length_prefix_distinguishes_salt_boundary() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    // Without length prefixes, the serialization of two very similar
+    // salts that differ only in length would be easier to confuse. The
+    // length prefix guarantees distinct serializations and hence ids.
+    let id_short = client.derive_escrow_id(
+        &token,
+        &100i128,
+        &owner,
+        &Bytes::from_slice(&env, b"aa"),
+        &0u64,
+        &None,
+    );
+    let id_long = client.derive_escrow_id(
+        &token,
+        &100i128,
+        &owner,
+        &Bytes::from_slice(&env, b"aaa"),
+        &0u64,
+        &None,
+    );
+    assert_ne!(id_short, id_long);
+}
+
+#[test]
+fn test_escrow_id_empty_salt_still_derives() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    let id = client.derive_escrow_id(&token, &100i128, &owner, &Bytes::new(&env), &0u64, &None);
+    assert_eq!(id.len(), 32);
+}
+
+// ============================================================================
+// Input validation.
+// ============================================================================
+
+#[test]
+fn test_escrow_id_rejects_negative_amount() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"neg");
+
+    let result = client.try_derive_escrow_id(&token, &-1i128, &owner, &salt, &0u64, &None);
+    assert_eq!(result, Err(Ok(crate::errors::QuickexError::InvalidAmount)));
+}
+
+#[test]
+fn test_escrow_id_rejects_oversized_salt() {
+    let (env, client) = setup();
+    let token = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    let mut large_salt = Bytes::new(&env);
+    for _ in 0..1025 {
+        large_salt.push_back(0xAA);
+    }
+
+    let result = client.try_derive_escrow_id(&token, &100i128, &owner, &large_salt, &0u64, &None);
+    assert_eq!(result, Err(Ok(crate::errors::QuickexError::InvalidSalt)));
+}
+
+// ============================================================================
+// Acceptance criteria: duplicate deposits return existing escrow
+// deterministically.
+// ============================================================================
+
+#[test]
+fn test_deposit_idempotent_on_identical_params() {
+    let (env, client) = setup();
+    let (token, mint_client, token_client) = register_token(&env);
+    let owner = Address::generate(&env);
+    let salt = Bytes::from_slice(&env, b"idem");
+    let amount = 1_000i128;
+
+    // Fund the owner so the first deposit succeeds. The second deposit
+    // must NOT transfer again — idempotent behavior returns the existing
+    // commitment without a second transfer.
+    mint_client.mint(&owner, &amount);
+
+    let commitment1 = client.deposit(&token, &amount, &owner, &salt, &0u64, &None);
+
+    // After first deposit, owner's balance is 0 (transferred to contract).
+    assert_eq!(token_client.balance(&owner), 0);
+
+    // Re-submit the same exact request: should dedupe and return the
+    // same commitment, without pulling more funds.
+    let commitment2 = client.deposit(&token, &amount, &owner, &salt, &0u64, &None);
+    assert_eq!(commitment1, commitment2);
+    assert_eq!(token_client.balance(&owner), 0);
+
+    // The escrow-id → commitment mapping should resolve to the stored
+    // commitment, proving the derivation is observable on-chain.
+    let escrow_id = client.derive_escrow_id(&token, &amount, &owner, &salt, &0u64, &None);
+    let mapped = client.get_escrow_id_commitment(&escrow_id);
+    assert_eq!(mapped, Some(commitment1));
+}
+
+#[test]
+fn test_deposit_different_params_yield_different_ids() {
+    let (env, client) = setup();
+    let (token, mint_client, _) = register_token(&env);
+    let owner = Address::generate(&env);
+    let amount = 500i128;
+
+    mint_client.mint(&owner, &(amount * 2));
+
+    let c1 = client.deposit(
+        &token,
+        &amount,
+        &owner,
+        &Bytes::from_slice(&env, b"s1"),
+        &0u64,
+        &None,
+    );
+    let c2 = client.deposit(
+        &token,
+        &amount,
+        &owner,
+        &Bytes::from_slice(&env, b"s2"),
+        &0u64,
+        &None,
+    );
+    assert_ne!(c1, c2);
+
+    let id1 = client.derive_escrow_id(
+        &token,
+        &amount,
+        &owner,
+        &Bytes::from_slice(&env, b"s1"),
+        &0u64,
+        &None,
+    );
+    let id2 = client.derive_escrow_id(
+        &token,
+        &amount,
+        &owner,
+        &Bytes::from_slice(&env, b"s2"),
+        &0u64,
+        &None,
+    );
+    assert_ne!(id1, id2);
+}

--- a/app/contract/contracts/quickex/src/lib.rs
+++ b/app/contract/contracts/quickex/src/lib.rs
@@ -9,6 +9,9 @@ mod commitment;
 mod commitment_test;
 mod errors;
 mod escrow;
+mod escrow_id;
+#[cfg(test)]
+mod escrow_id_test;
 mod events;
 mod fee;
 #[cfg(test)]
@@ -196,6 +199,35 @@ impl QuickexContract {
             return Err(QuickexError::OperationPaused);
         }
         escrow::deposit(&env, token, amount, owner, salt, timeout_secs, arbiter)
+    }
+
+    /// Derive a deterministic 32-byte escrow id from the full creation payload.
+    ///
+    /// Issue #304: enables duplicate detection and idempotent re-submission.
+    /// Same inputs always yield the same id; any change to `token`, `amount`,
+    /// `owner`, `salt`, `timeout_secs`, or `arbiter` yields a different id
+    /// (see [`escrow_id`] module for the canonical serialization).
+    ///
+    /// # Errors
+    /// * `InvalidAmount` - Amount is negative
+    /// * `InvalidSalt` - Salt length exceeds 1024 bytes
+    pub fn derive_escrow_id(
+        env: Env,
+        token: Address,
+        amount: i128,
+        owner: Address,
+        salt: Bytes,
+        timeout_secs: u64,
+        arbiter: Option<Address>,
+    ) -> Result<BytesN<32>, QuickexError> {
+        escrow_id::derive_escrow_id(&env, &token, amount, &owner, &salt, timeout_secs, &arbiter)
+    }
+
+    /// Look up the escrow commitment associated with a deterministic `escrow_id`.
+    ///
+    /// Returns `None` if no escrow has been created for this id yet.
+    pub fn get_escrow_id_commitment(env: Env, escrow_id: BytesN<32>) -> Option<BytesN<32>> {
+        storage::get_escrow_id_mapping(&env, &escrow_id)
     }
 
     /// Create a deterministic commitment hash for an amount (off-chain / pre-deposit use).

--- a/app/contract/contracts/quickex/src/storage.rs
+++ b/app/contract/contracts/quickex/src/storage.rs
@@ -100,6 +100,10 @@ pub enum DataKey {
     FeeConfig,
     /// Platform wallet address for fee collection (singleton).
     PlatformWallet,
+    /// Maps a deterministic 32-byte `escrow_id` (see [`crate::escrow_id`])
+    /// to the commitment key of the escrow it identifies. Enables
+    /// idempotent deduplication of identical creation requests.
+    EscrowIdMap(BytesN<32>),
 }
 
 // -----------------------------------------------------------------------------
@@ -287,6 +291,27 @@ pub fn get_stealth_escrow(env: &Env, stealth_address: &BytesN<32>) -> Option<Ste
 pub fn put_stealth_escrow(env: &Env, stealth_address: &BytesN<32>, entry: &StealthEscrowEntry) {
     let key = DataKey::StealthEscrow(stealth_address.clone());
     env.storage().persistent().set(&key, entry);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_THRESHOLD, SIX_MONTHS_IN_LEDGERS);
+}
+
+// -----------------------------------------------------------------------------
+// Escrow-id map helpers (Issue #304)
+// -----------------------------------------------------------------------------
+
+/// Look up the 32-byte commitment associated with a deterministic `escrow_id`.
+pub fn get_escrow_id_mapping(env: &Env, escrow_id: &BytesN<32>) -> Option<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::EscrowIdMap(escrow_id.clone()))
+}
+
+/// Record the mapping `escrow_id → commitment` so future identical creates
+/// can be recognized and deduplicated.
+pub fn put_escrow_id_mapping(env: &Env, escrow_id: &BytesN<32>, commitment: &BytesN<32>) {
+    let key = DataKey::EscrowIdMap(escrow_id.clone());
+    env.storage().persistent().set(&key, commitment);
     env.storage()
         .persistent()
         .extend_ttl(&key, LEDGER_THRESHOLD, SIX_MONTHS_IN_LEDGERS);

--- a/app/contract/contracts/quickex/test_snapshots/bench_test/bench_deposit.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/bench_test/bench_deposit.1.json
@@ -280,6 +280,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "e267469525f1ca98840d956653895bd3cd2c712978e10e5ca43bef9559f4adf4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "e267469525f1ca98840d956653895bd3cd2c712978e10e5ca43bef9559f4adf4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "cd3e8299a6539ca050a04dc21ec2b9b297b27319c20e612085a674cd14a15b40"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_deposit_different_params_yield_different_ids.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_deposit_different_params_yield_different_ids.1.json
@@ -38,7 +38,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "i128": "85070591730234615865843651857942052863"
+                  "i128": "1000"
                 }
               ]
             }
@@ -60,13 +60,13 @@
                   "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "i128": "85070591730234615865843651857942052863"
+                  "i128": "500"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "bytes": "6c617267655f616d6f756e745f73616c74"
+                  "bytes": "7331"
                 },
                 {
                   "u64": "0"
@@ -89,7 +89,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                     },
                     {
-                      "i128": "85070591730234615865843651857942052863"
+                      "i128": "500"
                     }
                   ]
                 }
@@ -100,8 +100,6 @@
         }
       ]
     ],
-    [],
-    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
@@ -109,27 +107,49 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "withdraw",
+              "function_name": "deposit",
               "args": [
                 {
                   "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "i128": "85070591730234615865843651857942052863"
-                },
-                {
-                  "bytes": "76d93610d736ffb01fea1ba593cd35220a0dce7eeb27e075fa0a19bd00518f38"
+                  "i128": "500"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "bytes": "6c617267655f616d6f756e745f73616c74"
-                }
+                  "bytes": "7332"
+                },
+                {
+                  "u64": "0"
+                },
+                "void"
               ]
             }
           },
-          "sub_invocations": []
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "500"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
         }
       ]
     ],
@@ -217,7 +237,7 @@
                   "symbol": "Escrow"
                 },
                 {
-                  "bytes": "76d93610d736ffb01fea1ba593cd35220a0dce7eeb27e075fa0a19bd00518f38"
+                  "bytes": "013f8a09b3acf499700b7ad370c2ec954adec5c5af3d0af0305f0108a72d1ed0"
                 }
               ]
             },
@@ -237,7 +257,7 @@
                       "symbol": "Escrow"
                     },
                     {
-                      "bytes": "76d93610d736ffb01fea1ba593cd35220a0dce7eeb27e075fa0a19bd00518f38"
+                      "bytes": "013f8a09b3acf499700b7ad370c2ec954adec5c5af3d0af0305f0108a72d1ed0"
                     }
                   ]
                 },
@@ -249,7 +269,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "85070591730234615865843651857942052863"
+                        "i128": "500"
                       }
                     },
                     {
@@ -289,7 +309,111 @@
                       "val": {
                         "vec": [
                           {
-                            "symbol": "Spent"
+                            "symbol": "Pending"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Escrow"
+                },
+                {
+                  "bytes": "8b25ff70a4db57be2571fefc2cd0eb7705daf36914ee1359ca932bb1db496dce"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Escrow"
+                    },
+                    {
+                      "bytes": "8b25ff70a4db57be2571fefc2cd0eb7705daf36914ee1359ca932bb1db496dce"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "500"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "arbiter"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Pending"
                           }
                         ]
                       }
@@ -321,7 +445,7 @@
                   "symbol": "EscrowIdMap"
                 },
                 {
-                  "bytes": "6097f8f105ad76a8ac7f346614ac26c86772bf0dbea8f2b5cce2e2cda617dfbd"
+                  "bytes": "9d387c70041acf746ccc7274787d5988324e3e4eff16878d33906445b5939e7c"
                 }
               ]
             },
@@ -341,13 +465,58 @@
                       "symbol": "EscrowIdMap"
                     },
                     {
-                      "bytes": "6097f8f105ad76a8ac7f346614ac26c86772bf0dbea8f2b5cce2e2cda617dfbd"
+                      "bytes": "9d387c70041acf746ccc7274787d5988324e3e4eff16878d33906445b5939e7c"
                     }
                   ]
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "76d93610d736ffb01fea1ba593cd35220a0dce7eeb27e075fa0a19bd00518f38"
+                  "bytes": "013f8a09b3acf499700b7ad370c2ec954adec5c5af3d0af0305f0108a72d1ed0"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "ddaf1c19d0c634bc1980f5a5c8dfd729cb79f56a043995b23c8e260ae49c52a2"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "ddaf1c19d0c634bc1980f5a5c8dfd729cb79f56a043995b23c8e260ae49c52a2"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "8b25ff70a4db57be2571fefc2cd0eb7705daf36914ee1359ca932bb1db496dce"
                 }
               }
             },
@@ -529,7 +698,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "0"
+                        "i128": "1000"
                       }
                     },
                     {
@@ -599,7 +768,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "85070591730234615865843651857942052863"
+                        "i128": "0"
                       }
                     },
                     {

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_deposit_idempotent_on_identical_params.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_deposit_idempotent_on_identical_params.1.json
@@ -38,7 +38,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "i128": "85070591730234615865843651857942052863"
+                  "i128": "1000"
                 }
               ]
             }
@@ -60,13 +60,13 @@
                   "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "i128": "85070591730234615865843651857942052863"
+                  "i128": "1000"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "bytes": "6c617267655f616d6f756e745f73616c74"
+                  "bytes": "6964656d"
                 },
                 {
                   "u64": "0"
@@ -89,7 +89,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                     },
                     {
-                      "i128": "85070591730234615865843651857942052863"
+                      "i128": "1000"
                     }
                   ]
                 }
@@ -101,7 +101,6 @@
       ]
     ],
     [],
-    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
@@ -109,23 +108,24 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "withdraw",
+              "function_name": "deposit",
               "args": [
                 {
                   "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "i128": "85070591730234615865843651857942052863"
-                },
-                {
-                  "bytes": "76d93610d736ffb01fea1ba593cd35220a0dce7eeb27e075fa0a19bd00518f38"
+                  "i128": "1000"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "bytes": "6c617267655f616d6f756e745f73616c74"
-                }
+                  "bytes": "6964656d"
+                },
+                {
+                  "u64": "0"
+                },
+                "void"
               ]
             }
           },
@@ -133,6 +133,7 @@
         }
       ]
     ],
+    [],
     [],
     []
   ],
@@ -217,7 +218,7 @@
                   "symbol": "Escrow"
                 },
                 {
-                  "bytes": "76d93610d736ffb01fea1ba593cd35220a0dce7eeb27e075fa0a19bd00518f38"
+                  "bytes": "350bfba6f3c960bc4b51c7a2c84012abb1b7f56fe32c59d09b71b1793eea291c"
                 }
               ]
             },
@@ -237,7 +238,7 @@
                       "symbol": "Escrow"
                     },
                     {
-                      "bytes": "76d93610d736ffb01fea1ba593cd35220a0dce7eeb27e075fa0a19bd00518f38"
+                      "bytes": "350bfba6f3c960bc4b51c7a2c84012abb1b7f56fe32c59d09b71b1793eea291c"
                     }
                   ]
                 },
@@ -249,7 +250,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "85070591730234615865843651857942052863"
+                        "i128": "1000"
                       }
                     },
                     {
@@ -289,7 +290,7 @@
                       "val": {
                         "vec": [
                           {
-                            "symbol": "Spent"
+                            "symbol": "Pending"
                           }
                         ]
                       }
@@ -321,7 +322,7 @@
                   "symbol": "EscrowIdMap"
                 },
                 {
-                  "bytes": "6097f8f105ad76a8ac7f346614ac26c86772bf0dbea8f2b5cce2e2cda617dfbd"
+                  "bytes": "cec1606af9d11ca88bdd3a2b1eceb33e30a7f040531510b6f1b13ecd09cca7c6"
                 }
               ]
             },
@@ -341,13 +342,13 @@
                       "symbol": "EscrowIdMap"
                     },
                     {
-                      "bytes": "6097f8f105ad76a8ac7f346614ac26c86772bf0dbea8f2b5cce2e2cda617dfbd"
+                      "bytes": "cec1606af9d11ca88bdd3a2b1eceb33e30a7f040531510b6f1b13ecd09cca7c6"
                     }
                   ]
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "76d93610d736ffb01fea1ba593cd35220a0dce7eeb27e075fa0a19bd00518f38"
+                  "bytes": "350bfba6f3c960bc4b51c7a2c84012abb1b7f56fe32c59d09b71b1793eea291c"
                 }
               }
             },
@@ -529,7 +530,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "0"
+                        "i128": "1000"
                       }
                     },
                     {
@@ -599,7 +600,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "85070591730234615865843651857942052863"
+                        "i128": "0"
                       }
                     },
                     {

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_amount.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_amount.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_arbiter_identity.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_arbiter_identity.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_arbiter_presence.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_arbiter_presence.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_owner.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_owner.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_salt.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_salt.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_timeout.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_timeout.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_token.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_changes_with_token.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_deterministic.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_deterministic.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_domain_separated_from_commitment.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_domain_separated_from_commitment.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_empty_salt_still_derives.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_empty_salt_still_derives.1.json
@@ -1,0 +1,77 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_length_prefix_distinguishes_salt_boundary.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_length_prefix_distinguishes_salt_boundary.1.json
@@ -1,0 +1,78 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_rejects_negative_amount.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_rejects_negative_amount.1.json
@@ -1,0 +1,77 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_rejects_oversized_salt.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_rejects_oversized_salt.1.json
@@ -1,0 +1,77 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_stable_across_many_calls.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/escrow_id_test/test_escrow_id_stable_across_many_calls.1.json
@@ -1,0 +1,92 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/fee_test/test_withdrawal_with_fee.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/fee_test/test_withdrawal_with_fee.1.json
@@ -544,6 +544,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "e92f08e12ddced35956009205481e46ea55f6e4610390f1af175c04ac1e6a7a6"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "e92f08e12ddced35956009205481e46ea55f6e4610390f1af175c04ac1e6a7a6"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "84111ca45cc738443573015360a44ff2c8ee143031e3afe8e86e723d7870fa87"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "FeeConfig"
                 }
               ]

--- a/app/contract/contracts/quickex/test_snapshots/fee_test/test_zero_fee.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/fee_test/test_zero_fee.1.json
@@ -541,6 +541,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "e92f08e12ddced35956009205481e46ea55f6e4610390f1af175c04ac1e6a7a6"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "e92f08e12ddced35956009205481e46ea55f6e4610390f1af175c04ac1e6a7a6"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "84111ca45cc738443573015360a44ff2c8ee143031e3afe8e86e723d7870fa87"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "FeeConfig"
                 }
               ]

--- a/app/contract/contracts/quickex/test_snapshots/test/regression_golden_path_full_flow.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/regression_golden_path_full_flow.1.json
@@ -366,6 +366,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "899a2584c0f50dcb772f0f77e2d3f018952d9ded38f1f374c4c569ade365d1db"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "899a2584c0f50dcb772f0f77e2d3f018952d9ded38f1f374c4c569ade365d1db"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "3b9c99303dea51750332fac124ca785b4dc0a759e4daa0d0d6655d4c004740d5"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "privacy_enabled"
                 },
                 {

--- a/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_custom_token_deposit_refund.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_custom_token_deposit_refund.1.json
@@ -305,6 +305,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "acbd63501b84596f9949f4dff465c0b423422291ee7171f2978c5ccd4eb4bb55"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "acbd63501b84596f9949f4dff465c0b423422291ee7171f2978c5ccd4eb4bb55"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2bee6a3ad3c105085830bb078edcd7a2f0cdf267b78214382793175c524bb82c"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_dispute_resolution_multi_token.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_dispute_resolution_multi_token.1.json
@@ -337,6 +337,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "4327600e0eb1743bfb9d43c629afeea6b5182b83e731293d13015e558884823a"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "4327600e0eb1743bfb9d43c629afeea6b5182b83e731293d13015e558884823a"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "218985855c7d466d15165ea7ce82b583b05b2b73e92ae896a1db03dbd4f4ef67"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_multiple_tokens_concurrent.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_multiple_tokens_concurrent.1.json
@@ -903,6 +903,141 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "28e1c791d3307becc722f176b89c5dfa4250c2a82498448043ac83357eb65699"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "28e1c791d3307becc722f176b89c5dfa4250c2a82498448043ac83357eb65699"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "39b20c06923778516d073ef677091c052a38b331c216a6a0cfad746822fe99fa"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "5e6bc0230e12fa2e411337143123a6d730a1c6fb738460465fc2e6ac07775aef"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "5e6bc0230e12fa2e411337143123a6d730a1c6fb738460465fc2e6ac07775aef"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "50000450c357772a3dce89400c186826cef49624c96f7d319f38dbade3bfbb52"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "97da81a4436baa23c1e36b01bfd23f8d85db73bd24ea67122ec9311da458ea29"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "97da81a4436baa23c1e36b01bfd23f8d85db73bd24ea67122ec9311da458ea29"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "584276c0a126dd7511823a6245a45151fcb465a734765ea3769fa7c3c0f09a16"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_native_xlm_deposit_withdrawal.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_native_xlm_deposit_withdrawal.1.json
@@ -317,6 +317,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "fc2d17fdc32386c1cd4ec00206eefc27ee1206339bc2814f3db2257477982be8"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "fc2d17fdc32386c1cd4ec00206eefc27ee1206339bc2814f3db2257477982be8"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "d296f7500791c2d91b58b6eee1c20263541723cac80fc482c5ec553a0f4bfe53"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_privacy_preserved_across_tokens.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_privacy_preserved_across_tokens.1.json
@@ -386,6 +386,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "a35c65b964aca901f8cb82ae139f1be31b731056e470a93235a2164db1a5c239"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "a35c65b964aca901f8cb82ae139f1be31b731056e470a93235a2164db1a5c239"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "73f89b4d9913294a49b7d6d9723a6982c37b83a41ef6bab2f31d923e94a9e4b9"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "privacy_enabled"
                 },
                 {

--- a/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_usdc_sac_deposit_withdrawal.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_cross_asset_usdc_sac_deposit_withdrawal.1.json
@@ -317,6 +317,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "487a2fa845932cff8070eafa6579dea1ddc7feecc87cb5d3585cafe1f8b770f3"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "487a2fa845932cff8070eafa6579dea1ddc7feecc87cb5d3585cafe1f8b770f3"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "b68997224b98dc45214d7134fe69693bed98afb0d1ae79791af286b5eb32d748"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_dispute_fails_on_non_pending_status.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_dispute_fails_on_non_pending_status.1.json
@@ -316,6 +316,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "fbe70168aec2c5ca6029be6f9c3c1a5d92acf7db854aee84a288062e89963a2c"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "fbe70168aec2c5ca6029be6f9c3c1a5d92acf7db854aee84a288062e89963a2c"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "dbf996be540e46debf89623544b0cc6d4dce5f488dcc6a583c1460622d4d55d6"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_dispute_fails_without_arbiter.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_dispute_fails_without_arbiter.1.json
@@ -281,6 +281,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "5991c072c977d1e974047c15f459d4f6b5d4022d5e86c1fe7d9cc931dd0f4afb"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "5991c072c977d1e974047c15f459d4f6b5d4022d5e86c1fe7d9cc931dd0f4afb"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "d15dc4ee5b6b9a79e6005ad96eb6870adbd203452b5e054d7fa84b48e58e07c6"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_dispute_successful.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_dispute_successful.1.json
@@ -287,6 +287,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "43bb532b1458d977711c95ec46f34b57affe3f1138963ef2351b0a3518a69c45"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "43bb532b1458d977711c95ec46f34b57affe3f1138963ef2351b0a3518a69c45"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2236844983a8c21e632568d48575c931ff04992e3f97964cf6aba95aef2e2b01"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_double_refund_fails.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_double_refund_fails.1.json
@@ -303,6 +303,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "a54767f5ab6058e52c3ef46d0d0a1f28f5174674703ece566507c6cbf1639a77"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "a54767f5ab6058e52c3ef46d0d0a1f28f5174674703ece566507c6cbf1639a77"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "4d27b006ad08e358a86d96580a8d804f442d92f42d76ca066d9cad0a7e59e9af"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_event_snapshot_escrow_disputed_schema.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_event_snapshot_escrow_disputed_schema.1.json
@@ -285,6 +285,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "4e0f174d5987a00fecf1444fb1793d0088b576e011f0e8d045eb8885711df0d6"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "4e0f174d5987a00fecf1444fb1793d0088b576e011f0e8d045eb8885711df0d6"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "7802516c5431283aca29f43c9abc7a427bfef9108d1407a05e147069b35f97d9"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_event_snapshot_escrow_refunded_schema.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_event_snapshot_escrow_refunded_schema.1.json
@@ -302,6 +302,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "935df7d5d300533d57750ea999dfbdf4ba81a2445acdf29a4974ec1213c822cd"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "935df7d5d300533d57750ea999dfbdf4ba81a2445acdf29a4974ec1213c822cd"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "3c57e466c93d8a8db55b09a67105269e57abae939d99b9bf6c7451f50690e929"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_get_escrow_details_shows_arbiter_to_owner_and_arbiter.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_get_escrow_details_shows_arbiter_to_owner_and_arbiter.1.json
@@ -312,6 +312,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "117d6fddb2819e9c0612c0ec726f96ad21c13ae0a2aed4bc88cb4e6b2024281d"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "117d6fddb2819e9c0612c0ec726f96ad21c13ae0a2aed4bc88cb4e6b2024281d"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "f5689f35bd710f65ab6c47995f95e41d11cf5873ae914b2660246f50f7175678"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "privacy_enabled"
                 },
                 {

--- a/app/contract/contracts/quickex/test_snapshots/test/test_refund_fails_during_dispute.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_refund_fails_during_dispute.1.json
@@ -286,6 +286,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "b07747f0c5409bf3a7267241a637fe6d81cc3fb450f2238bcea8f574d522e5ee"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "b07747f0c5409bf3a7267241a637fe6d81cc3fb450f2238bcea8f574d522e5ee"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "9ffac7846653f5989afd4257b5e69d807d26b5ee295000a2f6d66ae8d5c8d98f"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_refund_fails_when_paused.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_refund_fails_when_paused.1.json
@@ -346,6 +346,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "68f1415c0fc83a6c7f36fbaf4b2fb88b9a5924a00b884b7ca38da734a8620b0e"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "68f1415c0fc83a6c7f36fbaf4b2fb88b9a5924a00b884b7ca38da734a8620b0e"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "a5eef92d40c8a36be61a4d41827610f2ef59fc2151a5775b33f15e6b2b5125c5"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "PauseFlags"
                 }
               ]

--- a/app/contract/contracts/quickex/test_snapshots/test/test_refund_pause_unpause.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_refund_pause_unpause.1.json
@@ -390,6 +390,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "68f1415c0fc83a6c7f36fbaf4b2fb88b9a5924a00b884b7ca38da734a8620b0e"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "68f1415c0fc83a6c7f36fbaf4b2fb88b9a5924a00b884b7ca38da734a8620b0e"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "a5eef92d40c8a36be61a4d41827610f2ef59fc2151a5775b33f15e6b2b5125c5"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "PauseFlags"
                 }
               ]

--- a/app/contract/contracts/quickex/test_snapshots/test/test_refund_successful.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_refund_successful.1.json
@@ -305,6 +305,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "68f1415c0fc83a6c7f36fbaf4b2fb88b9a5924a00b884b7ca38da734a8620b0e"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "68f1415c0fc83a6c7f36fbaf4b2fb88b9a5924a00b884b7ca38da734a8620b0e"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "a5eef92d40c8a36be61a4d41827610f2ef59fc2151a5775b33f15e6b2b5125c5"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_refund_unauthorized_fails.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_refund_unauthorized_fails.1.json
@@ -281,6 +281,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "9a30978d7130c4ad2fa8a334102d6dbfc40227f10a72bdcbdfafebd8ee191996"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "9a30978d7130c4ad2fa8a334102d6dbfc40227f10a72bdcbdfafebd8ee191996"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "391df8149cb7eecf32a865278031c3fa10c33a911b9be05f9f9b328bede24090"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_resolve_dispute_fails_for_non_arbiter.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_resolve_dispute_fails_for_non_arbiter.1.json
@@ -310,6 +310,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "6d8a9a06864592f4d7b791e720f4fa2564cd1364690e3539a46ab1ec3de77e98"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "6d8a9a06864592f4d7b791e720f4fa2564cd1364690e3539a46ab1ec3de77e98"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "7fd539bda900c889b68680a7ff9d36acb9bdfad11fe5339652744573d4a452ce"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_resolve_dispute_fails_on_non_disputed_status.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_resolve_dispute_fails_on_non_disputed_status.1.json
@@ -285,6 +285,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "921b4fddda908387db76b09a93a845b22313e7fa41b656d124ef82224715f48c"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "921b4fddda908387db76b09a93a845b22313e7fa41b656d124ef82224715f48c"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "d3b427a8c1e4175bfc2e923ebaeaa5830f8c9055a9723ff4a71a5583438562bc"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_resolve_dispute_for_owner.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_resolve_dispute_for_owner.1.json
@@ -314,6 +314,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "aa52515e0bafece72c19836b2422d57bf35dc49c13ecfff4a51c8aa1d7337df1"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "aa52515e0bafece72c19836b2422d57bf35dc49c13ecfff4a51c8aa1d7337df1"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "895b032136e10aa2ac6f2327966a45563d84d53384984affe273131b6aca5f94"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_resolve_dispute_for_recipient.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_resolve_dispute_for_recipient.1.json
@@ -337,6 +337,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "d1d9032c8862c24be1cabb21f21383287d4690cfbb7f76e6ae25e9d6e36924b7"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "d1d9032c8862c24be1cabb21f21383287d4690cfbb7f76e6ae25e9d6e36924b7"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "1d29c425d6c3e252022821c6c5708a812cef40ee214723730553445774598638"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/app/contract/contracts/quickex/test_snapshots/test/test_withdraw_fails_during_dispute.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/test/test_withdraw_fails_during_dispute.1.json
@@ -286,6 +286,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowIdMap"
+                },
+                {
+                  "bytes": "4f5c1e0a2499466c1999149dd524553ba61725812f4aab6c194e06079a793628"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowIdMap"
+                    },
+                    {
+                      "bytes": "4f5c1e0a2499466c1999149dd524553ba61725812f4aab6c194e06079a793628"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "0406acea6caac9f81c72a2c923d5eddd1c082a5b67415f9d0c7e7e3fc1ff1aee"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }


### PR DESCRIPTION
Closes #304 — Deterministic Escrow ID Derivation (Hash-Based).

## Summary

Derive a stable 32-byte `escrow_id` from a canonical hash of the full escrow creation payload (token, amount, owner, salt, timeout_secs, arbiter) with strong domain separation and unambiguous field boundaries. Identical re-submissions of `deposit` now return the existing commitment deterministically instead of creating a duplicate escrow.

## Design

`escrow_id = SHA-256(DOMAIN_TAG || LP(token_xdr) || BE128(amount) || LP(owner_xdr) || BE64(timeout) || arbiter_tag || [LP(arbiter_xdr)] || LP(salt))`

- `DOMAIN_TAG = "QUICKEX::ESCROW_ID::v1"` — prevents collisions with `commitment` and stealth-address hashes.
- `LP(x) = u32_BE(len(x)) || x` — length prefixes make every variable-width field unambiguous.
- Fixed-width fields (i128 amount, u64 timeout, 1-byte arbiter tag) need no prefix.
- Salt capped at 1024 bytes (matches existing commitment module) to guard against DoS.

## Changes

- `src/escrow_id.rs` — new module with `derive_escrow_id` + canonical serialization doc.
- `src/storage.rs` — new `DataKey::EscrowIdMap(BytesN<32>) -> BytesN<32>` plus `get_escrow_id_mapping` / `put_escrow_id_mapping` helpers.
- `src/escrow.rs` — `deposit` now derives the id, short-circuits to return the existing commitment on duplicate, otherwise records the mapping after a successful deposit.
- `src/lib.rs` — exposes `derive_escrow_id(...)` and `get_escrow_id_commitment(escrow_id)` as contract methods so off-chain clients can compute / query the id.
- `src/escrow_id_test.rs` — 16 new tests.

## Acceptance criteria

- Same inputs always yield the same `escrow_id` — `test_escrow_id_deterministic`, `test_escrow_id_stable_across_many_calls`.
- Different inputs yield different `escrow_id` with negligible collision risk — one test per input field: amount, token, owner, salt, timeout, arbiter presence, arbiter identity, plus a length-prefix boundary test.
- Duplicate creates return the existing escrow deterministically — `test_deposit_idempotent_on_identical_params` verifies no second token transfer and identical commitment returned; the `EscrowIdMap` is also observable on-chain via `get_escrow_id_commitment`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 148/148 tests passing (132 pre-existing + 16 new).
- [x] `cargo build --target wasm32-unknown-unknown --release` — WASM build clean.
- [ ] Manual review of canonical serialization + domain tag before merge.