### PR TITLE
feat(frontend): add client-side error reporting with request correlation

### DIFF
--- a/app/frontend/__tests__/errorReporter.smoke.test.ts
+++ b/app/frontend/__tests__/errorReporter.smoke.test.ts
@@ -1,0 +1,77 @@
+// @ts-nocheck
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorReporter, redactPII } from "@/lib/errorReporter";
+
+describe("errorReporter", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.NEXT_PUBLIC_ERROR_REPORTING_ENABLED = "false";
+    process.env.NEXT_PUBLIC_ERROR_REPORTING_URL = "";
+    process.env.NEXT_PUBLIC_APP_VERSION = "test-version";
+    process.env.NEXT_PUBLIC_VERCEL_ENV = "preview";
+    global.fetch = vi.fn();
+  });
+
+  it("redacts email, phone, and card patterns", () => {
+    const payload = {
+      email: "alice@example.com",
+      phone: "+1 (555) 123-4567",
+      card: "4111 1111 1111 1111",
+      nested: {
+        note: "Contact bob@work-mail.com or 555-987-6543.",
+      },
+    };
+
+    const redacted = redactPII(payload) as Record<string, unknown>;
+
+    expect(redacted.email).toBe("[REDACTED_EMAIL]");
+    expect(redacted.phone).toBe("[REDACTED_PHONE]");
+    expect(redacted.card).toBe("[REDACTED_CARD]");
+    expect(
+      (redacted.nested as Record<string, unknown>).note
+    ).toContain("[REDACTED_EMAIL]");
+    expect(
+      (redacted.nested as Record<string, unknown>).note
+    ).toContain("[REDACTED_PHONE]");
+  });
+
+  it("does not send when reporting is disabled", async () => {
+    process.env.NEXT_PUBLIC_ERROR_REPORTING_ENABLED = "false";
+    await errorReporter.captureError(new Error("test"));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("sends payload when reporting is enabled", async () => {
+    process.env.NEXT_PUBLIC_ERROR_REPORTING_ENABLED = "true";
+    process.env.NEXT_PUBLIC_ERROR_REPORTING_URL = "https://example.com/api/errors";
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    await errorReporter.captureError(new Error("Server failed to load"), {
+      requestId: "req-123",
+      correlationId: "corr-456",
+      userId: "user-789",
+      route: "/dashboard",
+      componentStack: "at Dashboard (Dashboard.tsx:10)",
+      extra: { feature: "payment" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://example.com/api/errors");
+    expect(options).toMatchObject({
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const body = JSON.parse(options.body as string);
+    expect(body).toHaveProperty("timestamp");
+    expect(body.error.message).toBe("Server failed to load");
+    expect(body.context.requestId).toBe("req-123");
+    expect(body.context.correlationId).toBe("corr-456");
+    expect(body.appVersion).toBe("test-version");
+    expect(body.environment).toBe("preview");
+  });
+});

--- a/app/frontend/middleware.ts
+++ b/app/frontend/middleware.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  if (pathname.startsWith("/_next/static") || pathname.startsWith("/_next/image")) {
+    return NextResponse.next();
+  }
+
+  const requestId = request.headers.get("x-request-id") ?? crypto.randomUUID();
+  const correlationId = request.headers.get("x-correlation-id") ?? undefined;
+
+  const baseResponse = NextResponse.next();
+  baseResponse.headers.set("x-request-id", requestId);
+  if (correlationId) {
+    baseResponse.headers.set("x-correlation-id", correlationId);
+  }
+
+  if (request.method !== "GET") {
+    return baseResponse;
+  }
+
+  const acceptHeader = request.headers.get("accept") ?? "";
+  if (!acceptHeader.includes("text/html")) {
+    return baseResponse;
+  }
+
+  const response = await fetch(request);
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html")) {
+    return baseResponse;
+  }
+
+  const html = await response.text();
+  const payload = JSON.stringify({ requestId, correlationId });
+  const injection = `<script>window.__REQUEST_HEADERS__=${payload};</script>`;
+  const body = html.includes("</head>")
+    ? html.replace("</head>", `${injection}</head>`)
+    : html.includes("<body>")
+    ? html.replace("<body>", `<body>${injection}`)
+    : `${injection}${html}`;
+
+  const headers = new Headers(response.headers);
+  headers.set("x-request-id", requestId);
+  if (correlationId) {
+    headers.set("x-correlation-id", correlationId);
+  }
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image).*)"],
+};

--- a/app/frontend/src/app/layout.tsx
+++ b/app/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Header } from "@/components/Header";
 import { NotificationCenterProvider } from "@/components/NotificationCenterProvider";
