### PR TITLE
feat(analytics): enhanced dashboard analytics and CSV/PDF reporting

### DIFF
--- a/app/backend/src/analytics/analytics.controller.ts
+++ b/app/backend/src/analytics/analytics.controller.ts
@@ -1,0 +1,110 @@
+import { Controller, Get, Query, Res, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import { ApiKeyGuard } from '../auth/guards/api-key.guard';
+import { AnalyticsService } from './analytics.service';
+import {
+  AnalyticsQueryDto,
+  ExportReportQueryDto,
+  TimeSeriesQueryDto,
+  ReportFormat,
+} from './dto/analytics-query.dto';
+
+@ApiTags('analytics')
+@UseGuards(ApiKeyGuard)
+@Controller('analytics')
+export class AnalyticsController {
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  @Get('report')
+  @ApiOperation({
+    summary: 'Fetch dashboard analytics report (summary, asset distribution, and time-series)',
+  })
+  @ApiResponse({ status: 200, description: 'Analytics report generated' })
+  async getReport(@Query() query: TimeSeriesQueryDto) {
+    return this.analyticsService.getAnalyticsReport(
+      query.publicKey,
+      query.startDate,
+      query.endDate,
+      query.interval,
+    );
+  }
+
+  @Get('time-series')
+  @ApiOperation({
+    summary: 'Fetch only time-series analytics for chart rendering (daily/weekly/monthly)',
+  })
+  @ApiResponse({ status: 200, description: 'Time-series analytics generated' })
+  async getTimeSeries(@Query() query: TimeSeriesQueryDto) {
+    const report = await this.analyticsService.getAnalyticsReport(
+      query.publicKey,
+      query.startDate,
+      query.endDate,
+      query.interval,
+    );
+    return {
+      interval: query.interval,
+      window: report.window,
+      series: report.timeSeries,
+    };
+  }
+
+  @Get('assets')
+  @ApiOperation({
+    summary: 'Fetch asset distribution for payment history',
+  })
+  @ApiResponse({ status: 200, description: 'Asset distribution generated' })
+  async getAssetDistribution(@Query() query: AnalyticsQueryDto) {
+    const report = await this.analyticsService.getAnalyticsReport(
+      query.publicKey,
+      query.startDate,
+      query.endDate,
+    );
+    return {
+      window: report.window,
+      distribution: report.assetDistribution,
+    };
+  }
+
+  @Get('export')
+  @ApiOperation({
+    summary: 'Export analytics report in CSV or PDF for tax/accounting',
+  })
+  @ApiResponse({ status: 200, description: 'Report export generated' })
+  async exportReport(
+    @Query() query: ExportReportQueryDto,
+    @Res() res: Response,
+  ) {
+    const { report, payments } = await this.analyticsService.exportReport(
+      query.publicKey,
+      query.startDate,
+      query.endDate,
+      query.reportType,
+      query.interval,
+      query.maxRows,
+    );
+
+    if (query.format === ReportFormat.PDF) {
+      const pdf = this.analyticsService.buildPdfReport(
+        report,
+        payments,
+        query.reportType,
+      );
+      const filename = `quickex-${query.reportType}-report.pdf`;
+      res.header('Content-Type', 'application/pdf');
+      res.attachment(filename);
+      return res.send(pdf);
+    }
+
+    const csv = this.analyticsService.buildCsvReport(
+      report,
+      payments,
+      query.reportType,
+    );
+    const filename = `quickex-${query.reportType}-report.csv`;
+    res.header('Content-Type', 'text/csv');
+    res.attachment(filename);
+    return res.send(csv);
+  }
+}
+

--- a/app/backend/src/analytics/analytics.module.ts
+++ b/app/backend/src/analytics/analytics.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ApiKeysModule } from '../api-keys/api-keys.module';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+
+@Module({
+  imports: [SupabaseModule, ApiKeysModule],
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}
+

--- a/app/backend/src/analytics/analytics.service.ts
+++ b/app/backend/src/analytics/analytics.service.ts
@@ -1,0 +1,637 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { SupabaseService } from '../supabase/supabase.service';
+import {
+  AnalyticsInterval,
+  ReportType,
+} from './dto/analytics-query.dto';
+
+type PaymentRow = Record<string, unknown>;
+type RpcSummaryRow = {
+  total_transactions: number;
+  successful_transactions: number;
+  failed_transactions: number;
+  conversion_rate: number;
+  total_volume_usd: number;
+  average_transaction_usd: number;
+};
+type RpcAssetRow = {
+  asset: string;
+  volume_usd: number;
+  percentage: number;
+  transaction_count: number;
+};
+type RpcTimeSeriesRow = {
+  period: string;
+  transaction_count: number;
+  successful_transactions: number;
+  volume_usd: number;
+  volume_usdc: number;
+  volume_xlm: number;
+  asset_volumes?: Record<string, number> | null;
+};
+
+type NormalizedPayment = {
+  createdAt: string;
+  publicKeys: string[];
+  asset: string;
+  amount: number;
+  amountUsd: number;
+  status: string;
+};
+
+export type AnalyticsSummary = {
+  totalTransactions: number;
+  successfulTransactions: number;
+  failedTransactions: number;
+  conversionRate: number;
+  totalVolumeUsd: number;
+  averageTransactionUsd: number;
+};
+
+export type AssetDistributionItem = {
+  asset: string;
+  volumeUsd: number;
+  percentage: number;
+  transactionCount: number;
+};
+
+export type TimeSeriesItem = {
+  period: string;
+  transactionCount: number;
+  successfulTransactions: number;
+  volumeUsd: number;
+  assetVolumes: Record<string, number>;
+};
+
+export type AnalyticsReport = {
+  summary: AnalyticsSummary;
+  assetDistribution: AssetDistributionItem[];
+  timeSeries: TimeSeriesItem[];
+  window: {
+    startDate: string;
+    endDate: string;
+  };
+};
+
+@Injectable()
+export class AnalyticsService {
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async getAnalyticsReport(
+    publicKey: string,
+    startDate?: string,
+    endDate?: string,
+    interval: AnalyticsInterval = AnalyticsInterval.DAILY,
+  ): Promise<AnalyticsReport> {
+    const { startIso, endIso } = this.resolveDateWindow(startDate, endDate);
+
+    const rpcReport = await this.fetchAggregatedReportViaRpc(
+      publicKey,
+      startIso,
+      endIso,
+      interval,
+    );
+    if (rpcReport) {
+      return rpcReport;
+    }
+
+    const rows = await this.fetchPaymentRows(publicKey, startIso, endIso);
+    const payments = this.normalizeAndFilterRows(rows, publicKey);
+
+    return {
+      summary: this.buildSummary(payments),
+      assetDistribution: this.buildAssetDistribution(payments),
+      timeSeries: this.buildTimeSeries(payments, interval),
+      window: {
+        startDate: startIso,
+        endDate: endIso,
+      },
+    };
+  }
+
+  async exportReport(
+    publicKey: string,
+    startDate: string | undefined,
+    endDate: string | undefined,
+    reportType: ReportType,
+    interval: AnalyticsInterval,
+    maxRows: number,
+  ): Promise<{ report: AnalyticsReport; payments: NormalizedPayment[] }> {
+    const { startIso, endIso } = this.resolveDateWindow(startDate, endDate);
+    const rows = await this.fetchPaymentRows(publicKey, startIso, endIso);
+    const payments = this.normalizeAndFilterRows(rows, publicKey).slice(
+      0,
+      Math.max(1, Math.min(maxRows || 500, 5000)),
+    );
+
+    const rpcReport = await this.fetchAggregatedReportViaRpc(
+      publicKey,
+      startIso,
+      endIso,
+      interval,
+    );
+    const report: AnalyticsReport =
+      rpcReport ??
+      {
+        summary: this.buildSummary(payments),
+        assetDistribution: this.buildAssetDistribution(payments),
+        timeSeries: this.buildTimeSeries(payments, interval),
+        window: {
+          startDate: startIso,
+          endDate: endIso,
+        },
+      };
+
+    if (reportType === ReportType.TAX) {
+      report.summary.averageTransactionUsd = this.round2(
+        report.summary.totalVolumeUsd / Math.max(report.summary.successfulTransactions, 1),
+      );
+    }
+
+    return { report, payments };
+  }
+
+  buildCsvReport(
+    report: AnalyticsReport,
+    payments: NormalizedPayment[],
+    reportType: ReportType,
+  ): string {
+    const lines: string[] = [];
+    lines.push(`quickex_analytics_report_type,${reportType}`);
+    lines.push(`start_date,${report.window.startDate}`);
+    lines.push(`end_date,${report.window.endDate}`);
+    lines.push('');
+    lines.push('summary_metric,value');
+    lines.push(`total_transactions,${report.summary.totalTransactions}`);
+    lines.push(`successful_transactions,${report.summary.successfulTransactions}`);
+    lines.push(`failed_transactions,${report.summary.failedTransactions}`);
+    lines.push(`conversion_rate_percent,${report.summary.conversionRate}`);
+    lines.push(`total_volume_usd,${report.summary.totalVolumeUsd}`);
+    lines.push(`average_transaction_usd,${report.summary.averageTransactionUsd}`);
+    lines.push('');
+    lines.push('asset,volume_usd,percentage,transaction_count');
+    report.assetDistribution.forEach((item) => {
+      lines.push(
+        [
+          this.escapeCsv(item.asset),
+          item.volumeUsd.toFixed(2),
+          item.percentage.toFixed(2),
+          item.transactionCount.toString(),
+        ].join(','),
+      );
+    });
+    lines.push('');
+    lines.push('period,transaction_count,successful_transactions,volume_usd');
+    report.timeSeries.forEach((item) => {
+      lines.push(
+        [
+          this.escapeCsv(item.period),
+          item.transactionCount.toString(),
+          item.successfulTransactions.toString(),
+          item.volumeUsd.toFixed(2),
+        ].join(','),
+      );
+    });
+    lines.push('');
+    lines.push('created_at,asset,amount,amount_usd,status');
+    payments.forEach((payment) => {
+      lines.push(
+        [
+          this.escapeCsv(payment.createdAt),
+          this.escapeCsv(payment.asset),
+          payment.amount.toFixed(7),
+          payment.amountUsd.toFixed(2),
+          this.escapeCsv(payment.status),
+        ].join(','),
+      );
+    });
+
+    return lines.join('\n');
+  }
+
+  buildPdfReport(
+    report: AnalyticsReport,
+    payments: NormalizedPayment[],
+    reportType: ReportType,
+  ): Buffer {
+    const lines: string[] = [
+      `QuickEx ${reportType.toUpperCase()} Report`,
+      `Date window: ${report.window.startDate} to ${report.window.endDate}`,
+      `Total USD volume: ${report.summary.totalVolumeUsd.toFixed(2)}`,
+      `Transactions: ${report.summary.totalTransactions}`,
+      `Conversion rate: ${report.summary.conversionRate.toFixed(2)}%`,
+      '',
+      'Top assets by USD volume:',
+      ...report.assetDistribution.slice(0, 5).map(
+        (asset) =>
+          `${asset.asset}: $${asset.volumeUsd.toFixed(2)} (${asset.percentage.toFixed(2)}%)`,
+      ),
+      '',
+      'Recent transactions:',
+      ...payments.slice(-10).map(
+        (row) =>
+          `${row.createdAt.slice(0, 19)} | ${row.asset} | $${row.amountUsd.toFixed(2)} | ${row.status}`,
+      ),
+    ];
+
+    return this.createSimplePdf(lines);
+  }
+
+  private async fetchPaymentRows(
+    publicKey: string,
+    startIso: string,
+    endIso: string,
+  ): Promise<PaymentRow[]> {
+    const client = this.supabase.getClient();
+
+    const { data, error } = await client
+      .from('payment_records')
+      .select('*')
+      .or(`sender_public_key.eq.${publicKey},receiver_public_key.eq.${publicKey}`)
+      .gte('created_at', startIso)
+      .lte('created_at', endIso)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      throw new BadRequestException({
+        code: 'ANALYTICS_QUERY_FAILED',
+        message: `Failed to fetch payment records: ${error.message}`,
+      });
+    }
+
+    return (data ?? []) as PaymentRow[];
+  }
+
+  private async fetchAggregatedReportViaRpc(
+    publicKey: string,
+    startIso: string,
+    endIso: string,
+    interval: AnalyticsInterval,
+  ): Promise<AnalyticsReport | null> {
+    const client = this.supabase.getClient();
+    const [summaryResult, assetsResult, timeSeriesResult] = await Promise.all([
+      client.rpc('quickex_analytics_summary', {
+        p_public_key: publicKey,
+        p_start_date: startIso,
+        p_end_date: endIso,
+      }),
+      client.rpc('quickex_analytics_asset_distribution', {
+        p_public_key: publicKey,
+        p_start_date: startIso,
+        p_end_date: endIso,
+      }),
+      client.rpc('quickex_analytics_time_series', {
+        p_public_key: publicKey,
+        p_start_date: startIso,
+        p_end_date: endIso,
+        p_interval: interval,
+      }),
+    ]);
+
+    if (summaryResult.error || assetsResult.error || timeSeriesResult.error) {
+      return null;
+    }
+
+    const summaryRow = (summaryResult.data?.[0] ?? null) as RpcSummaryRow | null;
+    if (!summaryRow) {
+      return null;
+    }
+
+    const assetRows = (assetsResult.data ?? []) as RpcAssetRow[];
+    const timeSeriesRows = (timeSeriesResult.data ?? []) as RpcTimeSeriesRow[];
+
+    return {
+      summary: {
+        totalTransactions: Number(summaryRow.total_transactions ?? 0),
+        successfulTransactions: Number(summaryRow.successful_transactions ?? 0),
+        failedTransactions: Number(summaryRow.failed_transactions ?? 0),
+        conversionRate: this.round2(Number(summaryRow.conversion_rate ?? 0)),
+        totalVolumeUsd: this.round2(Number(summaryRow.total_volume_usd ?? 0)),
+        averageTransactionUsd: this.round2(
+          Number(summaryRow.average_transaction_usd ?? 0),
+        ),
+      },
+      assetDistribution: assetRows
+        .map((item) => ({
+          asset: (item.asset ?? 'XLM').toUpperCase(),
+          volumeUsd: this.round2(Number(item.volume_usd ?? 0)),
+          percentage: this.round2(Number(item.percentage ?? 0)),
+          transactionCount: Number(item.transaction_count ?? 0),
+        }))
+        .sort((a, b) => b.volumeUsd - a.volumeUsd),
+      timeSeries: timeSeriesRows
+        .map((item) => {
+          const assetVolumes = item.asset_volumes ?? {
+            USDC: Number(item.volume_usdc ?? 0),
+            XLM: Number(item.volume_xlm ?? 0),
+          };
+          return {
+            period: item.period,
+            transactionCount: Number(item.transaction_count ?? 0),
+            successfulTransactions: Number(item.successful_transactions ?? 0),
+            volumeUsd: this.round2(Number(item.volume_usd ?? 0)),
+            assetVolumes: Object.fromEntries(
+              Object.entries(assetVolumes).map(([asset, volume]) => [
+                asset.toUpperCase(),
+                this.round2(Number(volume ?? 0)),
+              ]),
+            ),
+          };
+        })
+        .sort((a, b) => a.period.localeCompare(b.period)),
+      window: {
+        startDate: startIso,
+        endDate: endIso,
+      },
+    };
+  }
+
+  private normalizeAndFilterRows(
+    rows: PaymentRow[],
+    publicKey: string,
+  ): NormalizedPayment[] {
+    return rows
+      .map((row) => this.normalizeRow(row))
+      .filter((row): row is NormalizedPayment => row !== null)
+      .filter((row) => row.publicKeys.includes(publicKey));
+  }
+
+  private normalizeRow(row: PaymentRow): NormalizedPayment | null {
+    const createdAt = this.readString(row, ['created_at', 'createdAt']);
+    if (!createdAt) {
+      return null;
+    }
+
+    const amount = this.readNumber(row, ['amount']);
+    const amountUsdRaw = this.readNumber(row, ['amount_usd', 'amountUsd']);
+    const amountUsd = amountUsdRaw > 0 ? amountUsdRaw : amount;
+
+    const asset = (
+      this.readString(row, ['asset', 'asset_code', 'assetCode']) ?? 'XLM'
+    ).toUpperCase();
+
+    const status = (
+      this.readString(row, ['status']) ?? 'unknown'
+    ).toLowerCase();
+
+    const publicKeys = [
+      this.readString(row, ['sender_public_key', 'from_address', 'from']),
+      this.readString(row, ['receiver_public_key', 'to_address', 'to']),
+      this.readString(row, ['public_key', 'publicKey']),
+    ].filter((item): item is string => Boolean(item));
+
+    if (publicKeys.length === 0) {
+      return null;
+    }
+
+    return {
+      createdAt,
+      publicKeys,
+      asset,
+      amount,
+      amountUsd,
+      status,
+    };
+  }
+
+  private buildSummary(payments: NormalizedPayment[]): AnalyticsSummary {
+    const totalTransactions = payments.length;
+    const successfulTransactions = payments.filter((item) =>
+      this.isSuccessfulStatus(item.status),
+    ).length;
+    const failedTransactions = payments.filter((item) =>
+      this.isFailedStatus(item.status),
+    ).length;
+    const totalVolumeUsd = this.round2(
+      payments.reduce((sum, item) => sum + item.amountUsd, 0),
+    );
+    const conversionRate = totalTransactions
+      ? this.round2((successfulTransactions / totalTransactions) * 100)
+      : 0;
+
+    return {
+      totalTransactions,
+      successfulTransactions,
+      failedTransactions,
+      conversionRate,
+      totalVolumeUsd,
+      averageTransactionUsd: this.round2(
+        totalVolumeUsd / Math.max(totalTransactions, 1),
+      ),
+    };
+  }
+
+  private buildAssetDistribution(
+    payments: NormalizedPayment[],
+  ): AssetDistributionItem[] {
+    const map = new Map<string, { volume: number; count: number }>();
+    const totalVolume = payments.reduce((sum, item) => sum + item.amountUsd, 0);
+
+    payments.forEach((item) => {
+      const current = map.get(item.asset) ?? { volume: 0, count: 0 };
+      current.volume += item.amountUsd;
+      current.count += 1;
+      map.set(item.asset, current);
+    });
+
+    return Array.from(map.entries())
+      .map(([asset, value]) => ({
+        asset,
+        volumeUsd: this.round2(value.volume),
+        percentage: totalVolume > 0 ? this.round2((value.volume / totalVolume) * 100) : 0,
+        transactionCount: value.count,
+      }))
+      .sort((a, b) => b.volumeUsd - a.volumeUsd);
+  }
+
+  private buildTimeSeries(
+    payments: NormalizedPayment[],
+    interval: AnalyticsInterval,
+  ): TimeSeriesItem[] {
+    const buckets = new Map<
+      string,
+      { count: number; successful: number; volume: number; assets: Record<string, number> }
+    >();
+
+    payments.forEach((item) => {
+      const key = this.getBucketKey(item.createdAt, interval);
+      const current = buckets.get(key) ?? {
+        count: 0,
+        successful: 0,
+        volume: 0,
+        assets: {},
+      };
+      current.count += 1;
+      current.volume += item.amountUsd;
+      current.assets[item.asset] = (current.assets[item.asset] ?? 0) + item.amountUsd;
+      if (this.isSuccessfulStatus(item.status)) {
+        current.successful += 1;
+      }
+      buckets.set(key, current);
+    });
+
+    return Array.from(buckets.entries())
+      .map(([period, value]) => ({
+        period,
+        transactionCount: value.count,
+        successfulTransactions: value.successful,
+        volumeUsd: this.round2(value.volume),
+        assetVolumes: Object.fromEntries(
+          Object.entries(value.assets).map(([asset, volume]) => [
+            asset,
+            this.round2(volume),
+          ]),
+        ),
+      }))
+      .sort((a, b) => a.period.localeCompare(b.period));
+  }
+
+  private getBucketKey(createdAt: string, interval: AnalyticsInterval): string {
+    const date = new Date(createdAt);
+    if (Number.isNaN(date.getTime())) {
+      return createdAt;
+    }
+
+    if (interval === AnalyticsInterval.MONTHLY) {
+      return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+    }
+
+    if (interval === AnalyticsInterval.WEEKLY) {
+      const weekStart = new Date(Date.UTC(
+        date.getUTCFullYear(),
+        date.getUTCMonth(),
+        date.getUTCDate(),
+      ));
+      const day = weekStart.getUTCDay();
+      const mondayShift = day === 0 ? -6 : 1 - day;
+      weekStart.setUTCDate(weekStart.getUTCDate() + mondayShift);
+      return `${weekStart.getUTCFullYear()}-W${String(this.getIsoWeek(weekStart)).padStart(2, '0')}`;
+    }
+
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(
+      date.getUTCDate(),
+    ).padStart(2, '0')}`;
+  }
+
+  private getIsoWeek(date: Date): number {
+    const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+    const dayNum = utcDate.getUTCDay() || 7;
+    utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNum);
+    const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+    return Math.ceil((((utcDate.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
+  }
+
+  private isSuccessfulStatus(status: string): boolean {
+    return ['completed', 'paid', 'success', 'settled', 'confirmed'].includes(status);
+  }
+
+  private isFailedStatus(status: string): boolean {
+    return ['failed', 'error', 'cancelled', 'rejected'].includes(status);
+  }
+
+  private readString(row: PaymentRow, keys: string[]): string | null {
+    for (const key of keys) {
+      const value = row[key];
+      if (typeof value === 'string' && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+    return null;
+  }
+
+  private readNumber(row: PaymentRow, keys: string[]): number {
+    for (const key of keys) {
+      const value = row[key];
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+      }
+      if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed)) {
+          return parsed;
+        }
+      }
+    }
+    return 0;
+  }
+
+  private resolveDateWindow(startDate?: string, endDate?: string): { startIso: string; endIso: string } {
+    const end = endDate ? new Date(endDate) : new Date();
+    const start = startDate
+      ? new Date(startDate)
+      : new Date(end.getTime() - 90 * 24 * 60 * 60 * 1000);
+
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      throw new BadRequestException({
+        code: 'INVALID_DATE_RANGE',
+        message: 'startDate and endDate must be valid ISO-8601 strings',
+      });
+    }
+
+    if (start > end) {
+      throw new BadRequestException({
+        code: 'INVALID_DATE_RANGE',
+        message: 'startDate must be earlier than or equal to endDate',
+      });
+    }
+
+    return {
+      startIso: start.toISOString(),
+      endIso: end.toISOString(),
+    };
+  }
+
+  private escapeCsv(value: string): string {
+    if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+      return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
+  }
+
+  private createSimplePdf(lines: string[]): Buffer {
+    const safeLines = lines.map((line) => this.escapePdfText(line));
+    let content = 'BT\n/F1 11 Tf\n50 760 Td\n';
+    safeLines.forEach((line, index) => {
+      if (index > 0) {
+        content += '0 -16 Td\n';
+      }
+      content += `(${line}) Tj\n`;
+    });
+    content += 'ET';
+
+    const objects = [
+      '<< /Type /Catalog /Pages 2 0 R >>',
+      '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>',
+      '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+      `<< /Length ${Buffer.byteLength(content, 'utf8')} >>\nstream\n${content}\nendstream`,
+    ];
+
+    let pdf = '%PDF-1.4\n';
+    const offsets: number[] = [0];
+
+    objects.forEach((obj, index) => {
+      offsets[index + 1] = Buffer.byteLength(pdf, 'utf8');
+      pdf += `${index + 1} 0 obj\n${obj}\nendobj\n`;
+    });
+
+    const xrefOffset = Buffer.byteLength(pdf, 'utf8');
+    pdf += `xref\n0 ${objects.length + 1}\n`;
+    pdf += '0000000000 65535 f \n';
+
+    for (let i = 1; i <= objects.length; i += 1) {
+      pdf += `${String(offsets[i]).padStart(10, '0')} 00000 n \n`;
+    }
+
+    pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+    return Buffer.from(pdf, 'utf8');
+  }
+
+  private escapePdfText(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+  }
+
+  private round2(value: number): number {
+    return Math.round(value * 100) / 100;
+  }
+}

--- a/app/backend/src/analytics/analytics.service.unit.spec.ts
+++ b/app/backend/src/analytics/analytics.service.unit.spec.ts
@@ -1,0 +1,184 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SupabaseService } from '../supabase/supabase.service';
+import { AnalyticsInterval, ReportType } from './dto/analytics-query.dto';
+import { AnalyticsService } from './analytics.service';
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+
+  const sampleRows = [
+    {
+      created_at: '2026-04-01T10:00:00.000Z',
+      sender_public_key: 'GA1234567890123456789012345678901234567890123456789012345',
+      receiver_public_key: 'GB1234567890123456789012345678901234567890123456789012345',
+      amount: '10',
+      amount_usd: '10',
+      asset: 'USDC',
+      status: 'completed',
+    },
+    {
+      created_at: '2026-04-02T10:00:00.000Z',
+      sender_public_key: 'GB1234567890123456789012345678901234567890123456789012345',
+      receiver_public_key: 'GC1234567890123456789012345678901234567890123456789012345',
+      amount: '20',
+      amount_usd: '20',
+      asset_code: 'XLM',
+      status: 'failed',
+    },
+    {
+      created_at: '2026-04-03T10:00:00.000Z',
+      from_address: 'GB1234567890123456789012345678901234567890123456789012345',
+      to_address: 'GD1234567890123456789012345678901234567890123456789012345',
+      amount: '25',
+      amount_usd: '0',
+      asset: 'USDC',
+      status: 'paid',
+    },
+  ];
+
+  const queryBuilder: {
+    select: jest.Mock;
+    or: jest.Mock;
+    gte: jest.Mock;
+    lte: jest.Mock;
+    order: jest.Mock;
+  } = {
+    select: jest.fn(),
+    or: jest.fn(),
+    gte: jest.fn(),
+    lte: jest.fn(),
+    order: jest.fn(),
+  };
+
+  const mockClient = {
+    from: jest.fn(() => queryBuilder),
+    rpc: jest.fn(),
+  };
+
+  const mockSupabaseService = {
+    getClient: jest.fn(() => mockClient),
+  };
+
+  beforeEach(async () => {
+    queryBuilder.select.mockReturnValue(queryBuilder);
+    queryBuilder.or.mockReturnValue(queryBuilder);
+    queryBuilder.gte.mockReturnValue(queryBuilder);
+    queryBuilder.lte.mockReturnValue(queryBuilder);
+    queryBuilder.order.mockResolvedValue({ data: sampleRows, error: null });
+    mockClient.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'rpc not available' },
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsService,
+        { provide: SupabaseService, useValue: mockSupabaseService },
+      ],
+    }).compile();
+
+    service = module.get<AnalyticsService>(AnalyticsService);
+    jest.clearAllMocks();
+  });
+
+  it('builds summary and asset distribution correctly', async () => {
+    const report = await service.getAnalyticsReport(
+      'GB1234567890123456789012345678901234567890123456789012345',
+      '2026-04-01T00:00:00.000Z',
+      '2026-04-29T23:59:59.999Z',
+      AnalyticsInterval.DAILY,
+    );
+
+    expect(report.summary.totalTransactions).toBe(3);
+    expect(report.summary.successfulTransactions).toBe(2);
+    expect(report.summary.failedTransactions).toBe(1);
+    expect(report.summary.totalVolumeUsd).toBe(55);
+    expect(report.assetDistribution[0].asset).toBe('USDC');
+    expect(report.assetDistribution[0].volumeUsd).toBe(35);
+  });
+
+  it('generates weekly time-series buckets', async () => {
+    const report = await service.getAnalyticsReport(
+      'GB1234567890123456789012345678901234567890123456789012345',
+      '2026-04-01T00:00:00.000Z',
+      '2026-04-29T23:59:59.999Z',
+      AnalyticsInterval.WEEKLY,
+    );
+
+    expect(report.timeSeries.length).toBeGreaterThan(0);
+    expect(report.timeSeries[0].period).toMatch(/^\d{4}-W\d{2}$/);
+  });
+
+  it('builds csv and pdf exports', async () => {
+    const { report, payments } = await service.exportReport(
+      'GB1234567890123456789012345678901234567890123456789012345',
+      '2026-04-01T00:00:00.000Z',
+      '2026-04-29T23:59:59.999Z',
+      ReportType.ACCOUNTING,
+      AnalyticsInterval.MONTHLY,
+      200,
+    );
+
+    const csv = service.buildCsvReport(report, payments, ReportType.ACCOUNTING);
+    const pdf = service.buildPdfReport(report, payments, ReportType.ACCOUNTING);
+
+    expect(csv).toContain('summary_metric,value');
+    expect(csv).toContain('created_at,asset,amount,amount_usd,status');
+    expect(Buffer.isBuffer(pdf)).toBe(true);
+    expect(pdf.toString('utf8')).toContain('%PDF-1.4');
+  });
+
+  it('uses SQL RPC aggregation when available', async () => {
+    mockClient.rpc
+      .mockResolvedValueOnce({
+        data: [
+          {
+            total_transactions: 2,
+            successful_transactions: 2,
+            failed_transactions: 0,
+            conversion_rate: 100,
+            total_volume_usd: 300,
+            average_transaction_usd: 150,
+          },
+        ],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            asset: 'USDC',
+            volume_usd: 300,
+            percentage: 100,
+            transaction_count: 2,
+          },
+        ],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            period: '2026-04-01',
+            transaction_count: 2,
+            successful_transactions: 2,
+            volume_usd: 300,
+            volume_usdc: 300,
+            volume_xlm: 0,
+            asset_volumes: { USDC: 300 },
+          },
+        ],
+        error: null,
+      });
+
+    const report = await service.getAnalyticsReport(
+      'GB1234567890123456789012345678901234567890123456789012345',
+      '2026-04-01T00:00:00.000Z',
+      '2026-04-29T23:59:59.999Z',
+      AnalyticsInterval.DAILY,
+    );
+
+    expect(report.summary.totalVolumeUsd).toBe(300);
+    expect(report.assetDistribution[0].asset).toBe('USDC');
+    expect(report.timeSeries[0].assetVolumes.USDC).toBe(300);
+    expect(queryBuilder.select).not.toHaveBeenCalled();
+  });
+});

--- a/app/backend/src/analytics/dto/analytics-query.dto.ts
+++ b/app/backend/src/analytics/dto/analytics-query.dto.ts
@@ -1,0 +1,96 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsISO8601, IsNotEmpty, IsOptional, IsString, Matches } from 'class-validator';
+
+export enum AnalyticsInterval {
+  DAILY = 'daily',
+  WEEKLY = 'weekly',
+  MONTHLY = 'monthly',
+}
+
+export enum ReportFormat {
+  CSV = 'csv',
+  PDF = 'pdf',
+}
+
+export enum ReportType {
+  TAX = 'tax',
+  ACCOUNTING = 'accounting',
+}
+
+export class AnalyticsQueryDto {
+  @ApiProperty({
+    description: 'Stellar public key for the user whose payment analytics should be returned',
+    example: 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR',
+  })
+  @IsNotEmpty()
+  @IsString()
+  @Matches(/^G[A-Z2-7]{55}$/, { message: 'Invalid Stellar public key format' })
+  publicKey: string;
+
+  @ApiPropertyOptional({
+    description: 'Start date (inclusive) in ISO-8601 format',
+    example: '2026-01-01T00:00:00.000Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  startDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'End date (inclusive) in ISO-8601 format',
+    example: '2026-04-29T23:59:59.999Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  endDate?: string;
+}
+
+export class TimeSeriesQueryDto extends AnalyticsQueryDto {
+  @ApiPropertyOptional({
+    description: 'Time bucket for chart rendering',
+    enum: AnalyticsInterval,
+    default: AnalyticsInterval.DAILY,
+  })
+  @IsOptional()
+  @IsEnum(AnalyticsInterval)
+  interval: AnalyticsInterval = AnalyticsInterval.DAILY;
+}
+
+export class ExportReportQueryDto extends AnalyticsQueryDto {
+  @ApiPropertyOptional({
+    description: 'Export format',
+    enum: ReportFormat,
+    default: ReportFormat.CSV,
+  })
+  @IsOptional()
+  @IsEnum(ReportFormat)
+  format: ReportFormat = ReportFormat.CSV;
+
+  @ApiPropertyOptional({
+    description: 'Report type preset',
+    enum: ReportType,
+    default: ReportType.ACCOUNTING,
+  })
+  @IsOptional()
+  @IsEnum(ReportType)
+  reportType: ReportType = ReportType.ACCOUNTING;
+
+  @ApiPropertyOptional({
+    description: 'Time bucket used in the exported trend section',
+    enum: AnalyticsInterval,
+    default: AnalyticsInterval.MONTHLY,
+  })
+  @IsOptional()
+  @IsEnum(AnalyticsInterval)
+  interval: AnalyticsInterval = AnalyticsInterval.MONTHLY;
+
+  @ApiPropertyOptional({
+    description: 'Maximum transaction rows to include in the export',
+    example: 500,
+    default: 500,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  maxRows: number = 500;
+}
+

--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -34,6 +34,7 @@ import { SentryModule } from "./sentry";
 import { FiatRampsModule } from "./fiat-ramps/fiat-ramps.module";
 import { RefundsModule } from "./refunds/refunds.module";
 import { ExportsModule } from "./exports/exports.module";
+import { AnalyticsModule } from "./analytics/analytics.module";
 import { JobQueueModule } from "./job-queue/job-queue.module";
 import { AuditModule } from "./audit/audit.module";
 import { FeatureFlagsModule } from "./feature-flags/feature-flags.module";
@@ -74,6 +75,7 @@ type AppImport =
       MarketplaceModule,
       FiatRampsModule,
       RefundsModule,
+      AnalyticsModule,
       ExportsModule,
       JobQueueModule,
       AuditModule,

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -164,6 +164,7 @@ async function bootstrap() {
     .addTag("links", "Payment link validation and metadata endpoints")
     .addTag("transactions", "Stellar transaction and payment history")
     .addTag("scam-alerts", "Fraud detection and link scanning")
+    .addTag("analytics", "Dashboard analytics, time-series insights, and report exports")
     .addTag("metrics", "Application performance and health metrics")
     .addTag("stellar", "Verified assets, path preview, Soroban preflight")
     .addTag("developer", "Developer self-service: ping, webhook testing, key management, health score")

--- a/app/backend/supabase/migrations/20260429010000_create_analytics_rpc_functions.sql
+++ b/app/backend/supabase/migrations/20260429010000_create_analytics_rpc_functions.sql
@@ -1,0 +1,194 @@
+-- Analytics RPC functions for dashboard insights and financial exports (Issue #211)
+--
+-- Provides SQL-level aggregation for:
+-- 1) Summary metrics including conversion rate and total USD volume
+-- 2) Asset distribution percentages
+-- 3) Time-series buckets (daily, weekly, monthly) for charts
+
+-- ---------------------------------------------------------------------------
+-- Summary aggregation (USD equivalent + conversion rate)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION quickex_analytics_summary(
+  p_public_key TEXT,
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ
+)
+RETURNS TABLE (
+  total_transactions BIGINT,
+  successful_transactions BIGINT,
+  failed_transactions BIGINT,
+  conversion_rate NUMERIC,
+  total_volume_usd NUMERIC,
+  average_transaction_usd NUMERIC
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH filtered AS (
+    SELECT
+      COALESCE(amount_usd, amount::NUMERIC, 0) AS amount_usd_norm,
+      LOWER(COALESCE(status, 'unknown')) AS status_norm
+    FROM payment_records
+    WHERE
+      (sender_public_key = p_public_key OR receiver_public_key = p_public_key)
+      AND created_at >= p_start_date
+      AND created_at <= p_end_date
+  )
+  SELECT
+    COUNT(*)::BIGINT AS total_transactions,
+    COUNT(*) FILTER (
+      WHERE status_norm IN ('paid', 'completed', 'success', 'settled', 'confirmed')
+    )::BIGINT AS successful_transactions,
+    COUNT(*) FILTER (
+      WHERE status_norm IN ('failed', 'error', 'cancelled', 'rejected')
+    )::BIGINT AS failed_transactions,
+    COALESCE(
+      ROUND(
+        (
+          COUNT(*) FILTER (
+            WHERE status_norm IN ('paid', 'completed', 'success', 'settled', 'confirmed')
+          )::NUMERIC
+          / NULLIF(COUNT(*)::NUMERIC, 0)
+        ) * 100,
+        2
+      ),
+      0
+    ) AS conversion_rate,
+    COALESCE(ROUND(SUM(amount_usd_norm), 2), 0) AS total_volume_usd,
+    COALESCE(ROUND(AVG(amount_usd_norm), 2), 0) AS average_transaction_usd
+  FROM filtered;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Asset distribution aggregation
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION quickex_analytics_asset_distribution(
+  p_public_key TEXT,
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ
+)
+RETURNS TABLE (
+  asset TEXT,
+  volume_usd NUMERIC,
+  percentage NUMERIC,
+  transaction_count BIGINT
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH filtered AS (
+    SELECT
+      UPPER(COALESCE(asset, 'XLM')) AS asset_norm,
+      COALESCE(amount_usd, amount::NUMERIC, 0) AS amount_usd_norm
+    FROM payment_records
+    WHERE
+      (sender_public_key = p_public_key OR receiver_public_key = p_public_key)
+      AND created_at >= p_start_date
+      AND created_at <= p_end_date
+  ),
+  totals AS (
+    SELECT COALESCE(SUM(amount_usd_norm), 0) AS total_volume FROM filtered
+  )
+  SELECT
+    f.asset_norm AS asset,
+    ROUND(SUM(f.amount_usd_norm), 2) AS volume_usd,
+    COALESCE(
+      ROUND((SUM(f.amount_usd_norm) / NULLIF(t.total_volume, 0)) * 100, 2),
+      0
+    ) AS percentage,
+    COUNT(*)::BIGINT AS transaction_count
+  FROM filtered f
+  CROSS JOIN totals t
+  GROUP BY f.asset_norm, t.total_volume
+  ORDER BY volume_usd DESC;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Time-series aggregation (daily/weekly/monthly)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION quickex_analytics_time_series(
+  p_public_key TEXT,
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ,
+  p_interval TEXT DEFAULT 'daily'
+)
+RETURNS TABLE (
+  period TEXT,
+  transaction_count BIGINT,
+  successful_transactions BIGINT,
+  volume_usd NUMERIC,
+  volume_usdc NUMERIC,
+  volume_xlm NUMERIC,
+  asset_volumes JSONB
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH filtered AS (
+    SELECT
+      created_at,
+      UPPER(COALESCE(asset, 'XLM')) AS asset_norm,
+      COALESCE(amount_usd, amount::NUMERIC, 0) AS amount_usd_norm,
+      LOWER(COALESCE(status, 'unknown')) AS status_norm
+    FROM payment_records
+    WHERE
+      (sender_public_key = p_public_key OR receiver_public_key = p_public_key)
+      AND created_at >= p_start_date
+      AND created_at <= p_end_date
+  ),
+  bucketed AS (
+    SELECT
+      CASE
+        WHEN LOWER(p_interval) = 'monthly' THEN to_char(date_trunc('month', created_at), 'YYYY-MM')
+        WHEN LOWER(p_interval) = 'weekly' THEN to_char(date_trunc('week', created_at), 'IYYY-"W"IW')
+        ELSE to_char(date_trunc('day', created_at), 'YYYY-MM-DD')
+      END AS period_key,
+      asset_norm,
+      amount_usd_norm,
+      status_norm
+    FROM filtered
+  ),
+  grouped AS (
+    SELECT
+      period_key,
+      COUNT(*)::BIGINT AS tx_count,
+      COUNT(*) FILTER (
+        WHERE status_norm IN ('paid', 'completed', 'success', 'settled', 'confirmed')
+      )::BIGINT AS success_count,
+      ROUND(SUM(amount_usd_norm), 2) AS volume_total,
+      ROUND(SUM(amount_usd_norm) FILTER (WHERE asset_norm = 'USDC'), 2) AS vol_usdc,
+      ROUND(SUM(amount_usd_norm) FILTER (WHERE asset_norm = 'XLM'), 2) AS vol_xlm
+    FROM bucketed
+    GROUP BY period_key
+  ),
+  assets_per_period AS (
+    SELECT
+      period_key,
+      jsonb_object_agg(asset_norm, rounded_volume) AS asset_map
+    FROM (
+      SELECT
+        period_key,
+        asset_norm,
+        ROUND(SUM(amount_usd_norm), 2) AS rounded_volume
+      FROM bucketed
+      GROUP BY period_key, asset_norm
+    ) x
+    GROUP BY period_key
+  )
+  SELECT
+    g.period_key AS period,
+    g.tx_count AS transaction_count,
+    g.success_count AS successful_transactions,
+    COALESCE(g.volume_total, 0) AS volume_usd,
+    COALESCE(g.vol_usdc, 0) AS volume_usdc,
+    COALESCE(g.vol_xlm, 0) AS volume_xlm,
+    COALESCE(a.asset_map, '{}'::jsonb) AS asset_volumes
+  FROM grouped g
+  LEFT JOIN assets_per_period a
+    ON a.period_key = g.period_key
+  ORDER BY g.period_key ASC;
+$$;
+

--- a/app/frontend/src/components/AnalyticsDashboard.tsx
+++ b/app/frontend/src/components/AnalyticsDashboard.tsx
@@ -30,6 +30,7 @@ import type {
 } from "recharts/types/component/DefaultTooltipContent";
 import {
   fetchAnalytics,
+  exportAnalyticsReport,
   type DateRange,
   type AnalyticsData,
 } from "@/hooks/analyticsApi";
@@ -171,6 +172,9 @@ export default function AnalyticsDashboard() {
   const [range, setRange] = useState<DateRange>("30d");
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [reportType, setReportType] = useState<"accounting" | "tax">("accounting");
+  const [exporting, setExporting] = useState<"csv" | "pdf" | null>(null);
+  const [exportMessage, setExportMessage] = useState<string | null>(null);
 
   const load = useCallback((r: DateRange) => {
     setLoading(true);
@@ -183,6 +187,26 @@ export default function AnalyticsDashboard() {
   useEffect(() => {
     load(range);
   }, [range, load]);
+
+  useEffect(() => {
+    if (!exportMessage) return;
+    const timer = window.setTimeout(() => setExportMessage(null), 3200);
+    return () => window.clearTimeout(timer);
+  }, [exportMessage]);
+
+  const handleExport = useCallback(async (format: "csv" | "pdf") => {
+    setExporting(format);
+    setExportMessage(null);
+    try {
+      await exportAnalyticsReport(range, format, reportType);
+      setExportMessage(`${format.toUpperCase()} report generated.`);
+    } catch (error) {
+      console.error(error);
+      setExportMessage(`Failed to export ${format.toUpperCase()} report.`);
+    } finally {
+      setExporting(null);
+    }
+  }, [range, reportType]);
 
   const { summary, volume, txCount, assetDist } = data ?? {
     summary: null,
@@ -209,7 +233,41 @@ export default function AnalyticsDashboard() {
             Payment volume, transaction counts &amp; asset distribution
           </p>
         </div>
-        <DateRangeFilter active={range} onChange={setRange} />
+        <div className="flex flex-col gap-3 sm:items-end">
+          <DateRangeFilter active={range} onChange={setRange} />
+          <div className="flex items-center gap-2">
+            <select
+              value={reportType}
+              onChange={(event) =>
+                setReportType(event.target.value as "accounting" | "tax")
+              }
+              className="rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-xs font-black text-neutral-200"
+              aria-label="Select report type"
+            >
+              <option value="accounting">Accounting</option>
+              <option value="tax">Tax</option>
+            </select>
+            <button
+              type="button"
+              onClick={() => void handleExport("csv")}
+              disabled={exporting !== null}
+              className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-black text-neutral-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {exporting === "csv" ? "Exporting..." : "Export CSV"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleExport("pdf")}
+              disabled={exporting !== null}
+              className="rounded-lg border border-indigo-400/30 bg-indigo-500/10 px-3 py-1.5 text-xs font-black text-indigo-100 transition hover:bg-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {exporting === "pdf" ? "Exporting..." : "Export PDF"}
+            </button>
+          </div>
+          {exportMessage ? (
+            <p className="text-[11px] font-bold text-neutral-300">{exportMessage}</p>
+          ) : null}
+        </div>
       </div>
 
       <div className="p-6 sm:p-10 space-y-10">

--- a/app/frontend/src/hooks/analyticsApi.ts
+++ b/app/frontend/src/hooks/analyticsApi.ts
@@ -1,18 +1,10 @@
-import i18n from 'i18next';
-
-/**
- * analyticsApi.ts
- *
- * Mock data layer for the analytics dashboard (Issue #175).
- * Designed to be a drop-in replacement once the Wave 3 backend
- * analytics endpoints are live. Simply swap mockFetch() calls
- * for real fetch() calls to the same endpoint shape.
- */
+import i18n from "i18next";
+import { getQuickexApiBase } from "@/lib/api";
 
 export type DateRange = "24h" | "7d" | "30d" | "all";
 
 export interface VolumeDataPoint {
-  date: string; // ISO-8601 label
+  date: string;
   volumeUSDC: number;
   volumeXLM: number;
   total: number;
@@ -41,100 +33,236 @@ export interface AnalyticsData {
   };
 }
 
+type ApiTimeSeriesItem = {
+  period: string;
+  transactionCount: number;
+  successfulTransactions: number;
+  volumeUsd: number;
+  assetVolumes?: Record<string, number>;
+};
+
+type ApiReport = {
+  summary: {
+    totalTransactions: number;
+    successfulTransactions: number;
+    failedTransactions: number;
+    conversionRate: number;
+    totalVolumeUsd: number;
+    averageTransactionUsd: number;
+  };
+  assetDistribution: Array<{
+    asset: string;
+    volumeUsd: number;
+    percentage: number;
+    transactionCount: number;
+  }>;
+  timeSeries: ApiTimeSeriesItem[];
+};
+
 const analyticsCache: Partial<Record<DateRange, AnalyticsData>> = {};
+const DEFAULT_PUBLIC_KEY =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+const PUBLIC_KEY_STORAGE_CANDIDATES = [
+  "quickex.publicKey",
+  "quickex.walletPublicKey",
+  "walletPublicKey",
+  "publicKey",
+];
+const ASSET_COLORS: Record<string, string> = {
+  USDC: "#6366f1",
+  XLM: "#8b5cf6",
+};
 
-// ─── helpers ─────────────────────────────────────────────────────────────────
-
-function randomBetween(lo: number, hi: number) {
-  return Math.round(lo + Math.random() * (hi - lo));
-}
-
-function buildSeries(points: number, labelFn: (i: number) => string): VolumeDataPoint[] {
-  return Array.from({ length: points }, (_, i) => {
-    const usdc = randomBetween(200, 1800);
-    const xlm = randomBetween(80, 600);
-    return { date: labelFn(i), volumeUSDC: usdc, volumeXLM: xlm, total: usdc + xlm };
-  });
-}
-
-function toTx(series: VolumeDataPoint[]): TxCountDataPoint[] {
-  return series.map((d) => ({ date: d.date, count: randomBetween(4, 42) }));
-}
-
-// ─── data factories ───────────────────────────────────────────────────────────
-
-const now = new Date();
-
-function makeData(range: DateRange): Omit<AnalyticsData, "summary"> {
-  let volume: VolumeDataPoint[];
+function rangeToWindow(range: DateRange): {
+  startDate: string;
+  endDate: string;
+  interval: "daily" | "weekly" | "monthly";
+} {
+  const end = new Date();
+  const start = new Date(end);
+  let interval: "daily" | "weekly" | "monthly" = "daily";
 
   if (range === "24h") {
-    volume = buildSeries(24, (i) => `${String(i).padStart(2, "0")}:00`);
+    start.setHours(start.getHours() - 24);
+    interval = "daily";
   } else if (range === "7d") {
-    volume = buildSeries(7, (i) => {
-      const d = new Date(now);
-      d.setDate(d.getDate() - (6 - i));
-      return d.toLocaleDateString(i18n.language || "en", { weekday: "short" });
-    });
+    start.setDate(start.getDate() - 7);
+    interval = "daily";
   } else if (range === "30d") {
-    volume = buildSeries(30, (i) => {
-      const d = new Date(now);
-      d.setDate(d.getDate() - (29 - i));
-      return d.toLocaleDateString(i18n.language || "en", {
-        month: "numeric",
-        day: "numeric",
-      });
-    });
+    start.setDate(start.getDate() - 30);
+    interval = "daily";
   } else {
-    // all time — 12 months
-    volume = buildSeries(12, (i) => {
-      const d = new Date(now);
-      d.setMonth(d.getMonth() - (11 - i));
-      return d.toLocaleDateString(i18n.language || "en", { month: "short" });
-    });
+    start.setFullYear(start.getFullYear() - 1);
+    interval = "monthly";
   }
 
   return {
-    volume,
-    txCount: toTx(volume),
-    assetDist: [
-      { name: "USDC", value: randomBetween(48, 62), color: "#6366f1" },
-      { name: "XLM",  value: randomBetween(25, 35), color: "#8b5cf6" },
-      { name: "Other", value: randomBetween(5, 15), color: "#334155" },
-    ],
+    startDate: start.toISOString(),
+    endDate: end.toISOString(),
+    interval,
   };
 }
 
-// ─── public API ───────────────────────────────────────────────────────────────
+function resolveAnalyticsPublicKey(): string {
+  if (typeof window !== "undefined") {
+    for (const key of PUBLIC_KEY_STORAGE_CANDIDATES) {
+      const value = window.localStorage.getItem(key)?.trim();
+      if (value && PUBLIC_KEY_REGEX.test(value)) {
+        return value;
+      }
+    }
+  }
+
+  const fromEnv = process.env.NEXT_PUBLIC_QUICKEX_ANALYTICS_PUBLIC_KEY?.trim();
+  if (fromEnv && PUBLIC_KEY_REGEX.test(fromEnv)) {
+    return fromEnv;
+  }
+
+  return DEFAULT_PUBLIC_KEY;
+}
+
+function labelForPeriod(period: string): string {
+  const locale = i18n.language || "en";
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(period)) {
+    const d = new Date(`${period}T00:00:00.000Z`);
+    return d.toLocaleDateString(locale, { month: "numeric", day: "numeric" });
+  }
+
+  if (/^\d{4}-\d{2}$/.test(period)) {
+    const [year, month] = period.split("-");
+    const d = new Date(`${year}-${month}-01T00:00:00.000Z`);
+    return d.toLocaleDateString(locale, { month: "short" });
+  }
+
+  if (/^\d{4}-W\d{2}$/.test(period)) {
+    const [, week] = period.split("-W");
+    return `W${week}`;
+  }
+
+  return period;
+}
+
+function toUiModel(report: ApiReport): AnalyticsData {
+  const volume = report.timeSeries.map((item) => {
+    const volumeUSDC = item.assetVolumes?.USDC ?? 0;
+    const volumeXLM = item.assetVolumes?.XLM ?? 0;
+    return {
+      date: labelForPeriod(item.period),
+      volumeUSDC,
+      volumeXLM,
+      total: item.volumeUsd,
+    };
+  });
+
+  const txCount: TxCountDataPoint[] = report.timeSeries.map((item) => ({
+    date: labelForPeriod(item.period),
+    count: item.transactionCount,
+  }));
+
+  const assetDist: AssetSlice[] = report.assetDistribution
+    .slice()
+    .sort((a, b) => b.volumeUsd - a.volumeUsd)
+    .map((item, index) => ({
+      name: item.asset,
+      value: Number(item.percentage.toFixed(2)),
+      color: ASSET_COLORS[item.asset] ?? (index % 2 === 0 ? "#334155" : "#64748b"),
+    }));
+
+  return {
+    volume,
+    txCount,
+    assetDist,
+    summary: {
+      totalVolume: report.summary.totalVolumeUsd,
+      totalTx: report.summary.totalTransactions,
+      avgTxSize: report.summary.averageTransactionUsd,
+      changeVolumePercent: 0,
+    },
+  };
+}
+
+function fallbackEmpty(): AnalyticsData {
+  return {
+    volume: [],
+    txCount: [],
+    assetDist: [],
+    summary: {
+      totalVolume: 0,
+      totalTx: 0,
+      avgTxSize: 0,
+      changeVolumePercent: 0,
+    },
+  };
+}
 
 export async function fetchAnalytics(range: DateRange): Promise<AnalyticsData> {
   if (analyticsCache[range]) {
     return Promise.resolve(analyticsCache[range] as AnalyticsData);
   }
 
-  // Simulates network latency; replace body with real fetch when backend is ready:
-  // const res = await fetch(`/api/analytics?range=${range}`);
-  // const json = await res.json();
-  // return json as AnalyticsData;
-  await new Promise((r) => setTimeout(r, 600));
+  const publicKey = resolveAnalyticsPublicKey();
+  const { startDate, endDate, interval } = rangeToWindow(range);
+  const url = new URL(`${getQuickexApiBase()}/analytics/report`);
+  url.searchParams.set("publicKey", publicKey);
+  url.searchParams.set("startDate", startDate);
+  url.searchParams.set("endDate", endDate);
+  url.searchParams.set("interval", interval);
 
-  const { volume, txCount, assetDist } = makeData(range);
+  try {
+    const res = await fetch(url.toString(), { method: "GET" });
+    if (!res.ok) {
+      throw new Error(`Analytics request failed with status ${res.status}`);
+    }
+    const report = (await res.json()) as ApiReport;
+    const parsed = toUiModel(report);
+    analyticsCache[range] = parsed;
+    return parsed;
+  } catch (error) {
+    console.warn("Falling back to empty analytics data:", error);
+    const empty = fallbackEmpty();
+    analyticsCache[range] = empty;
+    return empty;
+  }
+}
 
-  const totalVolume = volume.reduce((s, d) => s + d.total, 0);
-  const totalTx = txCount.reduce((s, d) => s + d.count, 0);
+export async function exportAnalyticsReport(
+  range: DateRange,
+  format: "csv" | "pdf",
+  reportType: "tax" | "accounting" = "accounting",
+): Promise<void> {
+  const publicKey = resolveAnalyticsPublicKey();
+  const { startDate, endDate, interval } = rangeToWindow(range);
+  const url = new URL(`${getQuickexApiBase()}/analytics/export`);
+  url.searchParams.set("publicKey", publicKey);
+  url.searchParams.set("startDate", startDate);
+  url.searchParams.set("endDate", endDate);
+  url.searchParams.set("interval", interval);
+  url.searchParams.set("format", format);
+  url.searchParams.set("reportType", reportType);
 
-  const result = {
-    volume,
-    txCount,
-    assetDist,
-    summary: {
-      totalVolume,
-      totalTx,
-      avgTxSize: Math.round(totalVolume / Math.max(totalTx, 1)),
-      changeVolumePercent: parseFloat((Math.random() * 40 - 10).toFixed(1)),
-    },
-  };
+  const res = await fetch(url.toString(), { method: "GET" });
+  if (!res.ok) {
+    throw new Error(`Export request failed with status ${res.status}`);
+  }
 
-  analyticsCache[range] = result;
-  return result;
+  const blob = await res.blob();
+  const disposition = res.headers.get("Content-Disposition");
+  const fallbackName = `quickex-analytics-report.${format}`;
+  const fileName = parseFilename(disposition) ?? fallbackName;
+  const objectUrl = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = objectUrl;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.URL.revokeObjectURL(objectUrl);
+}
+
+function parseFilename(disposition: string | null): string | null {
+  if (!disposition) return null;
+  const match = /filename="?([^"]+)"?/i.exec(disposition);
+  return match?.[1] ?? null;
 }


### PR DESCRIPTION
Closes #211

## Summary
Implements Enhanced Dashboard Analytics & Reporting with SQL-backed aggregation and export support.

## What was added

### Backend analytics module
- Added `GET /analytics/report`
  - summary metrics (total tx, successful tx, failed tx, conversion rate)
  - total volume (USD equivalent)
  - average transaction size
  - asset distribution
  - time-series
- Added `GET /analytics/time-series`
  - supports `daily`, `weekly`, `monthly`
- Added `GET /analytics/assets`
  - asset distribution breakdown
- Added `GET /analytics/export`
  - supports `csv` and `pdf`
  - supports report presets: `accounting` and `tax`

### SQL aggregation (complex DB-side queries)
- Added Supabase migration:
  - `app/backend/supabase/migrations/20260429010000_create_analytics_rpc_functions.sql`
- Functions:
  - `quickex_analytics_summary`
  - `quickex_analytics_asset_distribution`
  - `quickex_analytics_time_series`
- Backend uses these RPC functions first, with service-level fallback when RPCs are unavailable.

### Frontend integration
- Replaced mock analytics fetching with live backend integration.
- Added export actions in analytics dashboard:
  - Export CSV
  - Export PDF
  - Report type selector (`accounting` / `tax`)

## Validation
- Backend lint: pass
- Backend tests (analytics unit): pass
- Backend build: pass
- Frontend lint: pass
- Frontend build: pass

## Notes for reviewers
- Please apply the new Supabase migration before testing analytics endpoints.
