### PR TITLE
feat/Implemented scoped API keys platform

### DIFF
--- a/app/backend/src/api-keys/api-key.guard.ts
+++ b/app/backend/src/api-keys/api-key.guard.ts
@@ -1,0 +1,51 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ApiKeysService } from '../api-keys.service';
+import { ApiKeyScope } from '../api-keys.types';
+import { API_KEY_SCOPES_KEY } from '../decorators/scopes.decorator';
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private apiKeysService: ApiKeysService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredScopes = this.reflector.getAllAndOverride<ApiKeyScope[]>(API_KEY_SCOPES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    const request = context.switchToHttp().getRequest();
+    const rawKey = request.headers['x-api-key'] || request.headers['authorization']?.replace('Bearer ', '');
+
+    if (!rawKey) {
+      throw new UnauthorizedException('API key is missing');
+    }
+
+    const result = await this.apiKeysService.validateKey(rawKey);
+    if (!result) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    const { record, hasScope } = result;
+
+    if (this.apiKeysService.isOverQuota(record)) {
+      throw new ForbiddenException('Monthly API usage quota exceeded');
+    }
+
+    if (requiredScopes && !requiredScopes.every((scope) => hasScope(scope))) {
+      throw new ForbiddenException('API key does not have the required scopes');
+    }
+
+    request.apiKey = record;
+    return true;
+  }
+}

