### PR TITLE
fix: align Stellar asset whitelist with verified assets

### DIFF
--- a/app/backend/src/config/stellar.config.ts
+++ b/app/backend/src/config/stellar.config.ts
@@ -1,4 +1,5 @@
 import { registerAs } from '@nestjs/config';
+import { VERIFIED_STELLAR_ASSETS } from '../stellar/verified-assets.constant';
 
 export type Network = 'testnet' | 'mainnet';
 
@@ -33,19 +34,22 @@ export const NETWORK_ENV_KEY = 'STELLAR_NETWORK';
 export const DEFAULT_NETWORK: Network = 'testnet';
 
 export const USDC_ISSUER =
-  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2K34P4D5NXJ6Z4GJ5B7G';
+  VERIFIED_STELLAR_ASSETS.find((asset) => asset.code === 'USDC')?.issuer ?? '';
 
-export const SUPPORTED_ASSETS = [
-  {
-    type: 'native',
-    code: 'XLM',
-  },
-  {
-    type: 'credit_alphanum4',
-    code: 'USDC',
-    issuer: USDC_ISSUER,
-  },
-] as const satisfies readonly SupportedAsset[];
+export const SUPPORTED_ASSETS = VERIFIED_STELLAR_ASSETS.map((asset) => {
+  if (asset.type === 'native') {
+    return {
+      type: 'native',
+      code: 'XLM',
+    } as const;
+  }
+
+  return {
+    type: asset.type,
+    code: asset.code,
+    issuer: asset.issuer ?? '',
+  };
+}) satisfies readonly SupportedAsset[];
 
 export const HORIZON_BASE_URLS: Record<Network, string> = {
   testnet: 'https://horizon-testnet.stellar.org',
@@ -76,7 +80,12 @@ export class UnsupportedAssetError extends Error {
 }
 
 export function normalizeAssetCode(code: string): string {
-  return code.trim().toUpperCase();
+  const trimmed = code.trim();
+  const verified = VERIFIED_STELLAR_ASSETS.find(
+    (asset) => asset.code.toLowerCase() === trimmed.toLowerCase(),
+  );
+
+  return verified?.code ?? trimmed.toUpperCase();
 }
 
 export function normalizeAsset(input: AssetInput): NormalizedAsset {
@@ -92,7 +101,7 @@ export function normalizeAsset(input: AssetInput): NormalizedAsset {
   const issuer =
     type === 'native' || typeof input.issuer !== 'string'
       ? undefined
-      : input.issuer;
+      : input.issuer.trim();
 
   return {
     type,

--- a/app/backend/src/config/stellar.config.unit.spec.ts
+++ b/app/backend/src/config/stellar.config.unit.spec.ts
@@ -39,10 +39,38 @@ describe('stellar config', () => {
       );
     });
 
-    it('rejects issued assets with mismatched issuer', () => {
+    it('accepts every verified Stellar asset with its configured issuer', () => {
+      for (const asset of SUPPORTED_ASSETS) {
+        expect(isSupportedAsset(asset)).toBe(true);
+      }
+    });
+
+    it('normalizes mixed-case aliases to verified asset codes', () => {
+      const yxlm = SUPPORTED_ASSETS.find((asset) => asset.code === 'yXLM') as {
+        code: 'yXLM';
+        issuer: string;
+        type: 'credit_alphanum4';
+      };
+
       expect(
-        isSupportedAsset({ code: 'USDC', issuer: 'GBADISSUER' }),
-      ).toBe(false);
+        assertSupportedAsset({ code: 'yxlm', issuer: yxlm.issuer }),
+      ).toEqual(yxlm);
+    });
+
+    it('rejects issued assets with mismatched issuer', () => {
+      expect(isSupportedAsset({ code: 'USDC', issuer: 'GBADISSUER' })).toBe(
+        false,
+      );
+    });
+
+    it('rejects issued assets when the issuer is missing', () => {
+      expect(isSupportedAsset({ code: 'USDC' })).toBe(false);
+    });
+
+    it('trims issuer input before matching supported assets', () => {
+      expect(
+        isSupportedAsset({ code: 'USDC', issuer: ` ${USDC_ISSUER} ` }),
+      ).toBe(true);
     });
 
     it('rejects unknown asset codes', () => {


### PR DESCRIPTION
## Summary
- build backend supported assets from the verified Stellar asset registry
- preserve canonical asset casing for entries like yXLM while still accepting mixed-case input
- trim issuer input and cover verified assets, missing issuers, and issuer mismatches in config tests

## Checks
- npm test -- --runInBand src/config/stellar.config.unit.spec.ts
- npx eslint src/config/stellar.config.ts src/config/stellar.config.unit.spec.ts
- git diff --check

Closes #437