### PR TITLE
feat: add signature replay protection & nonce registry (#299)

### DIFF
--- a/app/contract/contracts/quickex/src/errors.rs
+++ b/app/contract/contracts/quickex/src/errors.rs
@@ -50,6 +50,11 @@ pub enum QuickexError {
     StealthAddressAlreadyUsed = 401,
     /// No stealth escrow found for the given stealth address.
     StealthEscrowNotFound = 402,
+    // Replay protection (500-599)
+    /// Nonce has already been consumed; signature replay detected.
+    NonceAlreadyUsed = 500,
+    /// Signed message has passed its expiry ledger timestamp.
+    SignatureExpired = 501,
     // Internal/unexpected conditions (900-999)
     InternalError = 900,
     InvalidTimeout = 901,

--- a/app/contract/contracts/quickex/src/lib.rs
+++ b/app/contract/contracts/quickex/src/lib.rs
@@ -16,6 +16,9 @@ mod events;
 mod fee;
 #[cfg(test)]
 mod fee_test;
+mod nonce;
+#[cfg(test)]
+mod nonce_registry_test;
 mod privacy;
 #[cfg(test)]
 mod role_test;
@@ -814,5 +817,45 @@ impl QuickexContract {
     /// Get all roles assigned to an account.
     pub fn get_roles(env: Env, account: Address) -> Vec<Role> {
         storage::get_roles(&env, &account)
+    }
+
+    // -----------------------------------------------------------------------
+    // Replay protection
+    // -----------------------------------------------------------------------
+
+    /// Verify and consume a one-time nonce for `signer`.
+    ///
+    /// Enforces:
+    /// 1. Expiry: if `expires_at > 0` and `now >= expires_at` → `SignatureExpired`.
+    /// 2. Uniqueness: if the (signer, nonce) pair was already consumed → `NonceAlreadyUsed`.
+    ///
+    /// On success the nonce is permanently recorded so it cannot be reused.
+    /// Callers should invoke this before executing any signature-gated operation.
+    ///
+    /// # Errors
+    /// * `SignatureExpired`   – payload has passed its expiry timestamp.
+    /// * `NonceAlreadyUsed`  – nonce was already consumed (replay detected).
+    pub fn verify_nonce(
+        env: Env,
+        signer: Address,
+        nonce: BytesN<32>,
+        expires_at: u64,
+    ) -> Result<(), QuickexError> {
+        nonce::verify_and_consume_nonce(&env, &signer, &nonce, expires_at)
+    }
+
+    /// Build the canonical domain-separated message hash for a signed payload.
+    ///
+    /// `SHA-256(contract_id || network_id || signer_xdr || nonce || BE(expires_at))`
+    ///
+    /// Clients should sign this hash off-chain and pass the nonce + expires_at
+    /// alongside the signature so the contract can verify and consume the nonce.
+    pub fn build_message_hash(
+        env: Env,
+        signer: Address,
+        nonce: BytesN<32>,
+        expires_at: u64,
+    ) -> BytesN<32> {
+        nonce::build_message_hash(&env, &signer, &nonce, expires_at)
     }
 }

--- a/app/contract/contracts/quickex/src/nonce.rs
+++ b/app/contract/contracts/quickex/src/nonce.rs
@@ -1,0 +1,90 @@
+//! Signature replay protection via a per-signer nonce registry.
+//!
+//! ## Domain separation
+//!
+//! Every signed payload must include:
+//! - The contract's own address (`env.current_contract_address()`).
+//! - The network passphrase hash (`env.ledger().network_id()`).
+//! - A unique nonce (`BytesN<32>`).
+//! - An expiry ledger timestamp (`expires_at`).
+//!
+//! The canonical signed message is:
+//! ```text
+//! SHA-256(contract_id || network_id || signer_xdr || nonce || BE(expires_at))
+//! ```
+//!
+//! ## Replay protection guarantees
+//!
+//! 1. **Nonce uniqueness** – once consumed, the (signer, nonce) pair is stored
+//!    permanently; any re-use returns [`QuickexError::NonceAlreadyUsed`].
+//! 2. **Expiry enforcement** – if `expires_at > 0` and the current ledger
+//!    timestamp is ≥ `expires_at`, the call returns [`QuickexError::SignatureExpired`].
+//! 3. **Domain binding** – the message digest binds the contract address and
+//!    network passphrase, so a signature valid on testnet cannot be replayed on
+//!    mainnet, and a signature for contract A cannot be used against contract B.
+
+use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env};
+
+use crate::{
+    errors::QuickexError,
+    storage::{consume_nonce, nonce_used},
+};
+
+/// Build the canonical domain-separated message digest for a signed payload.
+///
+/// `SHA-256(contract_id || network_id || signer_xdr || nonce || BE(expires_at))`
+pub fn build_message_hash(
+    env: &Env,
+    signer: &Address,
+    nonce: &BytesN<32>,
+    expires_at: u64,
+) -> BytesN<32> {
+    let mut msg = Bytes::new(env);
+    // Domain: contract address
+    msg.append(&env.current_contract_address().to_xdr(env));
+    // Domain: network passphrase hash (BytesN<32> → Bytes)
+    msg.append(&Bytes::from(env.ledger().network_id()));
+    // Signer identity
+    msg.append(&signer.to_xdr(env));
+    // Nonce
+    msg.append(&Bytes::from(nonce.clone()));
+    // Expiry (big-endian u64)
+    msg.append(&Bytes::from_array(env, &expires_at.to_be_bytes()));
+    env.crypto().sha256(&msg).into()
+}
+
+/// Verify replay protection for a signed operation and, if valid, consume the nonce.
+///
+/// Checks (in order):
+/// 1. Expiry: if `expires_at > 0` and `now >= expires_at` → [`SignatureExpired`].
+/// 2. Nonce uniqueness: if already consumed → [`NonceAlreadyUsed`].
+/// 3. Marks the nonce as consumed.
+///
+/// The caller is responsible for verifying the cryptographic signature itself
+/// (via `env.crypto().ed25519_verify` or `require_auth`). This function only
+/// enforces the replay-protection invariants.
+///
+/// # Arguments
+/// - `signer`     – address whose nonce registry is checked.
+/// - `nonce`      – 32-byte unique value chosen by the signer.
+/// - `expires_at` – ledger timestamp after which the payload is invalid; `0` = no expiry.
+pub fn verify_and_consume_nonce(
+    env: &Env,
+    signer: &Address,
+    nonce: &BytesN<32>,
+    expires_at: u64,
+) -> Result<(), QuickexError> {
+    // 1. Expiry check
+    if expires_at > 0 && env.ledger().timestamp() >= expires_at {
+        return Err(QuickexError::SignatureExpired);
+    }
+
+    // 2. Replay check
+    if nonce_used(env, signer, nonce) {
+        return Err(QuickexError::NonceAlreadyUsed);
+    }
+
+    // 3. Consume
+    consume_nonce(env, signer, nonce);
+    Ok(())
+}

--- a/app/contract/contracts/quickex/src/nonce_registry_test.rs
+++ b/app/contract/contracts/quickex/src/nonce_registry_test.rs
@@ -1,0 +1,159 @@
+//! Tests for signature replay protection and nonce registry (#299).
+//!
+//! Covers:
+//! - Replay attempt: same nonce rejected on second call.
+//! - Expired signature: nonce rejected when `expires_at` is in the past.
+//! - Valid nonce: accepted and consumed exactly once.
+//! - Domain separation: same nonce for different signers is independent.
+//! - No-expiry: `expires_at == 0` is never considered expired.
+//! - Message hash: deterministic and domain-bound.
+
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, BytesN, Env,
+    };
+
+    use crate::{errors::QuickexError, QuickexContract, QuickexContractClient};
+
+    fn setup<'a>() -> (Env, QuickexContractClient<'a>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(QuickexContract, ());
+        let client = QuickexContractClient::new(&env, &id);
+        let signer = Address::generate(&env);
+        (env, client, signer)
+    }
+
+    fn nonce(env: &Env, seed: u8) -> BytesN<32> {
+        BytesN::from_array(env, &[seed; 32])
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn valid_nonce_accepted() {
+        let (env, client, signer) = setup();
+        env.ledger().set_timestamp(1000);
+        let n = nonce(&env, 1);
+        // expires_at in the future
+        client.verify_nonce(&signer, &n, &2000).unwrap();
+    }
+
+    #[test]
+    fn no_expiry_always_valid() {
+        let (env, client, signer) = setup();
+        env.ledger().set_timestamp(u64::MAX - 1);
+        let n = nonce(&env, 2);
+        // expires_at == 0 → never expires
+        client.verify_nonce(&signer, &n, &0).unwrap();
+    }
+
+    // -----------------------------------------------------------------------
+    // Replay protection
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn replay_rejected() {
+        let (env, client, signer) = setup();
+        env.ledger().set_timestamp(1000);
+        let n = nonce(&env, 3);
+        client.verify_nonce(&signer, &n, &0).unwrap();
+        let err = client.try_verify_nonce(&signer, &n, &0).unwrap_err();
+        assert_eq!(
+            err.unwrap(),
+            QuickexError::NonceAlreadyUsed,
+            "second call must fail with NonceAlreadyUsed"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Expiry enforcement
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn expired_signature_rejected() {
+        let (env, client, signer) = setup();
+        env.ledger().set_timestamp(5000);
+        let n = nonce(&env, 4);
+        // expires_at is in the past
+        let err = client.try_verify_nonce(&signer, &n, &4999).unwrap_err();
+        assert_eq!(
+            err.unwrap(),
+            QuickexError::SignatureExpired,
+            "past expires_at must fail with SignatureExpired"
+        );
+    }
+
+    #[test]
+    fn expires_at_equal_to_now_rejected() {
+        let (env, client, signer) = setup();
+        env.ledger().set_timestamp(3000);
+        let n = nonce(&env, 5);
+        // expires_at == now is also expired (>=)
+        let err = client.try_verify_nonce(&signer, &n, &3000).unwrap_err();
+        assert_eq!(err.unwrap(), QuickexError::SignatureExpired);
+    }
+
+    // -----------------------------------------------------------------------
+    // Domain separation: different signers, same nonce
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn same_nonce_different_signers_are_independent() {
+        let (env, client, alice) = setup();
+        let bob = Address::generate(&env);
+        env.ledger().set_timestamp(1000);
+        let n = nonce(&env, 6);
+        // Alice consumes nonce 6
+        client.verify_nonce(&alice, &n, &0).unwrap();
+        // Bob can still use the same nonce bytes — different signer namespace
+        client.verify_nonce(&bob, &n, &0).unwrap();
+        // But Alice cannot reuse it
+        let err = client.try_verify_nonce(&alice, &n, &0).unwrap_err();
+        assert_eq!(err.unwrap(), QuickexError::NonceAlreadyUsed);
+    }
+
+    // -----------------------------------------------------------------------
+    // Message hash: deterministic and domain-bound
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn message_hash_is_deterministic() {
+        let (env, client, signer) = setup();
+        let n = nonce(&env, 7);
+        let h1 = client.build_message_hash(&signer, &n, &9999);
+        let h2 = client.build_message_hash(&signer, &n, &9999);
+        assert_eq!(h1, h2, "same inputs must produce the same hash");
+    }
+
+    #[test]
+    fn message_hash_differs_by_nonce() {
+        let (env, client, signer) = setup();
+        let h1 = client.build_message_hash(&signer, &nonce(&env, 8), &0);
+        let h2 = client.build_message_hash(&signer, &nonce(&env, 9), &0);
+        assert_ne!(h1, h2, "different nonces must produce different hashes");
+    }
+
+    #[test]
+    fn message_hash_differs_by_signer() {
+        let (env, client, alice) = setup();
+        let bob = Address::generate(&env);
+        let n = nonce(&env, 10);
+        let h1 = client.build_message_hash(&alice, &n, &0);
+        let h2 = client.build_message_hash(&bob, &n, &0);
+        assert_ne!(h1, h2, "different signers must produce different hashes");
+    }
+
+    #[test]
+    fn message_hash_differs_by_expiry() {
+        let (env, client, signer) = setup();
+        let n = nonce(&env, 11);
+        let h1 = client.build_message_hash(&signer, &n, &1000);
+        let h2 = client.build_message_hash(&signer, &n, &2000);
+        assert_ne!(h1, h2, "different expires_at must produce different hashes");
+    }
+}

--- a/app/contract/contracts/quickex/src/storage.rs
+++ b/app/contract/contracts/quickex/src/storage.rs
@@ -111,6 +111,9 @@ pub enum DataKey {
     EscrowIdMap(BytesN<32>),
     /// Roles assigned to an address.
     UserRole(Address),
+    /// Nonce registry entry keyed by (signer, nonce_bytes).
+    /// Value is the ledger timestamp at which the nonce was consumed.
+    Nonce(Address, BytesN<32>),
 }
 
 // -----------------------------------------------------------------------------
@@ -348,6 +351,27 @@ pub fn get_escrow_id_mapping(env: &Env, escrow_id: &BytesN<32>) -> Option<BytesN
 pub fn put_escrow_id_mapping(env: &Env, escrow_id: &BytesN<32>, commitment: &BytesN<32>) {
     let key = DataKey::EscrowIdMap(escrow_id.clone());
     env.storage().persistent().set(&key, commitment);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_THRESHOLD, SIX_MONTHS_IN_LEDGERS);
+}
+
+// -----------------------------------------------------------------------------
+// Nonce registry helpers
+// -----------------------------------------------------------------------------
+
+/// Returns `true` if the (signer, nonce) pair has already been consumed.
+pub fn nonce_used(env: &Env, signer: &Address, nonce: &BytesN<32>) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::Nonce(signer.clone(), nonce.clone()))
+}
+
+/// Mark a (signer, nonce) pair as consumed, recording the current ledger timestamp.
+pub fn consume_nonce(env: &Env, signer: &Address, nonce: &BytesN<32>) {
+    let key = DataKey::Nonce(signer.clone(), nonce.clone());
+    let now = env.ledger().timestamp();
+    env.storage().persistent().set(&key, &now);
     env.storage()
         .persistent()
         .extend_ttl(&key, LEDGER_THRESHOLD, SIX_MONTHS_IN_LEDGERS);


### PR DESCRIPTION
- Add DataKey::Nonce(Address, BytesN<32>) per-signer nonce registry
- Add nonce_used() and consume_nonce() storage helpers
- Add nonce.rs with verify_and_consume_nonce() and build_message_hash()
- Domain separation: SHA-256(contract_id || network_id || signer || nonce || expires_at)
- Add NonceAlreadyUsed=500 and SignatureExpired=501 error codes
- Expose verify_nonce() and build_message_hash() as public contract entry points
- Add nonce_registry_test.rs with 10 tests (replay, expiry, domain separation)


closes #299 