--- a/app/backend/src/api-keys/api-keys.repository.ts
+++ b/app/backend/src/api-keys/api-keys.repository.ts
@@ -17,6 +17,7 @@ export class ApiKeysRepository {
     scopes: ApiKeyScope[];
     owner_id: string | null;
     monthly_quota: number;
+    quota_reset_at: string;
   }): Promise<ApiKeyRecord> {
     const { data: row, error } = await this.client
       .from('api_keys')
@@ -62,7 +63,7 @@ export class ApiKeysRepository {
     const { data, error } = await this.client
       .from('api_keys')
       .select('*')
-      .eq('key_prefix', prefix)
+      .or(`key_prefix.eq.${prefix},previous_key_prefix.eq.${prefix}`)
       .eq('is_active', true);
 
     if (error) throw error;
@@ -80,14 +81,18 @@ export class ApiKeysRepository {
 
   async updateKey(
     id: string,
-    data: { key_hash: string; key_prefix: string },
+    data: {
+      key_hash: string;
+      key_prefix: string;
+      previous_key_hash?: string | null;
+      previous_key_prefix?: string | null;
+      rotated_at?: string | null;
+    },
   ): Promise<ApiKeyRecord> {
     const { data: row, error } = await this.client
       .from('api_keys')
       .update({
         ...data,
-        request_count: 0,
-        last_used_at: null,
         updated_at: new Date().toISOString(),
       })
       .eq('id', id)
@@ -102,6 +107,18 @@ export class ApiKeysRepository {
     const { error } = await this.client.rpc('increment_api_key_usage', {
       key_id: id,
     });
+    if (error) throw error;
+  }
+
+  async resetQuota(id: string, nextReset: string): Promise<void> {
+    const { error } = await this.client
+      .from('api_keys')
+      .update({
+        request_count: 0,
+        quota_reset_at: nextReset,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id);
     if (error) throw error;
   }
 

--- a/app/backend/src/api-keys/api-keys.service.ts
+++ b/app/backend/src/api-keys/api-keys.service.ts
@@ -17,6 +17,7 @@ import {
 const BCRYPT_ROUNDS = 10;
 const DEFAULT_QUOTA = 10_000;
 const KEY_PREFIX_LENGTH = 8; // chars used for prefix display / lookup
+const ROTATION_GRACE_PERIOD_MS = 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class ApiKeysService {
@@ -40,6 +41,7 @@ export class ApiKeysService {
       scopes: dto.scopes,
       owner_id: dto.owner_id ?? null,
       monthly_quota: DEFAULT_QUOTA,
+      quota_reset_at: this.getNextQuotaReset(),
     });
 
     this.logger.log(`API key created: id=${record.id} name="${record.name}"`);
@@ -71,6 +73,9 @@ export class ApiKeysService {
     const updated = await this.repo.updateKey(id, {
       key_hash: hash,
       key_prefix: prefix,
+      previous_key_hash: record.key_hash,
+      previous_key_prefix: record.key_prefix,
+      rotated_at: new Date().toISOString(),
     });
 
     this.logger.log(`API key rotated: id=${id}`);
@@ -93,8 +98,25 @@ export class ApiKeysService {
     const candidates = await this.repo.findByPrefix(prefix);
 
     for (const record of candidates) {
-      const match = await bcrypt.compare(rawKey, record.key_hash);
-      if (match) {
+      let isMatch = false;
+
+      // 1. Check primary key
+      if (record.key_prefix === prefix) {
+        isMatch = await bcrypt.compare(rawKey, record.key_hash);
+      }
+
+      // 2. Check rotated key if within grace period
+      if (!isMatch && record.previous_key_prefix === prefix && record.rotated_at) {
+        const graceExpiry = new Date(record.rotated_at).getTime() + ROTATION_GRACE_PERIOD_MS;
+        if (Date.now() < graceExpiry && record.previous_key_hash) {
+          isMatch = await bcrypt.compare(rawKey, record.previous_key_hash);
+        }
+      }
+
+      if (isMatch) {
+        // Check for monthly quota reset
+        await this.handleQuotaReset(record);
+
         // Fire-and-forget usage increment — don't block the request
         this.repo
           .incrementUsage(record.id)
@@ -123,6 +145,24 @@ export class ApiKeysService {
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
+
+  private async handleQuotaReset(record: ApiKeyRecord): Promise<void> {
+    if (new Date() > new Date(record.quota_reset_at)) {
+      const nextReset = this.getNextQuotaReset();
+      await this.repo.resetQuota(record.id, nextReset).catch((err) =>
+        this.logger.warn(`Failed to reset quota for ${record.id}: ${err}`),
+      );
+      // Update local copy for immediate validation
+      record.request_count = 0;
+      record.quota_reset_at = nextReset;
+    }
+  }
+
+  private getNextQuotaReset(): string {
+    const d = new Date();
+    d.setMonth(d.getMonth() + 1);
+    return d.toISOString();
+  }
 
   private generateRawKey(): string {
     const bytes = crypto.randomBytes(24).toString('hex');

--- a/app/backend/src/api-keys/api-keys.types.ts
+++ b/app/backend/src/api-keys/api-keys.types.ts
@@ -18,6 +18,10 @@ export interface ApiKeyRecord {
   request_count: number;
   monthly_quota: number;
   last_used_at: string | null;
+  rotated_at: string | null;
+  previous_key_hash: string | null;
+  previous_key_prefix: string | null;
+  quota_reset_at: string;
   created_at: string;
   updated_at: string;
 }

--- a/app/backend/src/api-keys/scopes.decorator.ts
+++ b/app/backend/src/api-keys/scopes.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common';
+import { ApiKeyScope } from '../api-keys.types';
+
+export const API_KEY_SCOPES_KEY = 'api_key_scopes';
+
+/** Decorator to specify required scopes for an API endpoint. */
+export const Scopes = (...scopes: ApiKeyScope[]) => SetMetadata(API_KEY_SCOPES_KEY, scopes);


### PR DESCRIPTION
Closes #239

## 🔑 Feat: API Key Platform v2 — Scopes, Rotation & Usage Quotas

Implements scoped API keys with hashed storage, seamless rotation with a 24-hour grace period, monthly quota enforcement, and a guard for scope-based access control.

### Updated Files

**`api-keys.types.ts`**
- Extended `ApiKeyRecord` with `previous_key_hash`, `previous_key_prefix`, `rotated_at`, and `quota_reset_at` fields

**`api-keys.repository.ts`**
- `findByPrefix()` — queries both primary and previous key prefix for rotation support
- `updateKey()` — now persists rotation metadata (`previous_key_hash`, `previous_key_prefix`, `rotated_at`)
- `resetQuota()` — resets `request_count` and advances `quota_reset_at` to next month

**`api-keys.service.ts`**
- `rotate()` — stores current key as previous before issuing new key; enables zero-downtime rotation
- `validateKey()` — checks primary key first, then falls back to previous key if within 24-hour grace period (`ROTATION_GRACE_PERIOD_MS`); triggers monthly quota reset on first use in new period
- `handleQuotaReset()` — automatically advances quota window when month has elapsed
- `getNextQuotaReset()` — calculates next monthly reset date

### New Files

**`decorators/scopes.decorator.ts`**
- `@Scopes(...scopes)` decorator using `SetMetadata` to declare required API key scopes per endpoint

**`guards/api-key.guard.ts`**
- `ApiKeyGuard` — extracts key from `X-API-Key` or `Authorization: Bearer` header, validates it, checks quota, and enforces required scopes before allowing request through
- Returns `401` for missing/invalid keys, `403` for quota exceeded or insufficient scopes

### Acceptance Criteria
✅ Keys never stored in plaintext — bcrypt used for all comparisons
✅ Rotation supports 24-hour overlap with auditable `rotated_at` timestamp
✅ Monthly quotas enforced consistently across all guarded endpoints with automatic reset
✅ Scope enforcement via `ApiKeyGuard` + `@Scopes()` decorator