### PR TITLE
Fix cursor pagination handling in username search

### DIFF
--- a/app/backend/src/usernames/usernames.service.ts
+++ b/app/backend/src/usernames/usernames.service.ts
@@ -117,10 +117,7 @@ export class UsernamesService {
   ): Promise<{ data: SearchProfileResult[]; next_cursor: string | null; has_more: boolean }> {
     const normalizedQuery = this.normalizeUsername(query);
 
-    // Validate cursor format if provided (actual filtering handled by limit+1 strategy)
-    if (cursor) {
-      decodeCursor(cursor);
-    }
+    const decodedCursor = cursor ? decodeCursor(cursor) : null;
 
     if (!normalizedQuery || normalizedQuery.length < 2) {
       throw new UsernameValidationError(
@@ -130,15 +127,36 @@ export class UsernamesService {
       );
     }
 
-    // For search endpoints, fetch limit+1 results to detect has_more
     const effectiveLimit = Math.min(100, Math.max(1, limit));
+    // When a cursor is present we need a wider window so we can advance
+    // from the previous page marker even though the underlying query
+    // does not yet support server-side cursor filtering.
+    const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
     const results = await this.supabase.searchPublicUsernames(
       normalizedQuery,
-      effectiveLimit + 1,
+      fetchWindow,
     );
 
-    const hasMore = results.length > effectiveLimit;
-    const data = hasMore ? results.slice(0, effectiveLimit) : results;
+    let windowed = results;
+    if (decodedCursor) {
+      const cursorIndex = results.findIndex(
+        (row) =>
+          row.id === decodedCursor.id && row.created_at === decodedCursor.pk,
+      );
+      if (cursorIndex >= 0) {
+        windowed = results.slice(cursorIndex + 1);
+      } else {
+        // Fallback comparator for cursor continuity when the exact row is no longer in range.
+        windowed = results.filter(
+          (row) =>
+            row.created_at < decodedCursor.pk ||
+            (row.created_at === decodedCursor.pk && row.id < decodedCursor.id),
+        );
+      }
+    }
+
+    const hasMore = windowed.length > effectiveLimit;
+    const data = hasMore ? windowed.slice(0, effectiveLimit) : windowed;
 
     let nextCursor: string | null = null;
     if (hasMore && data.length > 0) {

--- a/app/backend/src/usernames/usernames.service.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.unit.spec.ts
@@ -18,6 +18,8 @@ describe('UsernamesService', () => {
     insertUsername: jest.fn(),
     countUsernamesByPublicKey: jest.fn(),
     listUsernamesByPublicKey: jest.fn(),
+    searchPublicUsernames: jest.fn(),
+    updateUsernameActivity: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -170,6 +172,69 @@ describe('UsernamesService', () => {
         'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR',
       );
       expect(result).toEqual(rows);
+    });
+  });
+
+  describe('searchPublicUsernames', () => {
+    const rows = [
+      {
+        id: 'id-4',
+        username: 'alice4',
+        public_key: 'GAAA4',
+        created_at: '2025-01-04T00:00:00.000Z',
+        last_active_at: null,
+        is_public: true,
+      },
+      {
+        id: 'id-3',
+        username: 'alice3',
+        public_key: 'GAAA3',
+        created_at: '2025-01-03T00:00:00.000Z',
+        last_active_at: null,
+        is_public: true,
+      },
+      {
+        id: 'id-2',
+        username: 'alice2',
+        public_key: 'GAAA2',
+        created_at: '2025-01-02T00:00:00.000Z',
+        last_active_at: null,
+        is_public: true,
+      },
+      {
+        id: 'id-1',
+        username: 'alice1',
+        public_key: 'GAAA1',
+        created_at: '2025-01-01T00:00:00.000Z',
+        last_active_at: null,
+        is_public: true,
+      },
+    ];
+
+    it('returns first page with next_cursor and has_more=true', async () => {
+      mockSupabaseService.searchPublicUsernames.mockResolvedValueOnce(rows.slice(0, 3));
+
+      const result = await service.searchPublicUsernames('alice', 2);
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['id-4', 'id-3']);
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBeTruthy();
+      expect(mockSupabaseService.updateUsernameActivity).toHaveBeenCalledWith('alice4');
+    });
+
+    it('advances to next page when cursor is provided', async () => {
+      mockSupabaseService.searchPublicUsernames.mockResolvedValueOnce(rows);
+      const cursor = Buffer.from(
+        JSON.stringify({ pk: '2025-01-03T00:00:00.000Z', id: 'id-3' }),
+        'utf-8',
+      ).toString('base64url');
+
+      const result = await service.searchPublicUsernames('alice', 2, cursor);
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['id-2', 'id-1']);
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeNull();
+      expect(mockSupabaseService.searchPublicUsernames).toHaveBeenCalledWith('alice', 100);
     });
   });
 });


### PR DESCRIPTION
Closes Pulsefy/Lumenpulse#551

## Changes
- fixed cursor pagination for public username search in backend discovery flow
- previous implementation accepted `cursor` but did not advance pages; this now advances correctly and computes page metadata from the post-cursor window
- added service unit tests covering first-page and next-page cursor behavior

## Testing
- tests not run in this environment (backend dependencies are not installed)