### PR TITLE
Implement multi-payment escrow support

### DIFF
--- a/app/contract/contracts/quickex/src/batch.rs
+++ b/app/contract/contracts/quickex/src/batch.rs
@@ -35,7 +35,6 @@ pub struct BatchItemResult {
 pub struct BatchCreateItem {
     pub escrow_id: soroban_sdk::Bytes,
     pub owner: Address,
-    pub recipient: Address,
     pub token: Address,
     pub amount: i128,
     /// Unix timestamp; 0 means no expiry.
@@ -74,13 +73,13 @@ pub fn batch_create(
 
         let entry = EscrowEntry {
             owner: item.owner.clone(),
-            recipient: item.recipient.clone(),
             token: item.token.clone(),
-            amount: item.amount,
+            amount_due: item.amount,
+            amount_paid: item.amount,
             status: EscrowStatus::Pending,
+            created_at: env.ledger().timestamp(),
             expires_at: item.expires_at,
             arbiter: None,
-            commitment: None,
         };
 
         store_escrow(env, &item.escrow_id, &entry);

--- a/app/contract/contracts/quickex/src/bench_test.rs
+++ b/app/contract/contracts/quickex/src/bench_test.rs
@@ -55,7 +55,8 @@ fn seed_escrow(
 ) {
     let entry = EscrowEntry {
         token: token.clone(),
-        amount,
+        amount_due: amount,
+        amount_paid: amount,
         owner: owner.clone(),
         status: EscrowStatus::Pending,
         created_at: env.ledger().timestamp(),

--- a/app/contract/contracts/quickex/src/errors.rs
+++ b/app/contract/contracts/quickex/src/errors.rs
@@ -43,6 +43,8 @@ pub enum QuickexError {
     OperationPaused = 313,
     /// The stored contract version cannot be migrated by this release.
     InvalidContractVersion = 314,
+    /// Payment amount exceeds the remaining amount due for the escrow.
+    Overpayment = 315,
     // Stealth address errors (400-499)
     /// Derived stealth address does not match the provided one.
     StealthAddressMismatch = 400,

--- a/app/contract/contracts/quickex/src/escrow.rs
+++ b/app/contract/contracts/quickex/src/escrow.rs
@@ -129,9 +129,10 @@ fn compute_expires_at(env: &Env, timeout_secs: u64) -> Result<u64, QuickexError>
 // deposit
 // ---------------------------------------------------------------------------
 
-/// Deposit funds and create an escrow entry keyed by `SHA256(owner || amount || salt)`.
+/// Deposit funds and create an escrow entry keyed by `SHA256(owner || amount_due || salt)`.
 ///
 /// - Transfers `amount` from `owner` to the contract.
+/// - Sets `amount_due` to the target amount and `amount_paid` to the initial payment.
 /// - Sets status to `Pending`.
 /// - If `timeout_secs > 0`, the escrow expires `timeout_secs` seconds after creation.
 ///   Pass `0` for a non-expiring escrow.
@@ -171,26 +172,6 @@ pub fn deposit(
         commitment::amount_commitment_hashes(env, &owner, amount, &salt)?;
     let now = env.ledger().timestamp();
 
-    // let expires_at = if timeout_secs > 0 {
-    //     now.saturating_add(timeout_secs)
-    // } else {
-    //     0
-    // };
-
-    // non-optimized: token.clone() into entry + token used again for client
-    // let entry = EscrowEntry {
-    //     token: token.clone(),
-    //     amount,
-    //     owner: owner.clone(),
-    //     status: EscrowStatus::Pending,
-    //     created_at: now,
-    //     expires_at,
-    // };
-    // put_escrow(env, &commitment.clone().into(), &entry);
-    // let token_client = token::Client::new(env, &token);
-    // token_client.transfer(&owner, env.current_contract_address(), &amount);
-    // events::publish_deposit(env, commitment.clone(), token, amount);
-
     // optimized: build client first (borrows token), then move token into entry
     // commitment converted to Bytes once, reused
     let token_client = token::Client::new(env, &token);
@@ -206,7 +187,8 @@ pub fn deposit(
     }
     let entry = EscrowEntry {
         token, // moved
-        amount,
+        amount_due: amount,
+        amount_paid: amount, // Initial payment is the full amount
         owner: owner.clone(),
         status: EscrowStatus::Pending,
         created_at: now,
@@ -223,6 +205,7 @@ pub fn deposit(
         commitment.clone(),
         owner,
         token_client.address,
+        amount,
         amount,
         expires_at,
     );
@@ -262,23 +245,6 @@ pub fn deposit_with_commitment(
     // INV-3: validated, overflow-safe expiry computation
     let expires_at = compute_expires_at(env, timeout_secs)?;
 
-    // non-optimized: .clone().into() done twice, from.clone() + token.clone() unnecessarily
-    // if has_escrow(env, &commitment.clone().into()) {
-    //     return Err(QuickexError::CommitmentAlreadyExists);
-    // }
-    // let token_client = token::Client::new(env, &token);
-    // token_client.transfer(&from, env.current_contract_address(), &amount);
-    // let entry = EscrowEntry {
-    //     token: token.clone(),
-    //     amount,
-    //     owner: from.clone(),
-    //     status: EscrowStatus::Pending,
-    //     created_at: now,
-    //     expires_at,
-    // };
-    // put_escrow(env, &commitment.clone().into(), &entry);
-    // events::publish_deposit(env, commitment, token, amount);
-
     // optimized: convert commitment once, move args into entry
     let commitment_bytes: Bytes = commitment.clone().into();
     if has_escrow(env, &commitment_bytes) {
@@ -293,8 +259,9 @@ pub fn deposit_with_commitment(
     let from_ref = from.clone();
     let entry = EscrowEntry {
         token, // moved
-        amount,
-        owner: from, // moved
+        amount_due: amount,
+        amount_paid: amount, // Initial payment is the full amount
+        owner: from,         // moved
         status: EscrowStatus::Pending,
         created_at: now,
         expires_at,
@@ -308,8 +275,163 @@ pub fn deposit_with_commitment(
         from_ref,
         token_client.address,
         amount,
+        amount,
         expires_at,
     );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// deposit_partial
+// ---------------------------------------------------------------------------
+
+/// Deposit funds and create an escrow entry with a target amount higher than the initial payment.
+///
+/// - Transfers `initial_payment` from `owner` to the contract.
+/// - Sets `amount_due` to the target amount and `amount_paid` to the initial payment.
+/// - Sets status to `Pending`.
+/// - If `timeout_secs > 0`, the escrow expires `timeout_secs` seconds after creation.
+///   Pass `0` for a non-expiring escrow.
+/// - Optionally sets an `arbiter` who can resolve disputes.
+///
+/// # Errors
+/// - [`InvalidAmount`] – initial_payment ≤ 0 or amount_due ≤ 0.
+/// - [`InvalidSalt`] – salt > 1024 bytes.
+#[allow(clippy::too_many_arguments)]
+pub fn deposit_partial(
+    env: &Env,
+    token: Address,
+    amount_due: i128,
+    initial_payment: i128,
+    owner: Address,
+    salt: Bytes,
+    timeout_secs: u64,
+    arbiter: Option<Address>,
+) -> Result<BytesN<32>, QuickexError> {
+    if initial_payment <= 0 {
+        return Err(QuickexError::InvalidAmount);
+    }
+    if amount_due <= 0 {
+        return Err(QuickexError::InvalidAmount);
+    }
+
+    owner.require_auth();
+
+    // INV-3: validated, overflow-safe expiry computation
+    let expires_at = compute_expires_at(env, timeout_secs)?;
+
+    let commitment = commitment::create_amount_commitment(env, owner.clone(), amount_due, salt)?;
+    let now = env.ledger().timestamp();
+
+    let token_client = token::Client::new(env, &token);
+    let commitment_bytes: Bytes = commitment.clone().into();
+    let entry = EscrowEntry {
+        token, // moved
+        amount_due,
+        amount_paid: initial_payment,
+        owner: owner.clone(),
+        status: EscrowStatus::Pending,
+        created_at: now,
+        expires_at,
+        arbiter,
+    };
+
+    put_escrow(env, &commitment_bytes, &entry);
+    token_client.transfer(&owner, env.current_contract_address(), &initial_payment);
+
+    events::publish_escrow_deposited(
+        env,
+        commitment.clone(),
+        owner,
+        token_client.address,
+        amount_due,
+        initial_payment,
+        expires_at,
+    );
+
+    Ok(commitment)
+}
+
+// ---------------------------------------------------------------------------
+// partial_payment
+// ---------------------------------------------------------------------------
+
+/// Make a partial payment towards an existing escrow.
+///
+/// - Transfers `payment_amount` from `payer` to the contract.
+/// - Increments `amount_paid` by the payment amount.
+/// - Rejects overpayment (payment_amount > remaining amount due).
+/// - Emits a `PartialPayment` event.
+/// - If payment completes the escrow (amount_paid == amount_due), emits `EscrowFinalized`.
+///
+/// # Errors
+/// - [`InvalidAmount`] – payment_amount ≤ 0.
+/// - [`CommitmentNotFound`] – no escrow for the given commitment.
+/// - [`AlreadySpent`] – escrow already in a terminal state.
+/// - [`Overpayment`] – payment_amount exceeds the remaining amount due.
+pub fn partial_payment(
+    env: &Env,
+    commitment: BytesN<32>,
+    payer: Address,
+    payment_amount: i128,
+) -> Result<(), QuickexError> {
+    if payment_amount <= 0 {
+        return Err(QuickexError::InvalidAmount);
+    }
+
+    payer.require_auth();
+
+    let commitment_bytes: Bytes = commitment.clone().into();
+    let mut entry: EscrowEntry =
+        get_escrow(env, &commitment_bytes).ok_or(QuickexError::CommitmentNotFound)?;
+
+    // INV-5: terminal states are final
+    if entry.status != EscrowStatus::Pending {
+        return Err(QuickexError::AlreadySpent);
+    }
+
+    // Calculate remaining amount due
+    let remaining = entry.amount_due.saturating_sub(entry.amount_paid);
+
+    // Reject overpayment
+    if payment_amount > remaining {
+        return Err(QuickexError::Overpayment);
+    }
+
+    // Transfer payment to contract
+    let token_client = token::Client::new(env, &entry.token);
+    token_client.transfer(&payer, env.current_contract_address(), &payment_amount);
+
+    // Update amount_paid
+    entry.amount_paid = entry.amount_paid.saturating_add(payment_amount);
+
+    // Check if escrow is now fully paid
+    let is_fully_paid = entry.amount_paid >= entry.amount_due;
+
+    put_escrow(env, &commitment_bytes, &entry);
+
+    // Emit partial payment event
+    events::publish_partial_payment(
+        env,
+        commitment.clone(),
+        payer.clone(),
+        entry.token.clone(),
+        payment_amount,
+        entry.amount_paid,
+        entry.amount_due,
+    );
+
+    // If fully paid, emit finalization event
+    if is_fully_paid {
+        events::publish_escrow_finalized(
+            env,
+            commitment,
+            entry.owner,
+            entry.token,
+            entry.amount_paid,
+        );
+    }
 
     Ok(())
 }
@@ -321,18 +443,20 @@ pub fn deposit_with_commitment(
 /// Withdraw escrowed funds by proving commitment ownership.
 ///
 /// The caller (`to`) must authorize. The commitment is recomputed from
-/// `to`, `amount`, and `salt` and must match an existing pending escrow.
+/// `to`, `amount_due`, and `salt` and must match an existing pending escrow.
+/// The escrow must be fully paid (amount_paid >= amount_due).
 ///
 /// # Time-lock enforcement
 /// Enforces INV-1: if `expires_at > 0` and ledger timestamp >= `expires_at`,
 /// this function MUST fail. There is no admin override or bypass.
 ///
 /// # Errors
-/// - [`InvalidAmount`] – amount ≤ 0.
+/// - [`InvalidAmount`] – amount_due ≤ 0.
 /// - [`CommitmentNotFound`] – no escrow for computed commitment.
 /// - [`EscrowExpired`] – escrow has passed its expiry.
 /// - [`AlreadySpent`] – escrow already spent or refunded.
-/// - [`InvalidCommitment`] – stored amount ≠ requested amount.
+/// - [`InvalidCommitment`] – stored amount_due ≠ requested amount_due.
+/// - [`Overpayment`] – escrow is not fully paid yet.
 pub fn withdraw(env: &Env, amount: i128, to: Address, salt: Bytes) -> Result<bool, QuickexError> {
     if amount <= 0 {
         return Err(QuickexError::InvalidAmount);
@@ -368,26 +492,25 @@ pub fn withdraw(env: &Env, amount: i128, to: Address, salt: Bytes) -> Result<boo
         return Err(QuickexError::EscrowExpired);
     }
 
-    if entry.amount != amount {
+    if entry.amount_due != amount {
         return Err(QuickexError::InvalidCommitment);
     }
 
-    // non-optimized: full EscrowEntry clone
-    // let mut updated = entry.clone();
-    // updated.status = EscrowStatus::Spent;
-    // put_escrow(env, &commitment_bytes, &updated);
-    // let token_client = token::Client::new(env, &entry.token);
-    // token_client.transfer(&env.current_contract_address(), &to, &amount);
-    // events::publish_withdraw_toggled(env, to, commitment);
+    // Check if escrow is fully paid
+    if entry.amount_paid < entry.amount_due {
+        return Err(QuickexError::Overpayment);
+    }
 
     // optimized: destructure what we need, move entry instead of cloning
     let token_ref = entry.token.clone();
+    let amount_paid = entry.amount_paid;
+
     let mut updated = entry;
     updated.status = EscrowStatus::Spent;
     put_escrow(env, &commitment_bytes, &updated);
 
-    let fee_amount = fee::calculate_fee(env, amount);
-    let payout_amount = amount.saturating_sub(fee_amount);
+    let fee_amount = fee::calculate_fee(env, amount_paid);
+    let payout_amount = amount_paid.saturating_sub(fee_amount);
 
     let token_client = token::Client::new(env, &token_ref);
     token_client.transfer(&env.current_contract_address(), &to, &payout_amount);
@@ -402,7 +525,7 @@ pub fn withdraw(env: &Env, amount: i128, to: Address, salt: Bytes) -> Result<boo
         }
     }
 
-    events::publish_escrow_withdrawn(env, commitment, to, token_ref, amount, fee_amount);
+    events::publish_escrow_withdrawn(env, commitment, to, token_ref, amount_paid, fee_amount);
 
     Ok(true)
 }
@@ -453,14 +576,18 @@ pub fn refund(env: &Env, commitment: BytesN<32>, caller: Address) -> Result<(), 
         return Err(QuickexError::InvalidOwner);
     }
 
-    let mut updated = entry.clone();
+    let token_ref = entry.token.clone();
+    let owner_ref = entry.owner.clone();
+    let amount_paid = entry.amount_paid;
+
+    let mut updated = entry;
     updated.status = EscrowStatus::Refunded;
     put_escrow(env, &commitment_bytes, &updated);
 
-    let token_client = token::Client::new(env, &entry.token);
-    token_client.transfer(&env.current_contract_address(), &entry.owner, &entry.amount);
+    let token_client = token::Client::new(env, &token_ref);
+    token_client.transfer(&env.current_contract_address(), &owner_ref, &amount_paid);
 
-    events::publish_escrow_refunded(env, entry.owner, commitment, entry.token, entry.amount);
+    events::publish_escrow_refunded(env, owner_ref, commitment, token_ref, amount_paid);
 
     Ok(())
 }
@@ -603,10 +730,10 @@ pub fn resolve_dispute(
     put_escrow(env, &commitment_bytes, &updated);
 
     let (payout_amount, fee_amount) = if final_status == EscrowStatus::Spent {
-        let fee = fee::calculate_fee(env, entry.amount);
-        (entry.amount.saturating_sub(fee), fee)
+        let fee = fee::calculate_fee(env, entry.amount_paid);
+        (entry.amount_paid.saturating_sub(fee), fee)
     } else {
-        (entry.amount, 0)
+        (entry.amount_paid, 0)
     };
 
     let token_client = token::Client::new(env, &entry.token);
@@ -627,14 +754,20 @@ pub fn resolve_dispute(
     }
 
     if resolve_for_owner {
-        events::publish_escrow_refunded(env, entry.owner, commitment, entry.token, entry.amount);
+        events::publish_escrow_refunded(
+            env,
+            entry.owner,
+            commitment,
+            entry.token,
+            entry.amount_paid,
+        );
     } else {
         events::publish_escrow_withdrawn(
             env,
             commitment,
             recipient_address,
             entry.token,
-            entry.amount,
+            entry.amount_paid,
             fee_amount,
         );
     }

--- a/app/contract/contracts/quickex/src/events.rs
+++ b/app/contract/contracts/quickex/src/events.rs
@@ -35,7 +35,8 @@ pub struct EscrowDepositedEvent {
     pub owner: Address,
 
     pub token: Address,
-    pub amount: i128,
+    pub amount_due: i128,
+    pub amount_paid: i128,
     pub expires_at: u64,
     pub timestamp: u64,
 }
@@ -164,14 +165,16 @@ pub(crate) fn publish_escrow_deposited(
     commitment: BytesN<32>,
     owner: Address,
     token: Address,
-    amount: i128,
+    amount_due: i128,
+    amount_paid: i128,
     expires_at: u64,
 ) {
     EscrowDepositedEvent {
         escrow_id: commitment,
         owner,
         token,
-        amount,
+        amount_due,
+        amount_paid,
         expires_at,
         timestamp: env.ledger().timestamp(),
     }
@@ -189,6 +192,36 @@ pub struct EscrowRefundedEvent {
 
     pub token: Address,
     pub amount: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent(topics = ["TOPIC_ESCROW", "PartialPayment"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PartialPaymentEvent {
+    #[topic]
+    pub escrow_id: BytesN<32>,
+
+    #[topic]
+    pub payer: Address,
+
+    pub token: Address,
+    pub payment_amount: i128,
+    pub amount_paid: i128,
+    pub amount_due: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent(topics = ["TOPIC_ESCROW", "EscrowFinalized"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowFinalizedEvent {
+    #[topic]
+    pub escrow_id: BytesN<32>,
+
+    #[topic]
+    pub owner: Address,
+
+    pub token: Address,
+    pub total_amount: i128,
     pub timestamp: u64,
 }
 
@@ -230,6 +263,44 @@ pub(crate) fn publish_escrow_refunded(
     .publish(env);
 }
 
+pub(crate) fn publish_partial_payment(
+    env: &Env,
+    commitment: BytesN<32>,
+    payer: Address,
+    token: Address,
+    payment_amount: i128,
+    amount_paid: i128,
+    amount_due: i128,
+) {
+    PartialPaymentEvent {
+        escrow_id: commitment,
+        payer,
+        token,
+        payment_amount,
+        amount_paid,
+        amount_due,
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+pub(crate) fn publish_escrow_finalized(
+    env: &Env,
+    commitment: BytesN<32>,
+    owner: Address,
+    token: Address,
+    total_amount: i128,
+) {
+    EscrowFinalizedEvent {
+        escrow_id: commitment,
+        owner,
+        token,
+        total_amount,
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
 // ---------------------------------------------------------------------------
 // Stealth address events (Privacy v2 – Issue #157)
 // ---------------------------------------------------------------------------
@@ -246,7 +317,8 @@ pub struct EphemeralKeyRegisteredEvent {
     pub eph_pub: BytesN<32>,
 
     pub token: Address,
-    pub amount: i128,
+    pub amount_due: i128,
+    pub amount_paid: i128,
     pub expires_at: u64,
     pub timestamp: u64,
 }
@@ -256,14 +328,16 @@ pub(crate) fn publish_ephemeral_key_registered(
     stealth_address: BytesN<32>,
     eph_pub: BytesN<32>,
     token: Address,
-    amount: i128,
+    amount_due: i128,
+    amount_paid: i128,
     expires_at: u64,
 ) {
     EphemeralKeyRegisteredEvent {
         stealth_address,
         eph_pub,
         token,
-        amount,
+        amount_due,
+        amount_paid,
         expires_at,
         timestamp: env.ledger().timestamp(),
     }

--- a/app/contract/contracts/quickex/src/lib.rs
+++ b/app/contract/contracts/quickex/src/lib.rs
@@ -67,6 +67,7 @@ use types::{
 pub struct QuickexContract;
 
 #[contractimpl]
+#[allow(clippy::too_many_arguments)]
 impl QuickexContract {
     /// Withdraw escrowed funds by proving commitment ownership.
     ///
@@ -344,6 +345,88 @@ impl QuickexContract {
         )
     }
 
+    /// Deposit funds with a target amount higher than the initial payment.
+    ///
+    /// Transfers `initial_payment` from `owner` to the contract and stores an escrow
+    /// with `amount_due` set to the target amount. This enables multi-payment escrows
+    /// where the full amount can be paid over time via `partial_payment`.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `token` - Token contract address
+    /// * `amount_due` - Target amount to be paid
+    /// * `initial_payment` - Initial payment amount
+    /// * `owner` - Owner of the funds (must authorize)
+    /// * `salt` - Random salt (0–1024 bytes) for uniqueness
+    /// * `timeout_secs` - Seconds from now until the escrow expires (0 = no expiry)
+    /// * `arbiter` - Optional arbiter address who can resolve disputes
+    ///
+    /// # Errors
+    /// * `InvalidAmount` - initial_payment ≤ 0 or amount_due ≤ 0
+    /// * `InvalidSalt` - Salt length exceeds 1024 bytes
+    /// * `ContractPaused` - Contract is currently paused
+    #[allow(clippy::too_many_arguments)]
+    pub fn deposit_partial(
+        env: Env,
+        token: Address,
+        amount_due: i128,
+        initial_payment: i128,
+        owner: Address,
+        salt: Bytes,
+        timeout_secs: u64,
+        arbiter: Option<Address>,
+    ) -> Result<BytesN<32>, QuickexError> {
+        if admin::is_paused(&env) {
+            return Err(QuickexError::ContractPaused);
+        }
+        if is_feature_paused(&env, PauseFlag::Deposit) {
+            return Err(QuickexError::OperationPaused);
+        }
+        escrow::deposit_partial(
+            &env,
+            token,
+            amount_due,
+            initial_payment,
+            owner,
+            salt,
+            timeout_secs,
+            arbiter,
+        )
+    }
+
+    /// Make a partial payment towards an existing escrow.
+    ///
+    /// Transfers `payment_amount` from `payer` to the contract and increments the
+    /// escrow's `amount_paid` field. Rejects overpayment. Emits a `PartialPayment` event.
+    /// If the payment completes the escrow, emits an `EscrowFinalized` event.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `commitment` - 32-byte commitment hash identifying the escrow
+    /// * `payer` - Address making the payment (must authorize)
+    /// * `payment_amount` - Amount to pay; must be positive and not exceed remaining balance
+    ///
+    /// # Errors
+    /// * `InvalidAmount` - Payment amount is zero or negative
+    /// * `ContractPaused` - Contract is currently paused
+    /// * `CommitmentNotFound` - No escrow exists for the commitment
+    /// * `AlreadySpent` - Escrow is already in a terminal state
+    /// * `Overpayment` - Payment amount exceeds the remaining amount due
+    pub fn partial_payment(
+        env: Env,
+        commitment: BytesN<32>,
+        payer: Address,
+        payment_amount: i128,
+    ) -> Result<(), QuickexError> {
+        if admin::is_paused(&env) {
+            return Err(QuickexError::ContractPaused);
+        }
+        if is_feature_paused(&env, PauseFlag::Deposit) {
+            return Err(QuickexError::OperationPaused);
+        }
+        escrow::partial_payment(&env, commitment, payer, payment_amount)
+    }
+
     /// Refund an expired escrow back to its original owner.
     ///
     /// Can only be called after `expires_at` is reached. The caller must be the
@@ -615,7 +698,7 @@ impl QuickexContract {
                 if e.expires_at > 0 && env.ledger().timestamp() >= e.expires_at {
                     return false;
                 }
-                e.amount == amount
+                e.amount_due == amount
             }
             None => false,
         }
@@ -654,7 +737,8 @@ impl QuickexContract {
         if show_sensitive {
             Some(PrivacyAwareEscrowView {
                 token: entry.token,
-                amount: Some(entry.amount),
+                amount_due: Some(entry.amount_due),
+                amount_paid: Some(entry.amount_paid),
                 owner: Some(entry.owner),
                 status: entry.status,
                 created_at: entry.created_at,
@@ -664,7 +748,8 @@ impl QuickexContract {
         } else {
             Some(PrivacyAwareEscrowView {
                 token: entry.token,
-                amount: None,
+                amount_due: None,
+                amount_paid: None,
                 owner: None,
                 status: entry.status,
                 created_at: entry.created_at,

--- a/app/contract/contracts/quickex/src/stealth.rs
+++ b/app/contract/contracts/quickex/src/stealth.rs
@@ -104,15 +104,20 @@ pub fn register_ephemeral_key(
     let StealthDepositParams {
         sender,
         token,
-        amount,
+        amount_due,
+        amount_paid,
         eph_pub,
         spend_pub,
         stealth_address,
         timeout_secs,
     } = params;
 
-    if amount <= 0 {
+    if amount_due <= 0 || amount_paid <= 0 {
         return Err(QuickexError::InvalidAmount);
+    }
+
+    if amount_paid > amount_due {
+        return Err(QuickexError::Overpayment);
     }
 
     sender.require_auth();
@@ -135,7 +140,7 @@ pub fn register_ephemeral_key(
     // Transfer funds from sender to contract.
     let token_client = token::Client::new(env, &token);
     let contract_addr = env.current_contract_address();
-    token_client.transfer(&sender, &contract_addr, &amount);
+    token_client.transfer(&sender, &contract_addr, &amount_paid);
 
     let now = env.ledger().timestamp();
     let expires_at = if timeout_secs > 0 {
@@ -146,8 +151,8 @@ pub fn register_ephemeral_key(
 
     let entry = StealthEscrowEntry {
         token: token.clone(),
-        amount_due: amount,
-        amount_paid: amount,
+        amount_due,
+        amount_paid,
         eph_pub: eph_pub.clone(),
         status: EscrowStatus::Pending,
         created_at: now,
@@ -161,8 +166,8 @@ pub fn register_ephemeral_key(
         stealth_address.clone(),
         eph_pub,
         token,
-        amount,
-        amount,
+        amount_due,
+        amount_paid,
         expires_at,
     );
 

--- a/app/contract/contracts/quickex/src/stealth.rs
+++ b/app/contract/contracts/quickex/src/stealth.rs
@@ -146,7 +146,8 @@ pub fn register_ephemeral_key(
 
     let entry = StealthEscrowEntry {
         token: token.clone(),
-        amount,
+        amount_due: amount,
+        amount_paid: amount,
         eph_pub: eph_pub.clone(),
         status: EscrowStatus::Pending,
         created_at: now,
@@ -160,6 +161,7 @@ pub fn register_ephemeral_key(
         stealth_address.clone(),
         eph_pub,
         token,
+        amount,
         amount,
         expires_at,
     );
@@ -220,9 +222,19 @@ pub fn stealth_withdraw(
 
     // Transfer funds to recipient.
     let token_client = token::Client::new(env, &entry.token);
-    token_client.transfer(&env.current_contract_address(), &recipient, &entry.amount);
+    token_client.transfer(
+        &env.current_contract_address(),
+        &recipient,
+        &entry.amount_paid,
+    );
 
-    events::publish_stealth_withdrawn(env, stealth_address, recipient, entry.token, entry.amount);
+    events::publish_stealth_withdrawn(
+        env,
+        stealth_address,
+        recipient,
+        entry.token,
+        entry.amount_paid,
+    );
 
     Ok(true)
 }

--- a/app/contract/contracts/quickex/src/stealth_test.rs
+++ b/app/contract/contracts/quickex/src/stealth_test.rs
@@ -39,10 +39,12 @@ fn mint(env: &Env, token: &Address, recipient: &Address, amount: i128) {
 }
 
 /// Build a `StealthDepositParams` with the given fields.
+#[allow(clippy::too_many_arguments)]
 fn make_params(
     sender: Address,
     token: Address,
-    amount: i128,
+    amount_due: i128,
+    amount_paid: i128,
     eph_pub: BytesN<32>,
     spend_pub: BytesN<32>,
     stealth_address: BytesN<32>,
@@ -51,7 +53,8 @@ fn make_params(
     StealthDepositParams {
         sender,
         token,
-        amount,
+        amount_due,
+        amount_paid,
         eph_pub,
         spend_pub,
         stealth_address,
@@ -81,6 +84,7 @@ fn test_stealth_full_flow() {
     let returned_stealth = client.register_ephemeral_key(&make_params(
         sender,
         token.clone(),
+        amount,
         amount,
         eph_pub.clone(),
         spend_pub.clone(),
@@ -125,6 +129,7 @@ fn test_register_wrong_stealth_address_fails() {
             sender,
             token,
             amount,
+            amount,
             eph_pub,
             spend_pub,
             wrong_stealth,
@@ -154,6 +159,7 @@ fn test_register_duplicate_stealth_address_fails() {
         sender.clone(),
         token.clone(),
         amount,
+        amount,
         eph_pub.clone(),
         spend_pub.clone(),
         stealth_address.clone(),
@@ -164,6 +170,7 @@ fn test_register_duplicate_stealth_address_fails() {
         .try_register_ephemeral_key(&make_params(
             sender,
             token,
+            amount,
             amount,
             eph_pub,
             spend_pub,
@@ -194,6 +201,7 @@ fn test_stealth_withdraw_wrong_spend_pub_fails() {
     client.register_ephemeral_key(&make_params(
         sender,
         token,
+        amount,
         amount,
         eph_pub.clone(),
         spend_pub,
@@ -230,6 +238,7 @@ fn test_stealth_double_withdraw_fails() {
         sender,
         token,
         amount,
+        amount,
         eph_pub.clone(),
         spend_pub.clone(),
         stealth_address.clone(),
@@ -265,6 +274,7 @@ fn test_stealth_withdraw_after_expiry_fails() {
         sender,
         token,
         amount,
+        amount,
         eph_pub.clone(),
         spend_pub.clone(),
         stealth_address.clone(),
@@ -296,6 +306,7 @@ fn test_stealth_register_zero_amount_fails() {
         .try_register_ephemeral_key(&make_params(
             sender,
             token,
+            0,
             0,
             eph_pub,
             spend_pub,
@@ -338,6 +349,7 @@ fn test_stealth_register_fails_when_paused() {
         .try_register_ephemeral_key(&make_params(
             sender,
             token,
+            amount,
             amount,
             eph_pub,
             spend_pub,

--- a/app/contract/contracts/quickex/src/storage_test.rs
+++ b/app/contract/contracts/quickex/src/storage_test.rs
@@ -19,7 +19,8 @@ fn test_escrow_storage() {
 
         let entry = EscrowEntry {
             token: token.clone(),
-            amount,
+            amount_due: amount,
+            amount_paid: amount,
             owner: owner.clone(),
             status: EscrowStatus::Pending,
             created_at,
@@ -36,7 +37,8 @@ fn test_escrow_storage() {
         // Test get_escrow
         let retrieved_entry = get_escrow(&env, &commitment).unwrap();
         assert_eq!(retrieved_entry.token, token);
-        assert_eq!(retrieved_entry.amount, amount);
+        assert_eq!(retrieved_entry.amount_due, amount);
+        assert_eq!(retrieved_entry.amount_paid, amount);
         assert_eq!(retrieved_entry.owner, owner);
         assert_eq!(retrieved_entry.status, EscrowStatus::Pending);
         assert_eq!(retrieved_entry.created_at, created_at);
@@ -61,7 +63,8 @@ fn test_escrow_status_update() {
 
         let mut entry = EscrowEntry {
             token: token.clone(),
-            amount,
+            amount_due: amount,
+            amount_paid: amount,
             owner: owner.clone(),
             status: EscrowStatus::Pending,
             created_at,

--- a/app/contract/contracts/quickex/src/test.rs
+++ b/app/contract/contracts/quickex/src/test.rs
@@ -94,7 +94,8 @@ fn setup_escrow(
 
     let entry = EscrowEntry {
         token: token.clone(),
-        amount,
+        amount_due: amount,
+        amount_paid: amount,
         owner: depositor,
         status: EscrowStatus::Pending,
         created_at: env.ledger().timestamp(),
@@ -125,7 +126,8 @@ fn setup_escrow_with_owner(
 ) {
     let entry = EscrowEntry {
         token: token.clone(),
-        amount,
+        amount_due: amount,
+        amount_paid: amount,
         owner: owner.clone(),
         status: EscrowStatus::Pending,
         created_at: env.ledger().timestamp(),
@@ -172,7 +174,8 @@ fn test_get_escrow_details_privacy_enabled_hides_sensitive_fields() {
     let view = client.get_escrow_details(&commitment, &stranger).unwrap();
     assert_eq!(view.token, token);
     assert_eq!(view.status, EscrowStatus::Pending);
-    assert_eq!(view.amount, None);
+    assert_eq!(view.amount_due, None);
+    assert_eq!(view.amount_paid, None);
     assert_eq!(view.owner, None);
 }
 
@@ -208,7 +211,8 @@ fn test_get_escrow_details_privacy_enabled_owner_sees_full_details() {
     let view = client.get_escrow_details(&commitment, &owner).unwrap();
     assert_eq!(view.token, token);
     assert_eq!(view.status, EscrowStatus::Pending);
-    assert_eq!(view.amount, Some(amount));
+    assert_eq!(view.amount_due, Some(amount));
+    assert_eq!(view.amount_paid, Some(amount));
     assert_eq!(view.owner, Some(owner.clone()));
 }
 
@@ -240,7 +244,8 @@ fn test_get_escrow_details_privacy_disabled_shows_full_details() {
 
     // Privacy is off (never set) â€” stranger still gets full data
     let view = client.get_escrow_details(&commitment, &stranger).unwrap();
-    assert_eq!(view.amount, Some(amount));
+    assert_eq!(view.amount_due, Some(amount));
+    assert_eq!(view.amount_paid, Some(amount));
     assert_eq!(view.owner, Some(owner));
     assert_eq!(view.status, EscrowStatus::Pending);
 }
@@ -680,7 +685,8 @@ fn test_event_snapshot_escrow_deposited_schema() {
 
     let data_map = event_data_map(&env, data);
     assert!(data_map.get(Symbol::new(&env, "token")).is_some());
-    assert!(data_map.get(Symbol::new(&env, "amount")).is_some());
+    assert!(data_map.get(Symbol::new(&env, "amount_due")).is_some());
+    assert!(data_map.get(Symbol::new(&env, "amount_paid")).is_some());
     assert!(data_map.get(Symbol::new(&env, "expires_at")).is_some());
     assert!(data_map.get(Symbol::new(&env, "timestamp")).is_some());
 }
@@ -1161,7 +1167,8 @@ fn test_get_commitment_state_spent() {
     // Create entry with Spent status
     let entry = EscrowEntry {
         token: token.clone(),
-        amount,
+        amount_due: amount,
+        amount_paid: amount,
         owner: owner.clone(),
         status: EscrowStatus::Spent,
         created_at: env.ledger().timestamp(),
@@ -1308,7 +1315,8 @@ fn test_verify_proof_view_spent_commitment() {
     // Create entry with Spent status
     let entry = EscrowEntry {
         token: token.clone(),
-        amount,
+        amount_due: amount,
+        amount_paid: amount,
         owner: owner.clone(),
         status: EscrowStatus::Spent,
         created_at: env.ledger().timestamp(),
@@ -1361,7 +1369,8 @@ fn test_get_escrow_details_found() {
     assert!(details.is_some());
 
     let entry = details.unwrap();
-    assert_eq!(entry.amount, Some(amount));
+    assert_eq!(entry.amount_due, Some(amount));
+    assert_eq!(entry.amount_paid, Some(amount));
     assert_eq!(entry.token, token);
     assert_eq!(entry.status, EscrowStatus::Pending);
 }
@@ -1402,7 +1411,8 @@ fn test_get_escrow_details_spent_status() {
 
     let entry = EscrowEntry {
         token: token.clone(),
-        amount,
+        amount_due: amount,
+        amount_paid: amount,
         owner: owner.clone(),
         status: EscrowStatus::Spent,
         created_at: env.ledger().timestamp(),
@@ -1422,7 +1432,8 @@ fn test_get_escrow_details_spent_status() {
 
     let retrieved = details.unwrap();
     assert_eq!(retrieved.status, EscrowStatus::Spent);
-    assert_eq!(retrieved.amount, Some(amount));
+    assert_eq!(retrieved.amount_due, Some(amount));
+    assert_eq!(retrieved.amount_paid, Some(amount));
     assert_eq!(retrieved.token, token);
 }
 // ============================================================================
@@ -1507,7 +1518,8 @@ fn test_upgrade_migration_preserves_legacy_escrow_data() {
 
     let details = client.get_escrow_details(&commitment, &owner).unwrap();
     assert_eq!(details.token, token);
-    assert_eq!(details.amount, Some(amount));
+    assert_eq!(details.amount_due, Some(amount));
+    assert_eq!(details.amount_paid, Some(amount));
     assert_eq!(details.owner, Some(owner.clone()));
     assert_eq!(details.status, EscrowStatus::Pending);
 
@@ -2370,7 +2382,8 @@ fn test_cross_asset_privacy_preserved_across_tokens() {
 
     // Stranger should not see sensitive details
     let view = client.get_escrow_details(&commitment_a, &stranger).unwrap();
-    assert_eq!(view.amount, None);
+    assert_eq!(view.amount_due, None);
+    assert_eq!(view.amount_paid, None);
     assert_eq!(view.owner, None);
     assert_eq!(view.token, token_a);
     assert_eq!(view.status, EscrowStatus::Pending);
@@ -2448,7 +2461,8 @@ mod tests {
             let env = Env::default();
             EscrowEntry {
                 token: Address::generate(&env),
-                amount: 1000,
+                amount_due: 1000,
+                amount_paid: 1000,
                 owner: Address::generate(&env),
                 status: EscrowStatus::Pending,
                 created_at: 0,
@@ -2531,7 +2545,8 @@ mod tests {
         fn dummy_entry(env: &Env, status: EscrowStatus, expires_at: u64) -> EscrowEntry {
             EscrowEntry {
                 token: Address::generate(env),
-                amount: 1000,
+                amount_due: 1000,
+                amount_paid: 1000,
                 owner: Address::generate(env),
                 status,
                 created_at: 0,
@@ -2737,9 +2752,302 @@ mod tests {
 
                 // Both withdraw and refund reject non-Pending status
                 let is_terminal =
-                    entry.status != EscrowStatus::Pending && entry.status != EscrowStatus::Disputed;
-                assert!(is_terminal, "INV-5: {:?} must be a terminal state", status);
+                    entry.status == EscrowStatus::Spent || entry.status == EscrowStatus::Refunded;
+                assert!(is_terminal, "INV-5: terminal states must be final");
             }
         }
     }
+}
+
+// ============================================================================
+// Multi-Payment Tests
+// ============================================================================
+
+#[test]
+fn test_partial_payment_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let amount_due: i128 = 1000;
+    let initial_payment: i128 = 700;
+    let salt = Bytes::from_slice(&env, b"partial_payment_salt");
+
+    // Mint tokens to owner and payer
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &initial_payment);
+    token_client.mint(&payer, &300);
+
+    // Create escrow with partial initial payment
+    let commitment = client.deposit_partial(
+        &token,
+        &amount_due,
+        &initial_payment,
+        &owner,
+        &salt,
+        &0,
+        &None,
+    );
+
+    // Make partial payment
+    let payment_amount: i128 = 300;
+    client.partial_payment(&commitment, &payer, &payment_amount);
+
+    // Verify escrow state
+    let details = client.get_escrow_details(&commitment, &owner).unwrap();
+    assert_eq!(details.amount_due, Some(amount_due));
+    assert_eq!(details.amount_paid, Some(1000));
+    assert_eq!(details.status, EscrowStatus::Pending);
+}
+
+#[test]
+fn test_partial_payment_overpayment_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let amount_due: i128 = 1000;
+    let initial_payment: i128 = 500;
+    let salt = Bytes::from_slice(&env, b"overpayment_salt");
+
+    // Mint tokens to owner and payer
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &initial_payment);
+    token_client.mint(&payer, &501);
+
+    // Create escrow with partial initial payment
+    let commitment = client.deposit_partial(
+        &token,
+        &amount_due,
+        &initial_payment,
+        &owner,
+        &salt,
+        &0,
+        &None,
+    );
+
+    // Try to overpay
+    let payment_amount: i128 = 501; // More than remaining (500)
+    let result = client.try_partial_payment(&commitment, &payer, &payment_amount);
+    assert_contract_error(result, QuickexError::Overpayment);
+}
+
+#[test]
+fn test_partial_payment_fully_paid_triggers_finalization() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let amount_due: i128 = 1000;
+    let initial_payment: i128 = 500;
+    let salt = Bytes::from_slice(&env, b"finalization_salt");
+
+    // Mint tokens to owner and payer
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &initial_payment);
+    token_client.mint(&payer, &500);
+
+    // Create escrow with partial initial payment
+    let commitment = client.deposit_partial(
+        &token,
+        &amount_due,
+        &initial_payment,
+        &owner,
+        &salt,
+        &0,
+        &None,
+    );
+
+    // Make payment to complete the escrow
+    let payment_amount: i128 = 500;
+    client.partial_payment(&commitment, &payer, &payment_amount);
+
+    // Verify escrow is fully paid
+    let details = client.get_escrow_details(&commitment, &owner).unwrap();
+    assert_eq!(details.amount_due, Some(1000));
+    assert_eq!(details.amount_paid, Some(1000));
+    assert_eq!(details.status, EscrowStatus::Pending);
+}
+
+#[test]
+fn test_partial_payment_invalid_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let amount_due: i128 = 1000;
+    let initial_payment: i128 = 500;
+    let salt = Bytes::from_slice(&env, b"invalid_amount_salt");
+
+    // Mint tokens to owner
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &initial_payment);
+
+    // Create escrow
+    let commitment = client.deposit_partial(
+        &token,
+        &amount_due,
+        &initial_payment,
+        &owner,
+        &salt,
+        &0,
+        &None,
+    );
+
+    // Try to pay zero
+    let result = client.try_partial_payment(&commitment, &payer, &0);
+    assert_contract_error(result, QuickexError::InvalidAmount);
+
+    // Try to pay negative
+    let result = client.try_partial_payment(&commitment, &payer, &-100);
+    assert_contract_error(result, QuickexError::InvalidAmount);
+}
+
+#[test]
+fn test_partial_payment_nonexistent_escrow_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let payer = Address::generate(&env);
+    let fake_commitment = BytesN::from_array(&env, &[255; 32]);
+
+    // Try to pay to non-existent escrow
+    let result = client.try_partial_payment(&fake_commitment, &payer, &100);
+    assert_contract_error(result, QuickexError::CommitmentNotFound);
+}
+
+#[test]
+fn test_partial_payment_terminal_state_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let amount_due: i128 = 1000;
+    let salt = Bytes::from_slice(&env, b"terminal_state_salt");
+
+    // Mint tokens to owner
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &amount_due);
+
+    // Create and withdraw escrow (fully paid)
+    let commitment = client.deposit(&token, &amount_due, &owner, &salt, &0, &None);
+    client.withdraw(&token, &amount_due, &commitment, &owner, &salt);
+
+    // Try to make partial payment on spent escrow
+    let result = client.try_partial_payment(&commitment, &payer, &100);
+    assert_contract_error(result, QuickexError::AlreadySpent);
+}
+
+#[test]
+fn test_withdraw_requires_fully_paid() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let amount_due: i128 = 1000;
+    let initial_payment: i128 = 500;
+    let salt = Bytes::from_slice(&env, b"not_fully_paid_salt");
+
+    // Mint tokens to owner
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &initial_payment);
+
+    // Create escrow with partial payment
+    let commitment = client.deposit_partial(
+        &token,
+        &amount_due,
+        &initial_payment,
+        &owner,
+        &salt,
+        &0,
+        &None,
+    );
+
+    // Try to withdraw before fully paid
+    let result = client.try_withdraw(&token, &amount_due, &commitment, &owner, &salt);
+    assert_contract_error(result, QuickexError::Overpayment);
+}
+
+#[test]
+fn test_multi_payment_sequence() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let payer1 = Address::generate(&env);
+    let payer2 = Address::generate(&env);
+    let payer3 = Address::generate(&env);
+    let amount_due: i128 = 1000;
+    let initial_payment: i128 = 300;
+    let salt = Bytes::from_slice(&env, b"multi_payment_salt");
+
+    // Mint tokens to all participants
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &initial_payment);
+    token_client.mint(&payer1, &200);
+    token_client.mint(&payer2, &300);
+    token_client.mint(&payer3, &200);
+
+    // Create escrow with initial payment of 300
+    let commitment = client.deposit_partial(
+        &token,
+        &amount_due,
+        &initial_payment,
+        &owner,
+        &salt,
+        &0,
+        &None,
+    );
+
+    // First partial payment: 200
+    client.partial_payment(&commitment, &payer1, &200);
+    let details = client.get_escrow_details(&commitment, &owner).unwrap();
+    assert_eq!(details.amount_paid, Some(500));
+
+    // Second partial payment: 300
+    client.partial_payment(&commitment, &payer2, &300);
+    let details = client.get_escrow_details(&commitment, &owner).unwrap();
+    assert_eq!(details.amount_paid, Some(800));
+
+    // Final payment: 200 (completes the escrow)
+    client.partial_payment(&commitment, &payer3, &200);
+    let details = client.get_escrow_details(&commitment, &owner).unwrap();
+    assert_eq!(details.amount_paid, Some(1000));
+    assert_eq!(details.amount_due, Some(1000));
 }

--- a/app/contract/contracts/quickex/src/types.rs
+++ b/app/contract/contracts/quickex/src/types.rs
@@ -36,8 +36,10 @@ pub enum EscrowStatus {
 pub struct EscrowEntry {
     /// Token contract address for the escrowed funds.
     pub token: Address,
-    /// Amount in token base units.
-    pub amount: i128,
+    /// Total amount due in token base units (the target amount to be paid).
+    pub amount_due: i128,
+    /// Amount already paid towards the escrow.
+    pub amount_paid: i128,
     /// Owner who deposited and may refund after expiry.
     pub owner: Address,
     /// Current status (Pending, Spent, Refunded, Expired, Disputed).
@@ -54,7 +56,7 @@ pub struct EscrowEntry {
 /// Privacy-aware view of an escrow entry.
 ///
 /// Returned by [`QuickexContract::get_escrow_details`] instead of the raw
-/// [`EscrowEntry`]. Sensitive fields (`amount`, `owner`) are set to `None`
+/// [`EscrowEntry`]. Sensitive fields (`amount_due`, `amount_paid`, `owner`) are set to `None`
 /// when the escrow owner has privacy enabled and the caller is not the owner.
 ///
 /// ## Field visibility
@@ -65,15 +67,18 @@ pub struct EscrowEntry {
 /// | `status`     | ✓           | ✓                            | ✓                               |
 /// | `created_at` | ✓           | ✓                            | ✓                               |
 /// | `expires_at` | ✓           | ✓                            | ✓                               |
-/// | `amount`     | ✓           | ✓                            | `None`                          |
+/// | `amount_due` | ✓           | ✓                            | `None`                          |
+/// | `amount_paid`| ✓           | ✓                            | `None`                          |
 /// | `owner`      | ✓           | ✓                            | `None`                          |
 #[contracttype]
 #[derive(Clone)]
 pub struct PrivacyAwareEscrowView {
     /// Token contract address (always visible).
     pub token: Address,
-    /// Escrowed amount. `None` when privacy is enabled and caller is not the owner.
-    pub amount: Option<i128>,
+    /// Total amount due. `None` when privacy is enabled and caller is not the owner.
+    pub amount_due: Option<i128>,
+    /// Amount already paid. `None` when privacy is enabled and caller is not the owner.
+    pub amount_paid: Option<i128>,
     /// Owner address. `None` when privacy is enabled and caller is not the owner.
     pub owner: Option<Address>,
     /// Current lifecycle status (always visible).
@@ -97,8 +102,10 @@ pub struct StealthDepositParams {
     pub sender: Address,
     /// Token contract address.
     pub token: Address,
-    /// Amount to lock; must be positive.
-    pub amount: i128,
+    /// Total amount due; must be positive.
+    pub amount_due: i128,
+    /// Initial payment amount; must be positive and <= amount_due.
+    pub amount_paid: i128,
     /// Sender's ephemeral public key (32 bytes).
     pub eph_pub: BytesN<32>,
     /// Recipient's spend public key (32 bytes).
@@ -116,7 +123,7 @@ pub struct StealthDepositParams {
 ///
 /// ## Field visibility
 /// - `eph_pub` is public (needed by recipient to scan).
-/// - `token`, `amount`, `status`, `created_at`, `expires_at` are public.
+/// - `token`, `amount_due`, `amount_paid`, `status`, `created_at`, `expires_at` are public.
 /// - The link between `eph_pub` and the recipient's real identity is only
 ///   computable by the recipient (who holds the matching private key).
 #[contracttype]
@@ -124,8 +131,10 @@ pub struct StealthDepositParams {
 pub struct StealthEscrowEntry {
     /// Token contract address for the escrowed funds.
     pub token: Address,
-    /// Amount in token base units.
-    pub amount: i128,
+    /// Total amount due in token base units (the target amount to be paid).
+    pub amount_due: i128,
+    /// Amount already paid towards the escrow.
+    pub amount_paid: i128,
     /// Sender's ephemeral public key (32 bytes). Stored so the recipient can
     /// scan events and re-derive the shared secret off-chain.
     pub eph_pub: BytesN<32>,


### PR DESCRIPTION
- Add amount_due and amount_paid fields to EscrowEntry
- Add deposit_partial function for creating escrows with partial initial payment
- Add partial_payment function for making incremental payments
- Add Overpayment error to prevent exceeding amount_due
- Add PartialPaymentEvent and EscrowFinalizedEvent
- Update withdraw, refund, and resolve_dispute to use amount_paid
- Add comprehensive tests for multi-payment scenarios
- Update stealth escrow to support new fields
- Update batch operations to use new fields
- Add clippy allow attributes for functions with many arguments
close #301 