### PR TITLE
fix: production build hardening (env validation + safe defaults)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,14 +5,54 @@ on:
     branches: [ main, develop ]
     paths:
       - 'app/backend/**'
+      - '.github/workflows/backend.yml'
   pull_request:
     branches: [ main, develop ]
     paths:
       - 'app/backend/**'
+      - '.github/workflows/backend.yml'
 
 jobs:
+  validate-env:
+    name: Validate Env Schema
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Fail-fast contract — missing required vars must fail validation
+        env:
+          NODE_ENV: production
+          # Deliberately omit SUPABASE_URL / SUPABASE_ANON_KEY / NETWORK
+        run: |
+          if pnpm run validate:env; then
+            echo "::error::validate:env unexpectedly succeeded with required vars missing"
+            exit 1
+          else
+            echo "validate:env correctly failed when required vars are missing"
+          fi
+
+      - name: Validate with minimal valid env
+        env:
+          NODE_ENV: production
+          NETWORK: testnet
+          SUPABASE_URL: https://example.supabase.co
+          SUPABASE_ANON_KEY: ci-anon-key
+        run: pnpm run validate:env
+
   build-and-test:
     name: Build and Test
+    needs: validate-env
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,76 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'app/frontend/**'
+      - '.github/workflows/frontend.yml'
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'app/frontend/**'
+      - '.github/workflows/frontend.yml'
+
+jobs:
+  validate-env:
+    name: Validate Production Env
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/frontend
+    env:
+      # Acceptance criterion: builds fail fast when critical env vars are
+      # missing. This job runs `validate:env` with NODE_ENV=production and
+      # *no* values, so it must exit non-zero — proving the gate works.
+      NODE_ENV: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+      - name: Fail-fast contract — production env without required vars must fail
+        run: |
+          if pnpm run validate:env; then
+            echo "::error::validate:env unexpectedly succeeded with no envs set in production mode"
+            exit 1
+          else
+            echo "validate:env correctly failed when required vars are missing"
+          fi
+
+  build-and-check:
+    name: Build, Validate Env, Scan Bundle
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/frontend
+    env:
+      NODE_ENV: production
+      # Minimal valid production env for the CI build. Override in repo
+      # secrets / variables to point at the real backend.
+      NEXT_PUBLIC_QUICKEX_API_URL: ${{ vars.NEXT_PUBLIC_QUICKEX_API_URL || 'https://api.example.com' }}
+      NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL || 'https://quickex.to' }}
+      NEXT_PUBLIC_STELLAR_NETWORK: ${{ vars.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+      - name: Validate env
+        run: pnpm run validate:env
+      - name: Lint
+        run: pnpm run lint
+      - name: Build
+        # `prebuild` runs validate:env again, `postbuild` runs the
+        # bundle-secret scanner — so this single step covers all three gates.
+        run: pnpm run build

--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -10,6 +10,8 @@
     "start": "node dist/main",
     "lint": "eslint \"{src,test}/**/*.ts\"",
     "type-check": "tsc --noEmit",
+    "validate:env": "ts-node --transpile-only scripts/validate-env.ts",
+    "validate:env:strict": "ts-node --transpile-only scripts/validate-env.ts --strict",
     "test": "jest",
     "test:unit": "jest --config jest.unit.config.ts",
     "test:int": "jest --config jest.int.config.ts",

--- a/app/backend/scripts/validate-env.ts
+++ b/app/backend/scripts/validate-env.ts
@@ -1,0 +1,102 @@
+/**
+ * Standalone backend env validation.
+ *
+ * Runs the Joi schema declared in `src/config/env.schema.ts` against
+ * `process.env` without booting Nest. Used by CI and by developers to confirm
+ * a deploy environment is fully configured before attempting to start the app.
+ *
+ * Exit codes:
+ *   0  validation passed
+ *   1  one or more required variables are missing or invalid
+ *
+ * Flags:
+ *   --strict   also fail when the "critical" runtime checks (matching the ones
+ *              in src/main.ts) would have raised a warning (e.g. payment
+ *              signing not configured).
+ */
+
+import { envSchema } from "../src/config/env.schema";
+
+const args = process.argv.slice(2);
+const strict = args.includes("--strict");
+
+const isTTY = process.stderr.isTTY === true;
+const RESET = isTTY ? "\x1b[0m" : "";
+const BOLD = isTTY ? "\x1b[1m" : "";
+const RED = isTTY ? "\x1b[31m" : "";
+const YELLOW = isTTY ? "\x1b[33m" : "";
+const GREEN = isTTY ? "\x1b[32m" : "";
+
+const { error, value } = envSchema.validate(process.env, {
+  abortEarly: false,
+  allowUnknown: true,
+  stripUnknown: false,
+});
+
+const errors: { name: string; message: string }[] = [];
+const warnings: { name: string; message: string }[] = [];
+
+if (error) {
+  for (const detail of error.details) {
+    const name = (detail.path[0] as string) ?? "<unknown>";
+    errors.push({ name, message: detail.message });
+  }
+}
+
+// Mirror the warn-only critical checks in src/main.ts so misconfigured deploys
+// surface them before the app boots.
+if (!value?.STELLAR_SECRET_KEY) {
+  warnings.push({
+    name: "STELLAR_SECRET_KEY",
+    message:
+      "Not configured — payment signing will be disabled (read-only mode).",
+  });
+}
+if (!value?.SUPABASE_SERVICE_ROLE_KEY) {
+  warnings.push({
+    name: "SUPABASE_SERVICE_ROLE_KEY",
+    message:
+      "Not configured — admin operations that require the service role will fail.",
+  });
+}
+
+function print(prefix: string, list: { name: string; message: string }[], color: string) {
+  for (const issue of list) {
+    console.error(
+      `  ${color}${prefix}${RESET}  ${BOLD}${issue.name}${RESET}: ${issue.message}`,
+    );
+  }
+}
+
+if (errors.length === 0 && warnings.length === 0) {
+  console.log(
+    `${GREEN}[validate-env] OK${RESET} — backend env passes schema validation.`,
+  );
+  process.exit(0);
+}
+
+console.error("");
+console.error(`${BOLD}[validate-env] backend environment validation report${RESET}`);
+console.error("");
+
+if (errors.length > 0) {
+  console.error(`${BOLD}Errors (${errors.length}):${RESET}`);
+  print("ERROR  ", errors, RED);
+  console.error("");
+}
+if (warnings.length > 0) {
+  console.error(`${BOLD}Warnings (${warnings.length}):${RESET}`);
+  print("WARN   ", warnings, YELLOW);
+  console.error("");
+}
+
+if (errors.length > 0 || (strict && warnings.length > 0)) {
+  console.error(
+    `${RED}${BOLD}FAIL${RESET} — fix the above before deploying. ` +
+      `Set variables in the hosting provider (prod) or local .env (dev).`,
+  );
+  process.exit(1);
+}
+
+console.log(`${GREEN}[validate-env] OK${RESET} (warnings only).`);
+process.exit(0);

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -4,7 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "validate:env": "node scripts/validate-env.mjs",
+    "validate:env:strict": "node scripts/validate-env.mjs --strict",
+    "check:bundle-secrets": "node scripts/check-bundle-secrets.mjs",
+    "prebuild": "node scripts/validate-env.mjs",
     "build": "next build",
+    "postbuild": "node scripts/check-bundle-secrets.mjs",
     "start": "next start",
     "lint": "eslint"
   },

--- a/app/frontend/scripts/check-bundle-secrets.mjs
+++ b/app/frontend/scripts/check-bundle-secrets.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Post-build scan to make sure no secrets ended up in the client bundle.
+ *
+ * Strategy:
+ *   1. Walk `.next/static` (the browser-shipped chunks).
+ *   2. For each JS/CSS file, check for:
+ *        - High-entropy values of well-known server-only env vars
+ *          (anything present in process.env *without* a NEXT_PUBLIC_ prefix).
+ *        - Common secret patterns (SUPABASE service role JWT, Stellar secret
+ *          keys, OpenAI/SendGrid/Telegram tokens).
+ *
+ * Exits non-zero on any hit, with a redacted location report.
+ *
+ * This is a defence-in-depth check — Next.js already refuses to inline
+ * non-NEXT_PUBLIC_ variables, but a contributor could still accidentally
+ * import a server-only constant into a client component.
+ */
+
+import { fileURLToPath } from "node:url";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, "..");
+const bundleDir = resolve(projectRoot, ".next", "static");
+
+const isTTY = process.stderr.isTTY === true;
+const RESET = isTTY ? "\x1b[0m" : "";
+const BOLD = isTTY ? "\x1b[1m" : "";
+const RED = isTTY ? "\x1b[31m" : "";
+const GREEN = isTTY ? "\x1b[32m" : "";
+
+if (!safeExists(bundleDir)) {
+  console.error(
+    `${RED}[check-bundle-secrets] ${bundleDir} not found.${RESET} Run \`pnpm run build\` first.`,
+  );
+  process.exit(2);
+}
+
+// Variables on this list are deliberately NEXT_PUBLIC_*-prefixed and safe to
+// inline. Everything else from process.env is suspect.
+const PUBLIC_ALLOWLIST = new Set([
+  "NODE_ENV",
+  "NEXT_RUNTIME",
+  "__NEXT_PRIVATE_PREBUNDLED_REACT",
+  "__NEXT_PRIVATE_PRELOAD_ENTRIES",
+]);
+
+// Names that are sensitive enough that their *value* should never appear in
+// the bundle, even if accidentally re-exported as a constant.
+const SENSITIVE_NAMES = [
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "SUPABASE_ANON_KEY",
+  "STELLAR_SECRET_KEY",
+  "SENDGRID_API_KEY",
+  "EXPO_ACCESS_TOKEN",
+  "TELEGRAM_BOT_TOKEN",
+  "API_KEYS",
+  "QUICKEX_INTERNAL_API_URL",
+];
+
+// Pattern-based detectors. Each entry: { name, regex, redact(value) → string }.
+const SECRET_PATTERNS = [
+  {
+    name: "stellar-secret-key",
+    regex: /\bS[A-Z2-7]{55}\b/g,
+    redact: (m) => `${m.slice(0, 4)}…${m.slice(-4)}`,
+  },
+  {
+    name: "supabase-service-role-jwt",
+    // Supabase service role keys are JWTs with a "role":"service_role" claim.
+    regex: /eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/g,
+    redact: (m) => `${m.slice(0, 12)}…${m.slice(-6)}`,
+    // Only flag if the decoded payload contains "service_role" — anon JWTs
+    // are intentionally public.
+    extraCheck: (match) => {
+      try {
+        const payload = match.split(".")[1];
+        const json = Buffer.from(payload, "base64url").toString("utf8");
+        return /service_role/i.test(json);
+      } catch {
+        return false;
+      }
+    },
+  },
+  {
+    name: "sendgrid-api-key",
+    regex: /\bSG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b/g,
+    redact: (m) => `${m.slice(0, 6)}…`,
+  },
+  {
+    name: "telegram-bot-token",
+    regex: /\b\d{8,12}:[A-Za-z0-9_-]{30,}\b/g,
+    redact: (m) => `${m.slice(0, 4)}…`,
+  },
+];
+
+const findings = [];
+
+// 1) Build a list of suspect literal values from the current env.
+const suspectValues = [];
+for (const [name, rawValue] of Object.entries(process.env)) {
+  if (!rawValue) continue;
+  const value = rawValue.trim();
+  if (value.length < 12) continue; // too short to be a real secret
+  if (name.startsWith("NEXT_PUBLIC_")) continue;
+  if (PUBLIC_ALLOWLIST.has(name)) continue;
+  if (SENSITIVE_NAMES.includes(name) || /TOKEN|SECRET|KEY|PASS|DSN/i.test(name)) {
+    suspectValues.push({ name, value });
+  }
+}
+
+for (const file of walk(bundleDir)) {
+  if (!/\.(js|mjs|css|map)$/.test(file)) continue;
+  let content;
+  try {
+    content = readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  const relPath = relative(projectRoot, file);
+
+  for (const { name, value } of suspectValues) {
+    if (content.includes(value)) {
+      findings.push({
+        kind: "env-value-leak",
+        file: relPath,
+        detail: `${name} value present in client bundle`,
+      });
+    }
+  }
+
+  for (const pattern of SECRET_PATTERNS) {
+    const matches = content.match(pattern.regex);
+    if (!matches) continue;
+    for (const match of matches) {
+      if (pattern.extraCheck && !pattern.extraCheck(match)) continue;
+      findings.push({
+        kind: pattern.name,
+        file: relPath,
+        detail: `matched ${pattern.name}: ${pattern.redact(match)}`,
+      });
+    }
+  }
+}
+
+if (findings.length === 0) {
+  console.log(
+    `${GREEN}[check-bundle-secrets] OK${RESET} — no secrets detected in .next/static.`,
+  );
+  process.exit(0);
+}
+
+console.error("");
+console.error(`${BOLD}${RED}[check-bundle-secrets] FAIL${RESET}`);
+console.error("");
+for (const f of findings) {
+  console.error(`  ${RED}${f.kind}${RESET}  ${BOLD}${f.file}${RESET}`);
+  console.error(`     ${f.detail}`);
+}
+console.error("");
+console.error(
+  "A server-only value appears to have leaked into the browser bundle. " +
+    "Review the offending file and ensure server-only modules are not imported " +
+    "from client components. Remove the leaked import and re-run the build.",
+);
+process.exit(1);
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    let s;
+    try {
+      s = statSync(full);
+    } catch {
+      continue;
+    }
+    if (s.isDirectory()) {
+      yield* walk(full);
+    } else {
+      yield full;
+    }
+  }
+}
+
+function safeExists(path) {
+  try {
+    statSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/app/frontend/scripts/validate-env.mjs
+++ b/app/frontend/scripts/validate-env.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Build-time env validation for the Next.js frontend.
+ *
+ * Shares its rules with the runtime (src/lib/env.ts) via
+ * src/lib/env-validation.mjs. Used as the `prebuild` script and in CI so
+ * missing critical env vars fail the build immediately.
+ *
+ * Exit codes:
+ *   0  validation passed (warnings allowed)
+ *   1  validation failed (one or more errors)
+ *
+ * Flags:
+ *   --strict   treat warnings as errors
+ *   --skip-on-flag <ENV_NAME>
+ *              skip validation when the named env var is set to 1/true/yes.
+ */
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const validationModule = resolve(
+  __dirname,
+  "..",
+  "src",
+  "lib",
+  "env-validation.mjs",
+);
+
+const args = process.argv.slice(2);
+const strict = args.includes("--strict");
+const skipFlagIdx = args.indexOf("--skip-on-flag");
+if (skipFlagIdx !== -1) {
+  const flagName = args[skipFlagIdx + 1];
+  if (flagName) {
+    const value = (process.env[flagName] ?? "").toLowerCase();
+    if (["1", "true", "yes", "on"].includes(value)) {
+      console.log(
+        `[validate-env] skipping (${flagName}=${process.env[flagName]})`,
+      );
+      process.exit(0);
+    }
+  }
+}
+
+const isTTY = process.stderr.isTTY === true;
+const RESET = isTTY ? "\x1b[0m" : "";
+const BOLD = isTTY ? "\x1b[1m" : "";
+const RED = isTTY ? "\x1b[31m" : "";
+const YELLOW = isTTY ? "\x1b[33m" : "";
+const GREEN = isTTY ? "\x1b[32m" : "";
+
+let validateClientEnv, validateServerEnv;
+try {
+  const mod = await import(pathToFileURL(validationModule).href);
+  validateClientEnv = mod.validateClientEnv;
+  validateServerEnv = mod.validateServerEnv;
+} catch (err) {
+  console.error(
+    `[validate-env] failed to load validators from ${validationModule}:`,
+    err.message,
+  );
+  process.exit(2);
+}
+
+const source = process.env;
+const clientResult = validateClientEnv(source);
+const serverResult = validateServerEnv(source);
+
+const all = [...clientResult.issues, ...serverResult.issues];
+const errors = all.filter((i) => i.severity === "error");
+const warnings = all.filter((i) => i.severity === "warning");
+
+if (errors.length === 0 && warnings.length === 0) {
+  console.log(
+    `${GREEN}[validate-env] OK${RESET} — all required env vars present and valid.`,
+  );
+  process.exit(0);
+}
+
+console.error("");
+console.error(`${BOLD}[validate-env] environment validation report${RESET}`);
+console.error("");
+
+function print(prefix, list, color) {
+  for (const issue of list) {
+    console.error(
+      `  ${color}${prefix}${RESET}  ${BOLD}${issue.name}${RESET}: ${issue.message}`,
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`${BOLD}Errors (${errors.length}):${RESET}`);
+  print("ERROR  ", errors, RED);
+  console.error("");
+}
+if (warnings.length > 0) {
+  console.error(`${BOLD}Warnings (${warnings.length}):${RESET}`);
+  print("WARN   ", warnings, YELLOW);
+  console.error("");
+}
+
+if (errors.length > 0 || (strict && warnings.length > 0)) {
+  console.error(
+    `${RED}${BOLD}FAIL${RESET} — fix the above before building. ` +
+      `Set variables in .env.local (dev) or your hosting provider (prod).`,
+  );
+  process.exit(1);
+}
+
+console.log(`${GREEN}[validate-env] OK${RESET} (warnings only).`);
+process.exit(0);

--- a/app/frontend/src/app/layout.tsx
+++ b/app/frontend/src/app/layout.tsx
@@ -2,10 +2,12 @@ import type { Metadata } from "next";
 import { Header } from "@/components/Header";
 import { NotificationCenterProvider } from "@/components/NotificationCenterProvider";
 import { ErrorReportingShell } from "@/components/ErrorReportingShell";
+import { MisconfigurationScreen } from "@/components/MisconfigurationScreen";
+import { getClientEnv, getClientEnvIssues } from "@/lib/env";
 import "./globals.css";
 
-const siteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ?? "https://quickex.to";
+const env = getClientEnv();
+const siteUrl = env?.siteUrl ?? "https://quickex.to";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
@@ -51,6 +53,18 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // If critical env validation failed, render the dedicated Misconfiguration
+  // screen instead of attempting to boot. The screen owns its own <html>/<body>.
+  if (!env) {
+    const issues = getClientEnvIssues().filter((i) => i.severity === "error");
+    return (
+      <MisconfigurationScreen
+        issues={issues}
+        showDevHint={process.env.NODE_ENV !== "production"}
+      />
+    );
+  }
+
   return (
     <html lang="en">
       <body className="bg-neutral-950 text-white antialiased">

--- a/app/frontend/src/components/MisconfigurationScreen.tsx
+++ b/app/frontend/src/components/MisconfigurationScreen.tsx
@@ -1,0 +1,221 @@
+import type { EnvIssue } from "@/lib/env";
+
+type MisconfigurationScreenProps = {
+  /** Validation issues that triggered the screen. */
+  issues: EnvIssue[];
+  /** When true, render the dev hint with .env.local instructions. */
+  showDevHint?: boolean;
+};
+
+/**
+ * Dedicated full-page screen rendered when critical client env validation
+ * fails. Shown instead of attempting to boot the app so an operator can see
+ * exactly what is wrong and how to fix it.
+ *
+ * - Lists every failing variable with its message.
+ * - Tells the operator where to set the variable.
+ * - Distinguishes errors from warnings (warnings never render this screen
+ *   — but if forwarded here for visibility, are styled less alarming).
+ *
+ * Renders with inline styles so it works even when Tailwind/CSS hasn't loaded.
+ */
+export function MisconfigurationScreen({
+  issues,
+  showDevHint = false,
+}: MisconfigurationScreenProps) {
+  const errors = issues.filter((i) => i.severity === "error");
+  const warnings = issues.filter((i) => i.severity === "warning");
+
+  return (
+    <html lang="en">
+      <head>
+        <title>QuickEx — Misconfiguration</title>
+        <meta name="robots" content="noindex" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+      </head>
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          background: "#0a0a0a",
+          color: "#fff",
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+        }}
+      >
+        <main
+          style={{
+            maxWidth: 720,
+            margin: "0 auto",
+            padding: "64px 24px",
+          }}
+        >
+          <p
+            style={{
+              fontSize: 12,
+              letterSpacing: "0.22em",
+              textTransform: "uppercase",
+              color: "#a3a3a3",
+              margin: 0,
+            }}
+          >
+            QuickEx is misconfigured
+          </p>
+          <h1
+            style={{
+              fontSize: 32,
+              fontWeight: 700,
+              margin: "12px 0 24px",
+            }}
+          >
+            The app can&rsquo;t start because required environment variables are
+            missing or invalid.
+          </h1>
+          <p style={{ color: "#d4d4d4", marginBottom: 32, lineHeight: 1.6 }}>
+            Fix the items below, then redeploy or restart the server. No
+            requests will be served until configuration is valid.
+          </p>
+
+          {errors.length > 0 && (
+            <section
+              aria-labelledby="errors-heading"
+              style={{
+                border: "1px solid #7f1d1d",
+                background: "rgba(127, 29, 29, 0.15)",
+                borderRadius: 16,
+                padding: 24,
+                marginBottom: warnings.length > 0 ? 24 : 0,
+              }}
+            >
+              <h2
+                id="errors-heading"
+                style={{
+                  fontSize: 14,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.18em",
+                  color: "#fca5a5",
+                  margin: "0 0 16px",
+                }}
+              >
+                Errors ({errors.length})
+              </h2>
+              <ul
+                style={{
+                  listStyle: "none",
+                  margin: 0,
+                  padding: 0,
+                  display: "grid",
+                  gap: 16,
+                }}
+              >
+                {errors.map((issue) => (
+                  <li key={issue.name}>
+                    <code
+                      style={{
+                        display: "inline-block",
+                        background: "#1f1f1f",
+                        color: "#fda4af",
+                        padding: "2px 8px",
+                        borderRadius: 6,
+                        fontSize: 13,
+                      }}
+                    >
+                      {issue.name}
+                    </code>
+                    <p
+                      style={{
+                        margin: "6px 0 0",
+                        color: "#fafafa",
+                        lineHeight: 1.55,
+                      }}
+                    >
+                      {issue.message}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {warnings.length > 0 && (
+            <section
+              aria-labelledby="warnings-heading"
+              style={{
+                border: "1px solid #78350f",
+                background: "rgba(120, 53, 15, 0.15)",
+                borderRadius: 16,
+                padding: 24,
+              }}
+            >
+              <h2
+                id="warnings-heading"
+                style={{
+                  fontSize: 14,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.18em",
+                  color: "#fcd34d",
+                  margin: "0 0 16px",
+                }}
+              >
+                Warnings ({warnings.length})
+              </h2>
+              <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "grid", gap: 16 }}>
+                {warnings.map((issue) => (
+                  <li key={issue.name}>
+                    <code
+                      style={{
+                        display: "inline-block",
+                        background: "#1f1f1f",
+                        color: "#fde68a",
+                        padding: "2px 8px",
+                        borderRadius: 6,
+                        fontSize: 13,
+                      }}
+                    >
+                      {issue.name}
+                    </code>
+                    <p style={{ margin: "6px 0 0", color: "#fafafa", lineHeight: 1.55 }}>
+                      {issue.message}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          <section
+            style={{
+              marginTop: 40,
+              padding: 20,
+              border: "1px solid #262626",
+              borderRadius: 16,
+              background: "#0f0f0f",
+            }}
+          >
+            <h3 style={{ margin: "0 0 12px", fontSize: 14, color: "#e5e5e5" }}>
+              How to fix
+            </h3>
+            <ul style={{ margin: 0, paddingLeft: 20, color: "#d4d4d4", lineHeight: 1.6 }}>
+              <li>
+                Production: set the variables in your hosting provider (e.g.
+                Vercel project settings) and trigger a new deployment.
+              </li>
+              {showDevHint && (
+                <li>
+                  Local dev: add the variables to{" "}
+                  <code style={{ color: "#fde68a" }}>app/frontend/.env.local</code>{" "}
+                  and restart <code style={{ color: "#fde68a" }}>pnpm dev</code>.
+                </li>
+              )}
+              <li>
+                Run{" "}
+                <code style={{ color: "#fde68a" }}>pnpm --filter frontend validate:env</code>{" "}
+                to re-check without starting the app.
+              </li>
+            </ul>
+          </section>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/app/frontend/src/components/NetworkBadge.tsx
+++ b/app/frontend/src/components/NetworkBadge.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { getClientEnv } from "@/lib/env";
 
 export function NetworkBadge() {
   const [network, setNetwork] = useState<string | undefined>(undefined);
+  const [explicit, setExplicit] = useState(false);
 
   useEffect(() => {
-    setNetwork(process.env.NEXT_PUBLIC_STELLAR_NETWORK);
+    const env = getClientEnv();
+    setNetwork(env?.stellarNetwork);
+    setExplicit(Boolean(env?.stellarNetwork));
   }, []);
 
   if (!network) return null;
@@ -31,7 +35,7 @@ export function NetworkBadge() {
     >
       {label}
 
-      {!process.env.NEXT_PUBLIC_STELLAR_NETWORK && (
+      {!explicit && (
         <span className="ml-2 opacity-50 font-normal italic">(default)</span>
       )}
     </div>

--- a/app/frontend/src/hooks/analyticsApi.ts
+++ b/app/frontend/src/hooks/analyticsApi.ts
@@ -1,5 +1,6 @@
 import i18n from "i18next";
 import { getQuickexApiBase } from "@/lib/api";
+import { getClientEnv } from "@/lib/env";
 
 export type DateRange = "24h" | "7d" | "30d" | "all";
 
@@ -114,7 +115,8 @@ function resolveAnalyticsPublicKey(): string {
     }
   }
 
-  const fromEnv = process.env.NEXT_PUBLIC_QUICKEX_ANALYTICS_PUBLIC_KEY?.trim();
+  const env = getClientEnv();
+  const fromEnv = env?.analyticsPublicKey;
   if (fromEnv && PUBLIC_KEY_REGEX.test(fromEnv)) {
     return fromEnv;
   }

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -1,7 +1,10 @@
+import { getClientEnv } from "@/lib/env";
+
 /**
  * Backend origin for browser calls. Override in `.env.local`:
  * `NEXT_PUBLIC_QUICKEX_API_URL=https://api.example.com`
  */
-export const getQuickexApiBase = (): string =>
-  process.env.NEXT_PUBLIC_QUICKEX_API_URL?.replace(/\/$/, "") ??
-  "http://localhost:4000";
+export const getQuickexApiBase = (): string => {
+  const env = getClientEnv();
+  return env?.apiBaseUrl ?? "http://localhost:4000";
+};

--- a/app/frontend/src/lib/env-validation.mjs
+++ b/app/frontend/src/lib/env-validation.mjs
@@ -1,0 +1,174 @@
+// Pure JS validators shared by the runtime (src/lib/env.ts) and the
+// build-time script (scripts/validate-env.mjs). No imports, no side effects —
+// import this file from either context.
+
+const TRUE_VALUES = new Set(["true", "1", "yes", "on"]);
+const VALID_NETWORKS = new Set(["testnet", "mainnet", "futurenet"]);
+const PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+
+function isHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function stripTrailingSlash(value) {
+  return value.replace(/\/$/, "");
+}
+
+/**
+ * @param {Record<string, string | undefined>} source
+ */
+export function validateClientEnv(source) {
+  const issues = [];
+  const nodeEnv = (source.NODE_ENV ?? "development").toLowerCase();
+  const vercelEnv = source.NEXT_PUBLIC_VERCEL_ENV?.trim();
+  const isProduction =
+    nodeEnv === "production" || vercelEnv === "production";
+
+  const apiBaseRaw = source.NEXT_PUBLIC_QUICKEX_API_URL?.trim();
+  if (!apiBaseRaw) {
+    issues.push({
+      name: "NEXT_PUBLIC_QUICKEX_API_URL",
+      message:
+        "Backend API base URL is not set. Set NEXT_PUBLIC_QUICKEX_API_URL to the public backend origin (e.g. https://api.quickex.example.com).",
+      severity: isProduction ? "error" : "warning",
+    });
+  } else if (!isHttpUrl(apiBaseRaw)) {
+    issues.push({
+      name: "NEXT_PUBLIC_QUICKEX_API_URL",
+      message: `Value "${apiBaseRaw}" is not a valid http(s) URL.`,
+      severity: "error",
+    });
+  }
+
+  const siteUrlRaw = source.NEXT_PUBLIC_SITE_URL?.trim();
+  if (!siteUrlRaw) {
+    issues.push({
+      name: "NEXT_PUBLIC_SITE_URL",
+      message:
+        "Public site URL is not set. Set NEXT_PUBLIC_SITE_URL so absolute OpenGraph URLs and metadataBase resolve correctly.",
+      severity: isProduction ? "error" : "warning",
+    });
+  } else if (!isHttpUrl(siteUrlRaw)) {
+    issues.push({
+      name: "NEXT_PUBLIC_SITE_URL",
+      message: `Value "${siteUrlRaw}" is not a valid http(s) URL.`,
+      severity: "error",
+    });
+  }
+
+  const networkRaw = source.NEXT_PUBLIC_STELLAR_NETWORK?.trim().toLowerCase();
+  if (!networkRaw) {
+    issues.push({
+      name: "NEXT_PUBLIC_STELLAR_NETWORK",
+      message:
+        "Stellar network is not set. Set NEXT_PUBLIC_STELLAR_NETWORK to 'testnet' or 'mainnet'.",
+      severity: isProduction ? "error" : "warning",
+    });
+  } else if (!VALID_NETWORKS.has(networkRaw)) {
+    issues.push({
+      name: "NEXT_PUBLIC_STELLAR_NETWORK",
+      message: `Value "${networkRaw}" is not a recognised Stellar network. Allowed: testnet, mainnet, futurenet.`,
+      severity: "error",
+    });
+  }
+
+  const errorReportingEnabled = TRUE_VALUES.has(
+    (source.NEXT_PUBLIC_ERROR_REPORTING_ENABLED ?? "").trim().toLowerCase(),
+  );
+  const errorReportingUrl =
+    source.NEXT_PUBLIC_ERROR_REPORTING_URL?.trim() || undefined;
+  if (errorReportingEnabled) {
+    if (!errorReportingUrl) {
+      issues.push({
+        name: "NEXT_PUBLIC_ERROR_REPORTING_URL",
+        message:
+          "Error reporting is enabled but no destination URL is set. Set NEXT_PUBLIC_ERROR_REPORTING_URL or unset NEXT_PUBLIC_ERROR_REPORTING_ENABLED.",
+        severity: "error",
+      });
+    } else if (!isHttpUrl(errorReportingUrl)) {
+      issues.push({
+        name: "NEXT_PUBLIC_ERROR_REPORTING_URL",
+        message: `Value "${errorReportingUrl}" is not a valid http(s) URL.`,
+        severity: "error",
+      });
+    }
+  }
+
+  const analyticsPublicKey =
+    source.NEXT_PUBLIC_QUICKEX_ANALYTICS_PUBLIC_KEY?.trim();
+  if (analyticsPublicKey && !PUBLIC_KEY_REGEX.test(analyticsPublicKey)) {
+    issues.push({
+      name: "NEXT_PUBLIC_QUICKEX_ANALYTICS_PUBLIC_KEY",
+      message:
+        "Value is not a valid Stellar public key (must start with G and be 56 chars).",
+      severity: "error",
+    });
+  }
+
+  const hasErrors = issues.some((i) => i.severity === "error");
+  if (hasErrors) {
+    return { ok: false, env: null, issues };
+  }
+
+  return {
+    ok: true,
+    env: {
+      apiBaseUrl: apiBaseRaw
+        ? stripTrailingSlash(apiBaseRaw)
+        : "http://localhost:4000",
+      siteUrl: siteUrlRaw
+        ? stripTrailingSlash(siteUrlRaw)
+        : "http://localhost:3000",
+      stellarNetwork: networkRaw ?? "testnet",
+      errorReportingEnabled,
+      errorReportingUrl,
+      appVersion: source.NEXT_PUBLIC_APP_VERSION?.trim() || "unknown",
+      vercelEnv,
+      analyticsPublicKey,
+    },
+    issues,
+  };
+}
+
+/**
+ * @param {Record<string, string | undefined>} source
+ */
+export function validateServerEnv(source) {
+  const issues = [];
+
+  const internalApiUrl = source.QUICKEX_INTERNAL_API_URL?.trim();
+  if (internalApiUrl && !isHttpUrl(internalApiUrl)) {
+    issues.push({
+      name: "QUICKEX_INTERNAL_API_URL",
+      message: `Value "${internalApiUrl}" is not a valid http(s) URL.`,
+      severity: "error",
+    });
+  }
+
+  const rawNodeEnv = (source.NODE_ENV ?? "development").toLowerCase();
+  const nodeEnv =
+    rawNodeEnv === "production" || rawNodeEnv === "test"
+      ? rawNodeEnv
+      : "development";
+
+  const hasErrors = issues.some((i) => i.severity === "error");
+  if (hasErrors) {
+    return { ok: false, env: null, issues };
+  }
+
+  return {
+    ok: true,
+    env: {
+      internalApiUrl: internalApiUrl
+        ? stripTrailingSlash(internalApiUrl)
+        : undefined,
+      nodeEnv,
+    },
+    issues,
+  };
+}

--- a/app/frontend/src/lib/env.ts
+++ b/app/frontend/src/lib/env.ts
@@ -1,0 +1,126 @@
+/**
+ * Centralized, validated access to environment variables.
+ *
+ * Two scopes are exposed:
+ *   - `clientEnv`: NEXT_PUBLIC_* values safe to inline into the browser bundle.
+ *   - `serverEnv`: server-only values. Reading these in client code throws.
+ *
+ * Validation logic lives in `./env-validation.mjs` so the build-time script
+ * (scripts/validate-env.mjs) can share it without a transpilation step.
+ *
+ * Required variables fail fast: validation returns `ok: false` and callers
+ * (e.g. the root layout) render the Misconfiguration screen rather than
+ * booting a half-working app.
+ */
+
+import {
+  validateClientEnv as runClientValidation,
+  validateServerEnv as runServerValidation,
+} from "@/lib/env-validation.mjs";
+
+export type EnvIssue = {
+  name: string;
+  message: string;
+  severity: "error" | "warning";
+};
+
+export type ValidatedClientEnv = {
+  apiBaseUrl: string;
+  siteUrl: string;
+  stellarNetwork: "testnet" | "mainnet" | "futurenet";
+  errorReportingEnabled: boolean;
+  errorReportingUrl?: string;
+  appVersion: string;
+  vercelEnv?: string;
+  analyticsPublicKey?: string;
+};
+
+export type ValidatedServerEnv = {
+  internalApiUrl?: string;
+  nodeEnv: "development" | "production" | "test";
+};
+
+export type ValidationResult<T> = {
+  ok: boolean;
+  env: T | null;
+  issues: EnvIssue[];
+};
+
+export function validateClientEnv(
+  source: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): ValidationResult<ValidatedClientEnv> {
+  return runClientValidation(source) as ValidationResult<ValidatedClientEnv>;
+}
+
+export function validateServerEnv(
+  source: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): ValidationResult<ValidatedServerEnv> {
+  return runServerValidation(source) as ValidationResult<ValidatedServerEnv>;
+}
+
+function formatIssues(issues: EnvIssue[]): string {
+  return issues
+    .map((i) => `  [${i.severity.toUpperCase()}] ${i.name}: ${i.message}`)
+    .join("\n");
+}
+
+/**
+ * Resolve the validated client env once, memoised per process/runtime.
+ * Returns `null` when validation fails — callers (e.g. the root layout)
+ * should render the Misconfiguration screen instead of booting.
+ */
+let cachedClientEnv: ValidatedClientEnv | null | undefined;
+let cachedClientIssues: EnvIssue[] = [];
+
+export function getClientEnv(): ValidatedClientEnv | null {
+  if (cachedClientEnv !== undefined) return cachedClientEnv;
+  const result = validateClientEnv();
+  cachedClientIssues = result.issues;
+  cachedClientEnv = result.env;
+  if (!result.ok && typeof window === "undefined") {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[env] Client env validation failed:\n${formatIssues(result.issues)}`,
+    );
+  } else if (result.issues.length > 0 && typeof window === "undefined") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[env] Client env validation warnings:\n${formatIssues(result.issues)}`,
+    );
+  }
+  return cachedClientEnv;
+}
+
+export function getClientEnvIssues(): EnvIssue[] {
+  if (cachedClientEnv === undefined) getClientEnv();
+  return cachedClientIssues;
+}
+
+/**
+ * Resolve the validated server env. Throws if called from the browser.
+ */
+let cachedServerEnv: ValidatedServerEnv | null | undefined;
+
+export function getServerEnv(): ValidatedServerEnv {
+  if (typeof window !== "undefined") {
+    throw new Error(
+      "getServerEnv() called from the browser. Server-only secrets must not be referenced in client code.",
+    );
+  }
+  if (cachedServerEnv) return cachedServerEnv;
+  const result = validateServerEnv();
+  if (!result.ok || !result.env) {
+    const message = `[env] Server env validation failed:\n${formatIssues(result.issues)}`;
+    // eslint-disable-next-line no-console
+    console.error(message);
+    throw new Error(message);
+  }
+  cachedServerEnv = result.env;
+  return cachedServerEnv;
+}

--- a/app/frontend/src/lib/errorReporter.ts
+++ b/app/frontend/src/lib/errorReporter.ts
@@ -1,3 +1,5 @@
+import { getClientEnv } from "@/lib/env";
+
 export type ErrorContext = {
   requestId?: string;
   correlationId?: string;
@@ -34,9 +36,11 @@ export function redactPII(value: unknown): unknown {
 
 class ErrorReporter {
   async captureError(error: Error, context?: ErrorContext): Promise<void> {
-    const enabled = process.env.NEXT_PUBLIC_ERROR_REPORTING_ENABLED === "true";
-    const environment = process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.NODE_ENV || "unknown";
-    const appVersion = process.env.NEXT_PUBLIC_APP_VERSION || "unknown";
+    const env = getClientEnv();
+    const enabled = env?.errorReportingEnabled ?? false;
+    const environment =
+      env?.vercelEnv ?? process.env.NODE_ENV ?? "unknown";
+    const appVersion = env?.appVersion ?? "unknown";
     const errorPayload = {
       timestamp: new Date().toISOString(),
       error: redactPII({
@@ -56,7 +60,7 @@ class ErrorReporter {
       return;
     }
 
-    const url = process.env.NEXT_PUBLIC_ERROR_REPORTING_URL;
+    const url = env?.errorReportingUrl;
     if (!url) {
       console.warn(
         "Client error reporting URL is not configured. Error payload:",

--- a/app/frontend/src/lib/og-metadata.ts
+++ b/app/frontend/src/lib/og-metadata.ts
@@ -9,19 +9,17 @@
  *  - memo                  → only included when it is a short, non-sensitive label
  */
 
+import { getClientEnv, getServerEnv } from "@/lib/env";
+
 export const SITE_NAME = "QuickEx";
 export const SITE_DESCRIPTION = "Privacy-focused payments on Stellar";
 
 /** Resolved at build/request time from the environment. Falls back to a relative path. */
 export function getSiteUrl(): string {
-  return (
-    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ??
-    process.env.NEXT_PUBLIC_QUICKEX_API_URL?.replace(/\/$/, "").replace(
-      /:4000$/,
-      ":3000",
-    ) ??
-    "https://quickex.to"
-  );
+  const env = getClientEnv();
+  if (env?.siteUrl) return env.siteUrl;
+  if (env?.apiBaseUrl) return env.apiBaseUrl.replace(/:4000$/, ":3000");
+  return "https://quickex.to";
 }
 
 /** The default OG image served from /public */
@@ -49,9 +47,11 @@ export async function fetchPaymentMeta(params: {
   acceptedAssets?: string;
 }): Promise<SafePaymentMeta | null> {
   try {
+    const serverEnv = getServerEnv();
+    const clientEnv = getClientEnv();
     const apiBase =
-      process.env.QUICKEX_INTERNAL_API_URL?.replace(/\/$/, "") ??
-      process.env.NEXT_PUBLIC_QUICKEX_API_URL?.replace(/\/$/, "") ??
+      serverEnv.internalApiUrl ??
+      clientEnv?.apiBaseUrl ??
       "http://localhost:4000";
 
     const qs = new URLSearchParams({ username: params.username, amount: params.amount });


### PR DESCRIPTION
Adds startup-time environment validation, build-time secret scanning, a dedicated Misconfiguration screen, and CI gates so misconfigured deploys fail fast instead of shipping a broken or unsafe app.

Frontend
- New `src/lib/env-validation.mjs` shared by runtime and build script.
- `src/lib/env.ts` exposes validated `clientEnv` / `serverEnv` getters; `getServerEnv` throws if called from the browser.
- `RootLayout` renders `MisconfigurationScreen` instead of booting when critical client env validation fails (with dev hint and fix instructions).
- `prebuild` runs `validate:env`, `postbuild` runs `check:bundle-secrets` which scans `.next/static` for leaked env values and known secret patterns (Stellar S-keys, Supabase service-role JWTs, SendGrid, Telegram).
- Existing readers (`api.ts`, `og-metadata.ts`, `errorReporter.ts`, `NetworkBadge.tsx`, `analyticsApi.ts`, `layout.tsx`) now go through the validated env surface.

Backend
- `scripts/validate-env.ts` runs the existing Joi schema against `process.env` without booting Nest. `pnpm run validate:env` exits 1 on any missing / invalid required variable.

CI
- New `Frontend CI` workflow asserts that `validate:env` fails when required vars are missing (fail-fast contract) and then builds with a minimal valid env, exercising the prebuild/postbuild gates.
- `Backend CI` adds a `validate-env` job (same fail-fast contract) that gates the build job via `needs:`.

Closes: #444 