### PR TITLE
feat(mobile): add clear local data action and secure storage cleanup

### DIFF
--- a/app/mobile/__tests__/local-data.test.ts
+++ b/app/mobile/__tests__/local-data.test.ts
@@ -1,0 +1,47 @@
+import {
+  clearLocalData,
+} from "../services/local-data";
+import {
+  getWalletSession,
+  saveWalletSession,
+  getLastWalletType,
+  clearWalletSession,
+} from "../services/wallet-session";
+import {
+  getSecuritySettings,
+  hasFallbackPin,
+  getSensitiveToken,
+  saveSecuritySettings,
+  setFallbackPin,
+  saveSensitiveToken,
+} from "../services/security";
+import type { WalletSession } from "../services/wallet-session";
+
+const VALID_SESSION: WalletSession = {
+  publicKey: "GAMOSFOKEYHFDGMXIEFEYBUYK3ZMFYN3PFLOTBRXFGBFGRKBKLQSLGLP",
+  network: "testnet",
+  walletType: "demo",
+  connectedAt: Date.now(),
+  lastConfirmedAt: new Date().toISOString(),
+};
+
+describe("local data service", () => {
+  afterEach(async () => {
+    await clearWalletSession();
+  });
+
+  it("clears wallet session, secure storage, and cached app state", async () => {
+    await saveWalletSession(VALID_SESSION);
+    await saveSecuritySettings({ biometricLockEnabled: true });
+    await setFallbackPin("1234");
+    await saveSensitiveToken("qex_session_test_token");
+
+    await clearLocalData();
+
+    expect(await getWalletSession()).toBeNull();
+    expect(await getLastWalletType()).toBeNull();
+    expect(await getSecuritySettings()).toEqual({ biometricLockEnabled: false });
+    expect(await hasFallbackPin()).toBe(false);
+    expect(await getSensitiveToken()).toBeNull();
+  });
+});