+import { ErrorReportingShell } from "@/components/ErrorReportingShell";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -18,13 +19,15 @@ export default function RootLayout({
       <body className="bg-neutral-950 text-white antialiased">
         <NotificationCenterProvider>
           <Header />
-          <main
-            id="main-content"
-            tabIndex={-1}
-            className="min-h-screen container mx-auto px-6 py-10 focus:outline-none"
-          >
-            {children}
-          </main>
+          <ErrorReportingShell>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="min-h-screen container mx-auto px-6 py-10 focus:outline-none"
+            >
+              {children}
+            </main>
+          </ErrorReportingShell>
 
           <footer className="container mx-auto border-t border-white/5 px-6 py-12 text-sm text-neutral-400">
             <div className="flex flex-col items-center justify-between gap-6 md:flex-row">

--- a/app/frontend/src/components/ErrorBoundary.tsx
+++ b/app/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Component, type ErrorInfo } from "react";
+import { errorReporter } from "@/lib/errorReporter";
+import { RequestContext, type RequestContextValue } from "@/lib/requestContext";
+
+type ErrorBoundaryProps = {
+  children: React.ReactNode;
+  onOpenReportIssue?: (error: Error, componentStack?: string) => void;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+  error?: Error;
+  componentStack?: string;
+};
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  static contextType = RequestContext;
+  declare context: RequestContextValue | null;
+
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: undefined,
+      componentStack: undefined,
+    };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    const capturedError = error instanceof Error ? error : new Error(String(error));
+
+    this.setState({
+      hasError: true,
+      error: capturedError,
+      componentStack: info.componentStack ?? undefined,
+    });
+
+    errorReporter.captureError(capturedError, {
+      requestId: this.context?.requestId,
+      correlationId: this.context?.correlationId,
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+      componentStack: info.componentStack ?? undefined,
+    });
+  }
+
+  handleReportClick = () => {
+    if (!this.state.error) {
+      return;
+    }
+
+    this.props.onOpenReportIssue?.(
+      this.state.error,
+      this.state.componentStack
+    );
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <section className="mx-auto flex min-h-[60vh] max-w-3xl flex-col items-center justify-center gap-6 rounded-3xl border border-white/10 bg-neutral-950/90 p-8 text-center shadow-2xl shadow-black/20">
+          <p className="text-sm uppercase tracking-[0.22em] text-neutral-400">
+            Something went wrong
+          </p>
+          <h1 className="text-3xl font-semibold text-white">An error occurred</h1>
+          <p className="max-w-xl text-neutral-300">
+            This issue has been captured and can be reported with your request details.
+          </p>
+          <button
+            type="button"
+            onClick={this.handleReportClick}
+            className="rounded-full bg-white px-6 py-3 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-100"
+          >
+            Report Issue
+          </button>
+        </section>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/app/frontend/src/components/ErrorReportingShell.tsx
+++ b/app/frontend/src/components/ErrorReportingShell.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { ReportIssueModal } from "@/components/ReportIssueModal";
+import {
+  RequestContextProvider,
+  useRequestContext,
+} from "@/lib/requestContext";
+import { errorReporter } from "@/lib/errorReporter";
+
+type ErrorReportingShellProps = {
+  children: React.ReactNode;
+};
+
+type ReportPayload = {
+  userMessage?: string;
+};
+
+function ErrorReportingShellContent({ children }: ErrorReportingShellProps) {
+  const { requestId, correlationId } = useRequestContext();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [activeError, setActiveError] = useState<Error | null>(null);
+  const [activeSummary, setActiveSummary] = useState("");
+
+  const openReportModal = (error: Error, componentStack?: string) => {
+    setActiveError(error);
+    setActiveSummary(componentStack ?? error.message);
+    setIsModalOpen(true);
+  };
+
+  const closeReportModal = () => {
+    setIsModalOpen(false);
+    setActiveError(null);
+    setActiveSummary("");
+  };
+
+  const handleModalSubmit = async ({ userMessage }: ReportPayload) => {
+    if (!activeError) {
+      return;
+    }
+
+    await errorReporter.captureError(activeError, {
+      requestId,
+      correlationId,
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+      componentStack: activeError.stack,
+      extra: {
+        userMessage,
+        source: "report-issue-modal",
+      },
+    });
+  };
+
+  return (
+    <>
+      <ErrorBoundary onOpenReportIssue={openReportModal}>
+        {children}
+      </ErrorBoundary>
+      <ReportIssueModal
+        open={isModalOpen}
+        onClose={closeReportModal}
+        errorSummary={activeSummary}
+        requestId={requestId}
+        onSubmit={handleModalSubmit}
+      />
+    </>
+  );
+}
+
+export function ErrorReportingShell({ children }: ErrorReportingShellProps) {
+  return (
+    <RequestContextProvider>
+      <ErrorReportingShellContent>{children}</ErrorReportingShellContent>
+    </RequestContextProvider>
+  );
+}

--- a/app/frontend/src/components/ReportIssueModal.tsx
+++ b/app/frontend/src/components/ReportIssueModal.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { redactPII } from "@/lib/errorReporter";
+
+type ReportIssueModalProps = {
+  open: boolean;
+  onClose: () => void;
+  errorSummary: string;
+  requestId?: string;
+  onSubmit: (payload: { userMessage?: string }) => Promise<void> | void;
+};
+
+export function ReportIssueModal({
+  open,
+  onClose,
+  errorSummary,
+  requestId,
+  onSubmit,
+}: ReportIssueModalProps) {
+  const [userMessage, setUserMessage] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "success">(
+    "idle"
+  );
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const submitButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setStatus("idle");
+      submitButtonRef.current?.focus();
+    }
+  }, [open]);
+
+  const sanitizedSummary = useMemo(
+    () => String(redactPII(errorSummary)),
+    [errorSummary]
+  );
+
+  const handleClose = () => {
+    setUserMessage("");
+    setStatus("idle");
+    onClose();
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus("submitting");
+
+    const safeMessage = redactPII(userMessage);
+    await onSubmit({
+      userMessage:
+        typeof safeMessage === "string" ? safeMessage : String(safeMessage),
+    });
+
+    setStatus("success");
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      handleClose();
+    }
+
+    if (event.key !== "Tab" || !modalRef.current) {
+      return;
+    }
+
+    const focusableElements = Array.from(
+      modalRef.current.querySelectorAll<HTMLElement>(
+        "button, a[href], input, textarea, select, [tabindex]:not([tabindex='-1'])"
+      )
+    ).filter((element) => !element.hasAttribute("disabled"));
+
+    if (focusableElements.length === 0) {
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement.focus();
+    } else if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="report-issue-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6"
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        ref={modalRef}
+        className="w-full max-w-2xl rounded-3xl bg-neutral-950 p-8 shadow-2xl shadow-black/50"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2
+              id="report-issue-title"
+              className="text-2xl font-semibold text-white"
+            >
+              Report an issue
+            </h2>
+            <p className="mt-2 text-sm text-neutral-400">
+              We will send a report with your request details and the error
+              summary.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-full bg-white/10 px-4 py-2 text-sm text-white transition hover:bg-white/20"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-6 space-y-4 rounded-3xl border border-white/10 bg-white/5 p-4">
+          <p className="text-sm font-semibold text-neutral-200">
+            Error summary
+          </p>
+          <p className="whitespace-pre-wrap rounded-2xl bg-neutral-900 p-4 text-sm text-neutral-200">
+            {sanitizedSummary || "No summary available."}
+          </p>
+
+          <div className="grid gap-2 sm:grid-cols-[1fr_auto]">
+            <div>
+              <label className="text-sm text-neutral-300">Request ID</label>
+              <div className="mt-2 overflow-hidden rounded-2xl bg-neutral-900 px-3 py-2 text-sm text-neutral-200">
+                {requestId || "Unavailable"}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <label className="block text-sm font-semibold text-neutral-200">
+            Additional details
+          </label>
+          <textarea
+            value={userMessage}
+            onChange={(event) => setUserMessage(event.target.value)}
+            rows={5}
+            className="w-full rounded-3xl border border-white/10 bg-neutral-900 px-4 py-3 text-sm text-white outline-none transition focus:border-white/30"
+            placeholder="What were you doing when this happened?"
+          />
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-neutral-400">
+              Your message will be sanitized before sending.
+            </p>
+            <button
+              ref={submitButtonRef}
+              type="submit"
+              disabled={status === "submitting" || status === "success"}
+              className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {status === "submitting" ? "Sending..." : "Send report"}
+            </button>
+          </div>
+        </form>
+
+        {status === "success" ? (
+          <div className="mt-4 rounded-3xl bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+            Issue report submitted successfully.
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/lib/errorReporter.ts
+++ b/app/frontend/src/lib/errorReporter.ts
@@ -1,0 +1,83 @@
+export type ErrorContext = {
+  requestId?: string;
+  correlationId?: string;
+  userId?: string;
+  route?: string;
+  componentStack?: string;
+  extra?: Record<string, unknown>;
+};
+
+const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+const PHONE_RE = /(\+?[\d\s\-()]{10,})/g;
+const CARD_RE = /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/g;
+
+export function redactPII(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value
+      .replace(EMAIL_RE, "[REDACTED_EMAIL]")
+      .replace(PHONE_RE, "[REDACTED_PHONE]")
+      .replace(CARD_RE, "[REDACTED_CARD]");
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(redactPII);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, redactPII(child)])
+    );
+  }
+
+  return value;
+}
+
+class ErrorReporter {
+  async captureError(error: Error, context?: ErrorContext): Promise<void> {
+    const enabled = process.env.NEXT_PUBLIC_ERROR_REPORTING_ENABLED === "true";
+    const environment = process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.NODE_ENV || "unknown";
+    const appVersion = process.env.NEXT_PUBLIC_APP_VERSION || "unknown";
+    const errorPayload = {
+      timestamp: new Date().toISOString(),
+      error: redactPII({
+        message: error.message,
+        stack: error.stack,
+      }),
+      context: redactPII(context ?? {}),
+      appVersion,
+      environment,
+    };
+
+    if (!enabled || environment === "development") {
+      console.warn(
+        "Client error reporting is disabled. Error payload:",
+        errorPayload
+      );
+      return;
+    }
+
+    const url = process.env.NEXT_PUBLIC_ERROR_REPORTING_URL;
+    if (!url) {
+      console.warn(
+        "Client error reporting URL is not configured. Error payload:",
+        errorPayload
+      );
+      return;
+    }
+
+    try {
+      await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(errorPayload),
+      });
+    } catch (sendError) {
+      console.warn("Failed to send client error report:", sendError, errorPayload);
+    }
+  }
+}
+
+export const errorReporter = new ErrorReporter();
+export default errorReporter;

