### PR TITLE
feat: implement mobile release pipeline for internal testing builds

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,0 +1,104 @@
+name: Mobile Release Pipeline
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      runMatrix:
+        description: 'Build dev, staging, and production internal artifacts'
+        required: false
+        default: 'true'
+
+jobs:
+  production-release:
+    if: github.event_name == 'push'
+    name: Production Release Tag Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/mobile
+    strategy:
+      matrix:
+        platform: [android, ios]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Lint and type-check
+        run: pnpm run build
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli@latest
+
+      - name: Authenticate EAS
+        env:
+          EAS_TOKEN: ${{ secrets.EAS_TOKEN }}
+        run: eas login --token "$EAS_TOKEN"
+
+      - name: Build production internal artifact
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+          GIT_TAG: ${{ github.ref_name }}
+        run: |
+          eas build --platform ${{ matrix.platform }} --profile production --non-interactive
+
+  environment-matrix:
+    if: github.event_name == 'workflow_dispatch'
+    name: Environment Matrix Internal Builds
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/mobile
+    strategy:
+      matrix:
+        platform: [android, ios]
+        app_env: [dev, staging, production]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Lint and type-check
+        run: pnpm run build
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli@latest
+
+      - name: Authenticate EAS
+        env:
+          EAS_TOKEN: ${{ secrets.EAS_TOKEN }}
+        run: eas login --token "$EAS_TOKEN"
+
+      - name: Build internal artifact
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+          GIT_TAG: ${{ github.ref_name }}
+        run: |
+          eas build --platform ${{ matrix.platform }} --profile ${{ matrix.app_env }} --non-interactive

--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ Deployment is automated for most components, but requires platform-specific conf
 
 2. **Mobile (Expo)**:
    - Install Expo CLI if needed: `npm install -g @expo/cli`.
-   - From `app/mobile`: `expo publish` for over-the-air updates, or build via `expo build:ios` / `expo build:android`.
-   - Use Expo's dashboard to manage credentials and submissions to app stores.
+   - For internal testing builds, use EAS and the GitHub workflow defined in `./.github/workflows/mobile-release.yml`.
+   - From `app/mobile`: run `npx eas build --profile production --platform android` or `npx eas build --profile production --platform ios` when credentials are configured.
+   - Ensure `EAS_TOKEN` is stored in GitHub secrets and not exposed in logs.
 
 3. **Contracts (Soroban)**:
    - Build and deploy via CI/CD (e.g., GitHub Actions in `app/contract`).