--- a/app/mobile/app/settings.tsx
+++ b/app/mobile/app/settings.tsx
@@ -1,6 +1,7 @@
-import { Link } from "expo-router";
+import { Link, useRouter } from "expo-router";
 import React from "react";
 import {
+  Alert,
   Platform,
   Pressable,
   ScrollView,
@@ -15,6 +16,8 @@ import { LocaleSwitcher } from "../components/LocaleSwitcher";
 import { useNotifications } from "../components/notifications/NotificationContext";
 import OnboardingResetButton from "../components/onboarding/OnboardingResetButton";
 import { ThemeSelector } from "../components/ThemeSelector";
+import { useWallet } from "../hooks/useWallet";
+import { clearLocalData } from "../services/local-data";
 import {
   SYNC_INTERVALS_MINUTES,
   type SyncFrequency,
@@ -44,7 +47,9 @@ const FREQUENCY_OPTIONS: Array<{
 ];
 
 export default function SettingsScreen() {
+  const router = useRouter();
   const { theme } = useTheme();
+  const { disconnect } = useWallet();
   const {
     backgroundSyncSettings,
     backgroundTaskAvailable,
@@ -55,6 +60,36 @@ export default function SettingsScreen() {
     setSoundEnabled,
     syncNow,
   } = useNotifications();
+
+  const handleClearLocalData = () => {
+    Alert.alert(
+      "Clear Local Data",
+      "This action will remove cached app data, sign you out, and clear secure storage. This cannot be undone.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Clear Data",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              await disconnect();
+              await clearLocalData();
+              Alert.alert(
+                "Local Data Cleared",
+                "All local app data has been removed. Please reconnect your wallet.",
+              );
+              router.replace("/");
+            } catch (error) {
+              Alert.alert(
+                "Unable to Clear Data",
+                "Something went wrong while clearing local data. Please try again.",
+              );
+            }
+          },
+        },
+      ],
+    );
+  };
 
   return (
     <SafeAreaView
@@ -293,6 +328,23 @@ export default function SettingsScreen() {
           <OnboardingResetButton />
         </View>
 
+        <View style={styles.section}>
+          <Text style={[styles.sectionTitle, { color: theme.textPrimary }]}>Privacy & Data</Text>
+          <Pressable
+            style={[
+              styles.clearDataButton,
+              {
+                backgroundColor: theme.surface,
+                borderColor: theme.status.error,
+              },
+            ]}
+            onPress={handleClearLocalData}
+          >
+            <Text style={[styles.clearDataText, { color: theme.status.error }]}>Clear Local Data</Text>
+          </Pressable>
+          <Text style={[styles.helper, { color: theme.textMuted }]}>Remove all cached and secure data, sign out, and reset the app state.</Text>
+        </View>
+
         {Platform.OS !== "web" ? (
           <View style={styles.section}>
             <Text style={[styles.sectionTitle, { color: theme.textPrimary }]}>
@@ -395,6 +447,17 @@ const styles = StyleSheet.create({
   },
   syncNowButtonText: {
     fontSize: 13,
+    fontWeight: "700",
+  },
+  clearDataButton: {
+    borderWidth: 1,
+    borderRadius: 14,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    alignItems: "center",
+  },
+  clearDataText: {
+    fontSize: 15,
     fontWeight: "700",
   },
   section: {

--- a/app/mobile/services/local-data.ts
+++ b/app/mobile/services/local-data.ts
@@ -1,0 +1,26 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import { clearSecurityData } from "./security";
+import { clearWalletSession } from "./wallet-session";
+
+export async function clearLocalData(): Promise<void> {
+  try {
+    if (AsyncStorage && typeof AsyncStorage.clear === "function") {
+      await AsyncStorage.clear();
+    }
+  } catch (error) {
+    console.error("Failed to clear AsyncStorage during local data wipe", error);
+  }
+
+  try {
+    await clearSecurityData();
+  } catch (error) {
+    console.error("Failed to clear secure storage during local data wipe", error);
+  }
+
+  try {
+    await clearWalletSession();
+  } catch (error) {
+    console.error("Failed to clear wallet session during local data wipe", error);
+  }
+}

--- a/app/mobile/services/security.ts
+++ b/app/mobile/services/security.ts
@@ -189,3 +189,11 @@ export async function getSensitiveToken() {
 export async function clearSensitiveToken() {
   await deleteItem(SENSITIVE_TOKEN_KEY);
 }
+
+export async function clearSecurityData(): Promise<void> {
+  await Promise.all([
+    deleteItem(SECURITY_SETTINGS_KEY),
+    deleteItem(FALLBACK_PIN_HASH_KEY),
+    deleteItem(SENSITIVE_TOKEN_KEY),
+  ]);
+}


### PR DESCRIPTION
Close #455 

## PR Description

**Title:** `feat(mobile): add clear local data action and secure storage cleanup`

### Summary
This PR hardens mobile storage by adding a dedicated local data clearing flow and ensuring sensitive values are removed from secure storage and session storage.

### What changed
- Added local-data.ts
  - centralizes local data wipe logic
  - clears `AsyncStorage`, secure storage keys, and wallet session state
- Extended security.ts
  - added `clearSecurityData()`
  - removes security settings, fallback PIN hash, and sensitive session token
- Updated settings.tsx
  - added a new `Clear Local Data` action in Settings
  - includes confirmation dialog
  - signs out the user, clears local data, and returns to the home route
- Added test coverage:
  - local-data.test.ts

### Testing
- Verified workspace diagnostics show no TypeScript/JS errors in:
  - security.ts
  - local-data.ts
  - settings.tsx
  - local-data.test.ts
- Full test execution could not be performed in the current environment because `node`, `npm`, and `pnpm` are unavailable in the shell.

### Files changed
- local-data.ts
- security.ts
- settings.tsx
- local-data.test.ts