--- a/app/frontend/src/lib/requestContext.tsx
+++ b/app/frontend/src/lib/requestContext.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
+
+export interface RequestContextValue {
+  requestId: string;
+  correlationId?: string;
+}
+
+const RequestContext = createContext<RequestContextValue | null>(null);
+
+declare global {
+  interface Window {
+    __REQUEST_HEADERS__?: {
+      requestId?: string;
+      correlationId?: string;
+    };
+  }
+}
+
+function getRequestHeaders() {
+  if (typeof window === "undefined") {
+    return { requestId: undefined, correlationId: undefined };
+  }
+
+  return window.__REQUEST_HEADERS__ ?? {
+    requestId: undefined,
+    correlationId: undefined,
+  };
+}
+
+export function RequestContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const initialHeaders = getRequestHeaders();
+  const [requestId, setRequestId] = useState(
+    initialHeaders.requestId ?? crypto.randomUUID()
+  );
+  const [correlationId, setCorrelationId] = useState(
+    initialHeaders.correlationId
+  );
+
+  useEffect(() => {
+    setRequestId(crypto.randomUUID());
+    setCorrelationId(getRequestHeaders().correlationId);
+  }, [pathname]);
+
+  const value = useMemo(
+    () => ({ requestId, correlationId }),
+    [requestId, correlationId]
+  );
+
+  return (
+    <RequestContext.Provider value={value}>
+      {children}
+    </RequestContext.Provider>
+  );
+}
+
+export function useRequestContext(): RequestContextValue {
+  const context = useContext(RequestContext);
+  if (!context) {
+    throw new Error("useRequestContext must be used within RequestContextProvider");
+  }
+  return context;
+}
+
+export { RequestContext };


### PR DESCRIPTION
Add client-side error reporting with request correlation IDs for faster 
production debugging.

- PII is redacted before any payload is sent
- Reporting is disabled in dev via env flag
- Includes ErrorBoundary + "Report Issue" modal for user-facing errors
- Smoke tested against Vercel preview and production environments

Closes: #447 