--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -48,6 +48,15 @@ Run unit tests:
 pnpm --filter=mobile test
 ```
 
+## Internal Release Builds
+
+Internal testing builds for Android and iOS are produced using EAS. The pipeline is configured in `./.github/workflows/mobile-release.yml` and supports `dev`, `staging`, and `production` build profiles.
+
+- Ensure `EAS_TOKEN` is set in the repository secrets.
+- Release tags matching `v*` generate production internal artifacts automatically.
+- Build metadata and environment labels are surfaced in the app Settings screen.
+- For release readiness and privacy review, see `RELEASE_CHECKLIST.md`.
+
 ## Universal Links / App Links
 
 QuickEx deep-link verification files now live in:

--- a/app/mobile/RELEASE_CHECKLIST.md
+++ b/app/mobile/RELEASE_CHECKLIST.md
@@ -1,0 +1,34 @@
+# Mobile Release Checklist
+
+This checklist supports the internal testing build pipeline for QuickEx Mobile.
+
+## Release Pipeline
+- [ ] Verify `.github/workflows/mobile-release.yml` exists and triggers on release tags `v*`
+- [ ] Ensure `EAS_TOKEN` is configured in GitHub repository secrets
+- [ ] Confirm `app/mobile/eas.json` contains `dev`, `staging`, and `production` internal build profiles
+- [ ] Confirm build job does not print secrets or credentials in logs
+
+## Build Metadata
+- [ ] Confirm the app shows version and build metadata in Settings
+- [ ] Confirm the app displays the selected build environment (`dev`, `staging`, `production`)
+- [ ] Confirm the app displays the target network (`testnet` or `mainnet`)
+- [ ] On release tags, make sure production builds are generated for both Android and iOS
+
+## Permissions
+- [ ] Camera permission only for QR scanning
+- [ ] Local authentication permission only for wallet protection and unlocking secure data
+- [ ] Notifications permission only for push and badge updates
+- [ ] Background fetch permission only for sync activity and not for unnecessary telemetry
+
+## Privacy Review
+- [ ] No sensitive keys or secrets are embedded in mobile builds
+- [ ] Supabase anonymous keys are used only for public requests and not for private data
+- [ ] Wallet keys remain on-device and are never transmitted to backend services
+- [ ] Data transmitted over the network is encrypted and sent only to approved endpoints
+- [ ] User transaction history is treated as private and not shared with third parties without consent
+
+## QA Verification
+- [ ] Install internal build on Android and verify the correct environment shows in-app
+- [ ] Install internal build on iOS and verify the correct environment and network display
+- [ ] Verify the release tag or build metadata is visible if present
+- [ ] Confirm the app behaves normally in the selected network environment

--- a/app/mobile/app.config.ts
+++ b/app/mobile/app.config.ts
@@ -1,0 +1,31 @@
+import appJson from './app.json';
+
+const defaultEnvironment = process.env.CI ? 'production' : 'dev';
+const appEnv = process.env.APP_ENV ?? defaultEnvironment;
+const stellarNetwork = process.env.STELLAR_NETWORK ?? (appEnv === 'production' ? 'mainnet' : 'testnet');
+const buildNumber = process.env.BUILD_NUMBER ?? process.env.GITHUB_RUN_NUMBER ?? '1';
+const androidVersionCode = Number(process.env.ANDROID_VERSION_CODE ?? buildNumber);
+const buildTag = process.env.GIT_TAG ?? process.env.GITHUB_REF_NAME ?? '';
+
+export default ({ config }: { config: any }) => ({
+  ...appJson,
+  expo: {
+    ...appJson.expo,
+    extra: {
+      ...appJson.expo.extra,
+      environment: appEnv,
+      stellarNetwork,
+      buildNumber,
+      buildTag,
+      appVersion: appJson.expo.version,
+    },
+    ios: {
+      ...appJson.expo.ios,
+      buildNumber,
+    },
+    android: {
+      ...appJson.expo.android,
+      versionCode: androidVersionCode,
+    },
+  },
+});

--- a/app/mobile/app/settings.tsx
+++ b/app/mobile/app/settings.tsx
@@ -20,6 +20,13 @@ import {
   type SyncFrequency,
 } from "../services/background-sync";
 import { useTheme } from "../src/theme/ThemeContext";
+import {
+  APP_ENVIRONMENT,
+  APP_VERSION,
+  BUILD_METADATA,
+  BUILD_TAG,
+  STELLAR_NETWORK,
+} from "../src/config/build";
 
 const FREQUENCY_OPTIONS: Array<{
   value: SyncFrequency;
@@ -286,8 +293,54 @@ export default function SettingsScreen() {
           </View>
         </View>
 
+        <View
+          style={[
+            styles.card,
+            { backgroundColor: theme.surface, borderColor: theme.border },
+          ]}
+        >
+          <Text style={[styles.cardTitle, { color: theme.textPrimary }]}>Build Info</Text>
+
+          <View style={styles.row}>
+            <Text style={[styles.label, { color: theme.textPrimary }]}>Version</Text>
+            <Text style={[styles.helper, { color: theme.textMuted }]}> 
+              {APP_VERSION}
+            </Text>
+          </View>
+
+          <View style={styles.row}>
+            <Text style={[styles.label, { color: theme.textPrimary }]}>Build</Text>
+            <Text style={[styles.helper, { color: theme.textMuted }]}> 
+              {BUILD_METADATA}
+            </Text>
+          </View>
+
+          <View style={styles.row}>
+            <Text style={[styles.label, { color: theme.textPrimary }]}>Environment</Text>
+            <Text style={[styles.helper, { color: theme.textMuted }]}> 
+              {APP_ENVIRONMENT}
+            </Text>
+          </View>
+
+          <View style={styles.row}>
+            <Text style={[styles.label, { color: theme.textPrimary }]}>Network</Text>
+            <Text style={[styles.helper, { color: theme.textMuted }]}> 
+              {STELLAR_NETWORK}
+            </Text>
+          </View>
+
+          {BUILD_TAG ? (
+            <View style={styles.row}>
+              <Text style={[styles.label, { color: theme.textPrimary }]}>Tag</Text>
+              <Text style={[styles.helper, { color: theme.textMuted }]}> 
+                {BUILD_TAG}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+
         <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: theme.textPrimary }]}>
+          <Text style={[styles.sectionTitle, { color: theme.textPrimary }]}> 
             Onboarding
           </Text>
           <OnboardingResetButton />

--- a/app/mobile/eas.json
+++ b/app/mobile/eas.json
@@ -1,0 +1,46 @@
+{
+  "cli": {
+    "version": ">= 3.49.0"
+  },
+  "build": {
+    "dev": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": false
+      },
+      "env": {
+        "APP_ENV": "dev",
+        "STELLAR_NETWORK": "testnet"
+      }
+    },
+    "staging": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": false
+      },
+      "env": {
+        "APP_ENV": "staging",
+        "STELLAR_NETWORK": "testnet"
+      }
+    },
+    "production": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": false
+      },
+      "env": {
+        "APP_ENV": "production",
+        "STELLAR_NETWORK": "mainnet"
+      }
+    }
+  }
+}

--- a/app/mobile/src/config/build.ts
+++ b/app/mobile/src/config/build.ts
@@ -1,0 +1,12 @@
+import Constants from 'expo-constants';
+
+const extra = Constants.expoConfig?.extra ?? {};
+
+export const APP_VERSION = String(Constants.expoConfig?.version ?? extra.appVersion ?? '1.0.0');
+export const BUILD_NUMBER = String(
+  extra.buildNumber ?? Constants.nativeBuildVersion ?? '1'
+);
+export const BUILD_TAG = String(extra.buildTag ?? '');
+export const APP_ENVIRONMENT = String(extra.environment ?? 'production');
+export const STELLAR_NETWORK = String(extra.stellarNetwork ?? 'mainnet');
+export const BUILD_METADATA = `${APP_VERSION}+${BUILD_NUMBER}`;

--- a/test.md
+++ b/test.md
@@ -1,0 +1,199 @@
+## README FILE
+
+QuickEx
+quickex no-bg (1)
+
+QuickEx is a fast, privacy-focused payment link platform built on the Stellar blockchain. It enables users to create unique, shareable usernames (e.g., quickex.to/yourname) and generate instant payment requests for USDC, XLM, or any Stellar asset. Payments can be received via QR code or direct wallet integration—no apps required—leveraging Stellar's sub-second settlements and optional X-Ray privacy for shielded transactions (mainnet now live). With low fees (<0.01¢), it's designed for instant, borderless transfers.
+
+This tool is ideal for freelancers invoicing clients, creators accepting tips, individuals handling remittances, or anyone facilitating global P2P payments. Whether you're a solo developer sharing a quick link for a gig or a small business streamlining donations, QuickEx prioritises simplicity, self-custody, and security without intermediaries.
+Features
+Core
+
+    Unique Username Links: Claim a permanent quickex.to/yourname for easy sharing.
+    One-Click Link Generator: Specify amount, memo, and privacy settings to create links like quickex.to/yourname/50.
+    QR Code & Wallet Integration: Auto-opens Freighter or Lobstr for seamless payments.
+    Real-Time Dashboard: Tracks earnings, history, and totals via Horizon API.
+
+Privacy & Security
+
+    X-Ray Privacy Toggle: Uses ZK proofs to hide amounts/senders (testnet ready; mainnet live since January 22, 2026).
+    Scam Alerts: Flags suspicious links (e.g., no memo or unusual patterns).
+    Self-Custody: Funds route directly to your wallet—no central holding.
+
+Advanced (v2+)
+
+    Multi-asset support with auto-swap.
+    Recurring/subscription links.
+    Fiat on/off-ramps (MoneyGram, Banxa).
+    Notifications (email/Telegram).
+
+Tech Stack
+
+    Frontend: Next.js 15, Tailwind CSS, Vercel hosting.
+    Backend: Next.js API routes (or dedicated Node.js/Express), Supabase (usernames), Horizon API (transactions).
+    Mobile: React Native (for iOS/Android apps).
+    Blockchain: Stellar SDK, Soroban (Rust contracts for privacy/escrow).
+    Wallet: Freighter/Lobstr via WalletConnect.
+    Monorepo: TurboRepo for shared packages (UI components, Stellar utils).
+
+Repository Structure
+
+QuickEx uses a monorepo for efficient development across apps and shared libraries. The structure features an app/ parent folder containing the core application directories (frontend, backend, mobile, contract), with shared packages for reusability. This setup allows for streamlined builds, testing, and dependency management via TurboRepo.
+
+quickex/
+├── app/
+│   ├── frontend/          # Next.js app (web dashboard and link generator)
+│   ├── backend/           # API server (Node.js/Express or Next.js API routes; handles usernames, transactions)
+│   ├── mobile/            # React Native app (iOS/Android for on-the-go payments)
+│   └── contract/          # Soroban Rust contracts (privacy/escrow logic)
+├── packages/
+│   ├── ui/                # Shared Tailwind components
+│   └── stellar-sdk/       # Stellar utils (Horizon queries, wallet connect)
+├── turbo.json             # Build/dev pipelines (configured for app/ subfolders)
+└── pnpm-workspace.yaml    # Workspace config (includes app/* and packages/*)
+
+Setup Instructions
+Prerequisites
+
+Before getting started, ensure you have the following installed:
+
+    Node.js 18+ (nodejs.org).
+    pnpm (for monorepo management; install via npm install -g pnpm).
+    A Stellar wallet (Freighter recommended; download from freighter.app).
+    Supabase account (free tier; sign up at supabase.com).
+    Git (for cloning).
+    Rust toolchain (for contracts; install via rustup.rs).
+    React Native CLI (for mobile; see reactnative.dev).
+
+Installation
+
+    Clone the repository:
+
+    git clone https://github.com/pulsefy/QuickEx.git
+    cd QuickEx
+
+    Install dependencies across the monorepo:
+
+    pnpm install
+
+Environment Setup
+
+    Create a Supabase project and retrieve your SUPABASE_URL and SUPABASE_ANON_KEY from the dashboard.
+    Copy .env.example to .env.local in the root directory and populate it:
+
+    SUPABASE_URL=your_supabase_url
+    SUPABASE_ANON_KEY=your_supabase_anon_key
+    NEXT_PUBLIC_STELLAR_NETWORK=testnet  # Use 'mainnet' for production
+
+    Configure the Stellar network:
+        Development: Defaults to testnet; fund your wallet at laboratory.stellar.org.
+        Production: Set to mainnet in .env.local and ensure your wallet holds real assets.
+    Backend (NestJS): create app/backend/.env and set STELLAR_NETWORK (default testnet). Example:
+
+    STELLAR_NETWORK=testnet
+
+    Allowed values: testnet, mainnet (default testnet). Supported assets are defined in app/backend/src/config/stellar.config.ts under SUPPORTED_ASSETS. To add a new asset, add a native or issued entry to SUPPORTED_ASSETS.
+    For contracts: Add environment variables to app/contract/.env (e.g., STELLAR_NETWORK=testnet).
+    For mobile: After installation, navigate to app/mobile and run npx pod-install (iOS) or configure the Android SDK.
+
+Running Locally
+
+    Launch all services using TurboRepo:
+
+    pnpm turbo run dev
+
+    This starts the frontend (app/frontend), backend (app/backend), and prepares contracts/mobile.
+    Access the web app at http://localhost:3000.
+    For the mobile app:
+
+    cd app/mobile && npx react-native run-ios  # or run-android
+
+    For contracts (testing/deploying):
+
+    cd app/contract && cargo test  # Run unit tests
+    # Deploy to testnet: Use Soroban CLI as per Soroban docs
+
+Connect your wallet in the app to claim a username and test features.
+Testing
+
+Run tests to validate code quality and functionality:
+
+    Lint and type-check the entire monorepo:
+
+    pnpm turbo run lint
+    pnpm turbo run type-check
+
+    Execute end-to-end tests (Playwright for frontend, Jest for others):
+
+    pnpm turbo run test:e2e
+
+    Tests require a testnet wallet; detailed setup is in TESTING.md.
+    Mobile-specific tests:
+
+    cd app/mobile && npm test
+
+Deployment
+
+Deployment is automated for most components, but requires platform-specific configuration:
+
+    Frontend and Backend (Vercel):
+        Connect the GitHub repository to Vercel via the dashboard.
+        Add environment variables from .env.local (e.g., Supabase keys, Stellar network).
+        Pushes to main trigger auto-deploys. Set a custom domain in the Vercel project settings.
+
+    Mobile (Expo):
+        Install Expo CLI if needed: npm install -g @expo/cli.
+        From app/mobile: expo publish for over-the-air updates, or build via expo build:ios / expo build:android.
+        Use Expo's dashboard to manage credentials and submissions to app stores.
+
+    Contracts (Soroban):
+        Build and deploy via CI/CD (e.g., GitHub Actions in app/contract).
+        For testnet: cd app/contract && soroban contract deploy --network testnet.
+        For mainnet: Update network config and deploy similarly, ensuring WASM optimization.
+
+For production readiness, always verify NEXT_PUBLIC_STELLAR_NETWORK=mainnet and conduct thorough testing. See DEPLOYMENT.md for advanced configurations like CI/CD pipelines.
+Usage
+
+    Claim Username: Connect your wallet in the app, select a name, and confirm the on-chain transaction.
+    Generate Link: In the dashboard, input amount, memo, and privacy options, then copy the generated link or QR code.
+    Receive Payment: Share the link; the payer clicks or scans to send funds directly to your wallet.
+    Enable Privacy: Toggle X-Ray mode to shield transactions (deploys Rust contract on mainnet).
+
+Contributing
+
+Contributions are welcome and encouraged to help evolve QuickEx! To get started:
+
+    Report Issues: Use GitHub Issues for bugs or feature requests. Include reproduction steps, environment details, and screenshots where possible.
+    Propose Features: Start a Discussion thread to align on ideas before coding.
+    Submit Pull Requests:
+        Fork the repository and create a feature branch: git checkout -b feature/your-feature.
+        Implement changes, ensuring they pass linting and tests.
+        Commit with clear messages (e.g., "feat: add multi-asset swap support").
+        Push and open a PR against main. Reference any related issues.
+    Monorepo Best Practices:
+        Use pnpm turbo run build to validate changes across packages.
+        Update shared packages (packages/ui or packages/stellar-sdk) only when needed, and bump versions.
+        Run pnpm turbo run lint --filter=... for targeted checks (e.g., --filter=app/frontend).
+
+All contributors must adhere to the Code of Conduct and sign off commits for DCO compliance. For more, see CONTRIBUTING.md.
+
+## TASK TO IMPLEMENT
+
+#451 MOB-31: Release Pipeline v1 (Internal Testing Builds)
+Repo Avatar Pulsefy/QiuckEx
+
+Complexity: 200 points
+Branch: feat/mobile-release-pipeline
+Summary
+Create a repeatable release pipeline that produces internal testing builds for contributors and QA without manual steps.
+Tasks
+
+    Set up CI to build signed internal artifacts for iOS and Android.
+    Add environment matrices (dev/staging/production) without code changes.
+    Ensure build metadata is visible in-app (version, build number, network).
+    Add a release checklist including permissions and privacy review.
+    Acceptance Criteria
+    Internal builds can be produced on every release tag reliably.
+    App clearly indicates build environment and network.
+    Build pipeline does not expose secrets in logs.
+


### PR DESCRIPTION

Summary

Implemented the first version of the mobile release pipeline for internal testing builds.
What changed

    Added app.config.ts to inject build metadata and environment values into Expo config
    Added eas.json with dev, staging, and production internal build profiles
    Added runtime build metadata helper at build.ts
    Updated mobile settings UI to display:
        app version
        build metadata
        environment
        Stellar network
        release tag
    Added GitHub Actions workflow mobile-release.yml to build internal artifacts on release tags and manual workflow dispatch
    Added release checklist documentation at RELEASE_CHECKLIST.md
    Updated docs in README.md and root README.md with new internal build instructions

Acceptance criteria

    Internal testing builds can be produced via release tags or manual dispatch
    Build metadata is visible in-app
    Environment and network are surfaced in the Settings UI
    Pipeline avoids exposing secrets in logs by using EAS_TOKEN from GitHub secrets

Notes

    Requires EAS_TOKEN configured in GitHub secrets
    dev/staging/production profiles are defined without code changes to the app logic
Closes #451 