### PR TITLE
feat: implement asset registry service with database and etags

### DIFF
--- a/app/backend/src/asset-metadata/asset-metadata.controller.ts
+++ b/app/backend/src/asset-metadata/asset-metadata.controller.ts
@@ -7,6 +7,10 @@ import {
   HttpStatus,
   Logger,
   UseGuards,
+  Query,
+  Req,
+  Res,
+  Body,
 } from "@nestjs/common";
 import {
   ApiHeader,
@@ -14,7 +18,10 @@ import {
   ApiResponse,
   ApiTags,
   ApiParam,
+  ApiQuery,
 } from "@nestjs/swagger";
+import { Request, Response } from "express";
+import * as crypto from "crypto";
 
 import { ApiKeyGuard } from "../auth/guards/api-key.guard";
 import { AssetMetadataService } from "./asset-metadata.service";
@@ -22,6 +29,7 @@ import {
   AssetMetadataResponseDto,
   AssetListResponseDto,
 } from "./dto/asset-metadata.dto";
+import { AdminVerifyAssetDto } from "./dto/admin-asset.dto";
 
 @ApiTags("assets")
 @ApiHeader({
@@ -40,16 +48,42 @@ export class AssetMetadataController {
   @ApiOperation({
     summary: "List all verified assets with metadata",
     description:
-      "Returns all verified assets with their branding information, icons, and metadata from TOML files.",
+      "Returns all verified assets with their branding information, icons, and metadata from TOML files. Supports searching by code or issuer.",
+  })
+  @ApiQuery({
+    name: "q",
+    description: "Search query to filter assets by code or issuer key",
+    required: false,
+    example: "USDC",
   })
   @ApiResponse({
     status: 200,
     description: "List of assets with metadata",
     type: AssetListResponseDto,
   })
-  async getAllAssets(): Promise<AssetListResponseDto> {
-    this.logger.debug("Fetching all assets metadata");
-    return this.assetMetadataService.getAllAssetsMetadata();
+  async getAllAssets(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+    @Query("q") query?: string,
+  ): Promise<AssetListResponseDto | void> {
+    this.logger.debug(`Fetching all assets metadata, search query: ${query || "none"}`);
+    const data = await this.assetMetadataService.getAllAssetsMetadata(query);
+
+    // Compute and set ETag header for caching
+    const etag = `W/"${crypto
+      .createHash("sha256")
+      .update(JSON.stringify(data))
+      .digest("hex")}"`;
+    res.setHeader("ETag", etag);
+    res.setHeader("Cache-Control", "public, max-age=0, must-revalidate");
+
+    // Check If-None-Match conditional request
+    if (req.headers["if-none-match"] === etag) {
+      res.status(HttpStatus.NOT_MODIFIED);
+      return;
+    }
+
+    return data;
   }
 
   @Get(":code")
@@ -63,6 +97,11 @@ export class AssetMetadataController {
     description: "Asset code (e.g., USDC, XLM, AQUA)",
     example: "USDC",
   })
+  @ApiQuery({
+    name: "issuer",
+    description: "Asset issuer public key (null/omitted for native XLM)",
+    required: false,
+  })
   @ApiResponse({
     status: 200,
     description: "Asset metadata retrieved successfully",
@@ -74,9 +113,56 @@ export class AssetMetadataController {
   })
   async getAssetMetadata(
     @Param("code") code: string,
+    @Query("issuer") issuer: string | undefined,
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<AssetMetadataResponseDto | void> {
+    this.logger.debug(`Fetching metadata for asset: ${code} (issuer: ${issuer || "none"})`);
+    const data = await this.assetMetadataService.getAssetMetadata(code, issuer);
+
+    // Compute and set ETag header for caching
+    const etag = `W/"${crypto
+      .createHash("sha256")
+      .update(JSON.stringify(data))
+      .digest("hex")}"`;
+    res.setHeader("ETag", etag);
+    res.setHeader("Cache-Control", "public, max-age=0, must-revalidate");
+
+    // Check If-None-Match conditional request
+    if (req.headers["if-none-match"] === etag) {
+      res.status(HttpStatus.NOT_MODIFIED);
+      return;
+    }
+
+    return data;
+  }
+
+  @Post("admin/verify")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Mark asset verified or unverified",
+    description:
+      "Admin workflow to verify/unverify assets and store them in the database.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Asset verification status updated successfully",
+    type: AssetMetadataResponseDto,
+  })
+  async verifyAsset(
+    @Body() body: AdminVerifyAssetDto,
   ): Promise<AssetMetadataResponseDto> {
-    this.logger.debug(`Fetching metadata for asset: ${code}`);
-    return this.assetMetadataService.getAssetMetadata(code);
+    this.logger.log(`Admin updating verification status for asset: ${body.code}`);
+    return this.assetMetadataService.verifyAsset(
+      body.code,
+      body.issuer ?? null,
+      body.verified,
+      {
+        type: body.type,
+        decimals: body.decimals,
+        iconUrl: body.iconUrl,
+      },
+    );
   }
 
   @Post(":code/refresh")
@@ -91,6 +177,11 @@ export class AssetMetadataController {
     description: "Asset code to refresh (e.g., USDC)",
     example: "USDC",
   })
+  @ApiQuery({
+    name: "issuer",
+    description: "Asset issuer public key (null/omitted for native XLM)",
+    required: false,
+  })
   @ApiResponse({
     status: 200,
     description: "Asset metadata refreshed successfully",
@@ -98,9 +189,10 @@ export class AssetMetadataController {
   })
   async refreshAssetMetadata(
     @Param("code") code: string,
+    @Query("issuer") issuer?: string,
   ): Promise<AssetMetadataResponseDto> {
-    this.logger.log(`Refreshing metadata for asset: ${code}`);
-    return this.assetMetadataService.refreshAssetMetadata(code);
+    this.logger.log(`Refreshing metadata for asset: ${code} (issuer: ${issuer || "none"})`);
+    return this.assetMetadataService.refreshAssetMetadata(code, issuer);
   }
 
   @Get("cache/stats")

--- a/app/backend/src/asset-metadata/asset-metadata.controller.unit.spec.ts
+++ b/app/backend/src/asset-metadata/asset-metadata.controller.unit.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AssetMetadataController } from "./asset-metadata.controller";
+import { AssetMetadataService } from "./asset-metadata.service";
+import { ApiKeyGuard } from "../auth/guards/api-key.guard";
+import { Request, Response } from "express";
+import * as crypto from "crypto";
+
+describe("AssetMetadataController", () => {
+  let controller: AssetMetadataController;
+  let service: jest.Mocked<AssetMetadataService>;
+
+  beforeEach(async () => {
+    const mockService = {
+      getAllAssetsMetadata: jest.fn(),
+      getAssetMetadata: jest.fn(),
+      refreshAssetMetadata: jest.fn(),
+      verifyAsset: jest.fn(),
+      getCacheStats: jest.fn(),
+      clearCache: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AssetMetadataController],
+      providers: [{ provide: AssetMetadataService, useValue: mockService }],
+    })
+      .overrideGuard(ApiKeyGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<AssetMetadataController>(AssetMetadataController);
+    service = module.get(AssetMetadataService);
+  });
+
+  describe("getAllAssets", () => {
+    it("should return data and set ETag header on first request", async () => {
+      const mockResult = {
+        assets: [
+          {
+            code: "USDC",
+            issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+            type: "credit_alphanum4" as const,
+            decimals: 7,
+            verified: true,
+            branding: {},
+            isFallback: false,
+            updatedAt: new Date().toISOString(),
+          },
+        ],
+        total: 1,
+      };
+
+      service.getAllAssetsMetadata.mockResolvedValue(mockResult);
+
+      const mockReq = { headers: {} } as unknown as Request;
+      const headersMap: Record<string, string> = {};
+      const mockRes = {
+        setHeader: jest.fn().mockImplementation((name, val) => {
+          headersMap[name] = val;
+        }),
+        status: jest.fn(),
+      } as unknown as Response;
+
+      const result = await controller.getAllAssets(mockReq, mockRes, "usdc");
+
+      expect(service.getAllAssetsMetadata).toHaveBeenCalledWith("usdc");
+      expect(result).toEqual(mockResult);
+      expect(mockRes.setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=0, must-revalidate");
+      expect(headersMap["ETag"]).toBeDefined();
+    });
+
+    it("should return 304 Not Modified if If-None-Match matches ETag", async () => {
+      const mockResult = { assets: [], total: 0 };
+      service.getAllAssetsMetadata.mockResolvedValue(mockResult);
+
+      const etag = `W/"${crypto
+        .createHash("sha256")
+        .update(JSON.stringify(mockResult))
+        .digest("hex")}"`;
+
+      const mockReq = {
+        headers: { "if-none-match": etag },
+      } as unknown as Request;
+
+      const mockRes = {
+        setHeader: jest.fn(),
+        status: jest.fn(),
+      } as unknown as Response;
+
+      const result = await controller.getAllAssets(mockReq, mockRes);
+
+      expect(result).toBeUndefined();
+      expect(mockRes.status).toHaveBeenCalledWith(304);
+    });
+  });
+
+  describe("verifyAsset", () => {
+    it("should call service verifyAsset and return metadata", async () => {
+      const body = {
+        code: "USDC",
+        issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+        type: "credit_alphanum4" as const,
+        decimals: 7,
+        iconUrl: "https://example.com/icon.png",
+        verified: true,
+      };
+
+      const expectedResponse = {
+        code: "USDC",
+        issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+        type: "credit_alphanum4" as const,
+        decimals: 7,
+        verified: true,
+        branding: {},
+        isFallback: false,
+        updatedAt: new Date().toISOString(),
+      };
+
+      service.verifyAsset.mockResolvedValue(expectedResponse);
+
+      const result = await controller.verifyAsset(body);
+
+      expect(service.verifyAsset).toHaveBeenCalledWith(
+        "USDC",
+        "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+        true,
+        {
+          type: "credit_alphanum4",
+          decimals: 7,
+          iconUrl: "https://example.com/icon.png",
+        }
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+});

--- a/app/backend/src/asset-metadata/asset-metadata.module.ts
+++ b/app/backend/src/asset-metadata/asset-metadata.module.ts
@@ -2,13 +2,14 @@ import { Module, forwardRef } from '@nestjs/common';
 
 import { StellarModule } from '../stellar/stellar.module';
 import { ApiKeysModule } from '../api-keys/api-keys.module';
+import { SupabaseModule } from '../supabase/supabase.module';
 import { AssetMetadataController } from './asset-metadata.controller';
 import { AssetMetadataService } from './asset-metadata.service';
 import { AssetMetadataCache } from './cache/asset-metadata.cache';
 import { TomlFetcherService } from './toml-fetcher.service';
 
 @Module({
-  imports: [forwardRef(() => StellarModule), ApiKeysModule],
+  imports: [forwardRef(() => StellarModule), ApiKeysModule, SupabaseModule],
   controllers: [AssetMetadataController],
   providers: [AssetMetadataService, AssetMetadataCache, TomlFetcherService],
   exports: [AssetMetadataService, AssetMetadataCache],

--- a/app/backend/src/asset-metadata/asset-metadata.service.ts
+++ b/app/backend/src/asset-metadata/asset-metadata.service.ts
@@ -14,6 +14,7 @@ import {
   AssetMetadataResponseDto,
   AssetListResponseDto,
 } from './dto/asset-metadata.dto';
+import { SupabaseService, VerifiedAssetDbRecord } from '../supabase/supabase.service';
 
 @Injectable()
 export class AssetMetadataService {
@@ -46,65 +47,196 @@ export class AssetMetadataService {
     private readonly cache: AssetMetadataCache,
     private readonly tomlFetcher: TomlFetcherService,
     private readonly horizonService: HorizonService,
+    private readonly supabaseService: SupabaseService,
   ) {}
 
-  /**
-   * Get metadata for all verified assets
-   */
-  async getAllAssetsMetadata(): Promise<AssetListResponseDto> {
-    const assets = await Promise.all(
-      VERIFIED_STELLAR_ASSETS.map((asset) => this.getAssetMetadata(asset.code)),
-    );
-
+  private mapDbRecordToRecord(dbRecord: VerifiedAssetDbRecord): VerifiedAssetRecord {
     return {
-      assets,
-      total: assets.length,
+      code: dbRecord.code,
+      type: dbRecord.type,
+      issuer: dbRecord.issuer,
+      verified: dbRecord.verified as true,
+      decimals: dbRecord.decimals,
+      branding: dbRecord.icon_url ? {
+        name: dbRecord.code,
+        icon: dbRecord.icon_url,
+        logo: dbRecord.icon_url,
+      } : undefined,
     };
   }
 
   /**
-   * Get metadata for a specific asset code
+   * Get metadata for all verified assets, optionally filtered by a search query
    */
-  async getAssetMetadata(code: string): Promise<AssetMetadataResponseDto> {
-    const upperCode = code.toUpperCase();
-    const verifiedAsset = VERIFIED_STELLAR_ASSETS.find(
-      (a) => a.code.toUpperCase() === upperCode,
+  async getAllAssetsMetadata(search?: string): Promise<AssetListResponseDto> {
+    const cacheKey = search ? `list:search:${search.toUpperCase()}` : 'list:all';
+    
+    // Check cache first
+    const cachedList = this.cache.get(cacheKey);
+    if (cachedList) {
+      return cachedList;
+    }
+
+    let records: VerifiedAssetRecord[] = [];
+
+    try {
+      let dbRecords: VerifiedAssetDbRecord[] = [];
+      if (search) {
+        dbRecords = await this.supabaseService.searchVerifiedAssets(search);
+      } else {
+        dbRecords = await this.supabaseService.fetchVerifiedAssets();
+      }
+
+      // Filter only verified assets and map them
+      records = dbRecords
+        .filter((r) => r.verified)
+        .map((r) => this.mapDbRecordToRecord(r));
+    } catch (error) {
+      this.logger.warn(`Failed to fetch assets from database: ${error.message}`);
+    }
+
+    // If DB returned nothing or failed, use fallback constant
+    if (records.length === 0) {
+      const fallbackList = VERIFIED_STELLAR_ASSETS.map(asset => ({ ...asset }));
+      if (search) {
+        const upperSearch = search.toUpperCase();
+        records = fallbackList.filter(
+          (a) =>
+            a.code.toUpperCase().includes(upperSearch) ||
+            (a.issuer && a.issuer.toUpperCase().includes(upperSearch)),
+        ) as VerifiedAssetRecord[];
+      } else {
+        records = fallbackList as VerifiedAssetRecord[];
+      }
+    }
+
+    const assets = await Promise.all(
+      records.map((asset) => this.getAssetMetadata(asset.code, asset.issuer)),
     );
+
+    const response: AssetListResponseDto = {
+      assets,
+      total: assets.length,
+    };
+
+    // Cache the list response
+    this.cache.set(cacheKey, response);
+
+    return response;
+  }
+
+  /**
+   * Get metadata for a specific asset code and optional issuer
+   */
+  async getAssetMetadata(code: string, issuer?: string | null): Promise<AssetMetadataResponseDto> {
+    const upperCode = code.toUpperCase();
+    const normIssuer = issuer || null;
+    const cacheKey = normIssuer ? `${upperCode}:${normIssuer.toUpperCase()}` : upperCode;
+
+    // Check cache first
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      return this.mapToResponseDto(cached.asset, cached.branding, cached.isFallback);
+    }
+
+    // Try finding the asset:
+    let verifiedAsset: VerifiedAssetRecord | undefined;
+
+    // 1. Try DB first
+    try {
+      const dbRecords = await this.supabaseService.fetchVerifiedAssets();
+      const dbRecord = dbRecords.find(
+        (r) =>
+          r.code.toUpperCase() === upperCode &&
+          (normIssuer === null
+            ? r.issuer === null
+            : r.issuer?.toUpperCase() === normIssuer.toUpperCase())
+      );
+      if (dbRecord) {
+        verifiedAsset = this.mapDbRecordToRecord(dbRecord);
+      }
+    } catch (error) {
+      this.logger.debug(`Could not check DB for asset metadata: ${error.message}`);
+    }
+
+    // 2. Fall back to constant whitelist
+    if (!verifiedAsset) {
+      const fallback = VERIFIED_STELLAR_ASSETS.find(
+        (a) =>
+          a.code.toUpperCase() === upperCode &&
+          (normIssuer === null
+            ? a.issuer === null
+            : a.issuer?.toUpperCase() === normIssuer.toUpperCase())
+      );
+      if (fallback) {
+        verifiedAsset = { ...fallback } as VerifiedAssetRecord;
+      }
+    }
 
     if (!verifiedAsset) {
       // Return unverified asset with fallback branding
       return this.createUnverifiedResponse(code);
     }
 
-    // Check cache first
-    const cached = this.cache.get(upperCode);
-    if (cached) {
-      return this.mapToResponseDto(verifiedAsset, cached.branding, false);
-    }
-
     // Fetch branding from TOML or use fallback
     const branding = await this.fetchAssetBranding(verifiedAsset);
+    const isFallback = this.isFallbackBranding(branding, verifiedAsset);
 
     // Cache the result
-    const cachedMetadata: CachedAssetMetadata = {
-      code: verifiedAsset.code,
-      issuer: verifiedAsset.issuer,
+    const cachedMetadata = {
+      asset: verifiedAsset,
       branding,
+      isFallback,
       fetchedAt: new Date(),
-      ttl: 1000 * 60 * 60 * 24, // 24 hours
     };
-    this.cache.set(upperCode, cachedMetadata);
+    this.cache.set(cacheKey, cachedMetadata);
 
-    const isFallback = this.isFallbackBranding(branding, verifiedAsset);
     return this.mapToResponseDto(verifiedAsset, branding, isFallback);
   }
 
   /**
    * Refresh metadata for a specific asset (clear cache and re-fetch)
    */
-  async refreshAssetMetadata(code: string): Promise<AssetMetadataResponseDto> {
-    this.cache.delete(code.toUpperCase());
-    return this.getAssetMetadata(code);
+  async refreshAssetMetadata(code: string, issuer?: string | null): Promise<AssetMetadataResponseDto> {
+    const normIssuer = issuer || null;
+    const cacheKey = normIssuer ? `${code.toUpperCase()}:${normIssuer.toUpperCase()}` : code.toUpperCase();
+    this.cache.delete(cacheKey);
+    // Clear list cache to reflect any changes
+    this.cache.clear();
+    return this.getAssetMetadata(code, issuer);
+  }
+
+  /**
+   * Mark an asset as verified/unverified in database and clear cache
+   */
+  async verifyAsset(
+    code: string,
+    issuer: string | null,
+    verified: boolean,
+    additionalData?: {
+      type?: 'native' | 'credit_alphanum4' | 'credit_alphanum12';
+      decimals?: number;
+      iconUrl?: string | null;
+    }
+  ): Promise<AssetMetadataResponseDto> {
+    const normCode = code.toUpperCase();
+    const normIssuer = issuer || null;
+
+    // Save/update in database
+    await this.supabaseService.upsertVerifiedAsset({
+      code: normCode,
+      issuer: normIssuer,
+      type: additionalData?.type || (normCode === 'XLM' ? 'native' : 'credit_alphanum4'),
+      decimals: additionalData?.decimals ?? 7,
+      icon_url: additionalData?.iconUrl || null,
+      verified,
+    });
+
+    // Clear entire cache immediately so changes are reflected
+    this.cache.clear();
+
+    // Fetch fresh metadata
+    return this.getAssetMetadata(normCode, normIssuer);
   }
 
   /**

--- a/app/backend/src/asset-metadata/asset-metadata.service.ts
+++ b/app/backend/src/asset-metadata/asset-metadata.service.ts
@@ -8,7 +8,6 @@ import { AssetMetadataCache } from './cache/asset-metadata.cache';
 import { TomlFetcherService } from './toml-fetcher.service';
 import {
   AssetBranding,
-  CachedAssetMetadata,
 } from './types/asset-metadata.types';
 import {
   AssetMetadataResponseDto,
@@ -72,7 +71,7 @@ export class AssetMetadataService {
     const cacheKey = search ? `list:search:${search.toUpperCase()}` : 'list:all';
     
     // Check cache first
-    const cachedList = this.cache.get(cacheKey);
+    const cachedList = this.cache.get(cacheKey) as AssetListResponseDto | undefined;
     if (cachedList) {
       return cachedList;
     }
@@ -134,7 +133,12 @@ export class AssetMetadataService {
     const cacheKey = normIssuer ? `${upperCode}:${normIssuer.toUpperCase()}` : upperCode;
 
     // Check cache first
-    const cached = this.cache.get(cacheKey);
+    const cached = this.cache.get(cacheKey) as {
+      asset: VerifiedAssetRecord;
+      branding: AssetBranding;
+      isFallback: boolean;
+      fetchedAt: Date;
+    } | undefined;
     if (cached) {
       return this.mapToResponseDto(cached.asset, cached.branding, cached.isFallback);
     }

--- a/app/backend/src/asset-metadata/asset-metadata.service.unit.spec.ts
+++ b/app/backend/src/asset-metadata/asset-metadata.service.unit.spec.ts
@@ -10,7 +10,6 @@ describe("AssetMetadataService", () => {
   let service: AssetMetadataService;
   let cache: jest.Mocked<AssetMetadataCache>;
   let tomlFetcher: jest.Mocked<TomlFetcherService>;
-  let horizonService: jest.Mocked<HorizonService>;
   let supabaseService: jest.Mocked<SupabaseService>;
 
   const mockDbAssets = [
@@ -77,7 +76,6 @@ describe("AssetMetadataService", () => {
     service = module.get<AssetMetadataService>(AssetMetadataService);
     cache = module.get(AssetMetadataCache);
     tomlFetcher = module.get(TomlFetcherService);
-    horizonService = module.get(HorizonService);
     supabaseService = module.get(SupabaseService);
   });
 

--- a/app/backend/src/asset-metadata/asset-metadata.service.unit.spec.ts
+++ b/app/backend/src/asset-metadata/asset-metadata.service.unit.spec.ts
@@ -1,0 +1,197 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AssetMetadataService } from "./asset-metadata.service";
+import { AssetMetadataCache } from "./cache/asset-metadata.cache";
+import { TomlFetcherService } from "./toml-fetcher.service";
+import { HorizonService } from "../stellar/horizon.service";
+import { SupabaseService } from "../supabase/supabase.service";
+import { VERIFIED_STELLAR_ASSETS } from "../stellar/verified-assets.constant";
+
+describe("AssetMetadataService", () => {
+  let service: AssetMetadataService;
+  let cache: jest.Mocked<AssetMetadataCache>;
+  let tomlFetcher: jest.Mocked<TomlFetcherService>;
+  let horizonService: jest.Mocked<HorizonService>;
+  let supabaseService: jest.Mocked<SupabaseService>;
+
+  const mockDbAssets = [
+    {
+      id: "uuid-1",
+      code: "USDC",
+      issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      type: "credit_alphanum4" as const,
+      decimals: 7,
+      icon_url: "https://example.com/usdc.png",
+      verified: true,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    {
+      id: "uuid-2",
+      code: "XLM",
+      issuer: null,
+      type: "native" as const,
+      decimals: 7,
+      icon_url: "https://example.com/xlm.png",
+      verified: true,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+  ];
+
+  beforeEach(async () => {
+    const mockCache = {
+      get: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+      clear: jest.fn(),
+      getStats: jest.fn(),
+    };
+
+    const mockTomlFetcher = {
+      fetchStellarToml: jest.fn(),
+      findCurrency: jest.fn(),
+      extractBranding: jest.fn(),
+    };
+
+    const mockHorizonService = {
+      // Mock any horizon methods used
+    };
+
+    const mockSupabaseService = {
+      fetchVerifiedAssets: jest.fn(),
+      searchVerifiedAssets: jest.fn(),
+      upsertVerifiedAsset: jest.fn(),
+      updateAssetVerificationStatus: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AssetMetadataService,
+        { provide: AssetMetadataCache, useValue: mockCache },
+        { provide: TomlFetcherService, useValue: mockTomlFetcher },
+        { provide: HorizonService, useValue: mockHorizonService },
+        { provide: SupabaseService, useValue: mockSupabaseService },
+      ],
+    }).compile();
+
+    service = module.get<AssetMetadataService>(AssetMetadataService);
+    cache = module.get(AssetMetadataCache);
+    tomlFetcher = module.get(TomlFetcherService);
+    horizonService = module.get(HorizonService);
+    supabaseService = module.get(SupabaseService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getAllAssetsMetadata", () => {
+    it("should return verified assets from database if database fetch succeeds", async () => {
+      supabaseService.fetchVerifiedAssets.mockResolvedValue(mockDbAssets);
+      cache.get.mockReturnValue(undefined); // cache miss
+      tomlFetcher.fetchStellarToml.mockResolvedValue({});
+
+      const result = await service.getAllAssetsMetadata();
+
+      expect(supabaseService.fetchVerifiedAssets).toHaveBeenCalled();
+      expect(result.assets.length).toBe(2);
+      expect(result.assets[0].code).toBe("USDC");
+      expect(result.assets[1].code).toBe("XLM");
+      expect(cache.set).toHaveBeenCalled();
+    });
+
+    it("should fall back to constant verified assets list if database returns empty or fails", async () => {
+      supabaseService.fetchVerifiedAssets.mockRejectedValue(new Error("DB error"));
+      cache.get.mockReturnValue(undefined);
+      tomlFetcher.fetchStellarToml.mockResolvedValue({});
+
+      const result = await service.getAllAssetsMetadata();
+
+      expect(supabaseService.fetchVerifiedAssets).toHaveBeenCalled();
+      expect(result.assets.length).toBe(VERIFIED_STELLAR_ASSETS.length);
+      expect(result.assets.map(a => a.code)).toContain("XLM");
+      expect(result.assets.map(a => a.code)).toContain("USDC");
+    });
+
+    it("should return cached assets list if list is cached", async () => {
+      const mockCachedResponse = { assets: [], total: 0 };
+      cache.get.mockReturnValue(mockCachedResponse);
+
+      const result = await service.getAllAssetsMetadata();
+
+      expect(cache.get).toHaveBeenCalledWith("list:all");
+      expect(supabaseService.fetchVerifiedAssets).not.toHaveBeenCalled();
+      expect(result).toEqual(mockCachedResponse);
+    });
+
+    it("should filter assets by search query", async () => {
+      supabaseService.searchVerifiedAssets.mockResolvedValue([mockDbAssets[0]]); // only USDC
+      cache.get.mockReturnValue(undefined);
+      tomlFetcher.fetchStellarToml.mockResolvedValue({});
+
+      const result = await service.getAllAssetsMetadata("usdc");
+
+      expect(supabaseService.searchVerifiedAssets).toHaveBeenCalledWith("usdc");
+      expect(result.assets.length).toBe(1);
+      expect(result.assets[0].code).toBe("USDC");
+    });
+  });
+
+  describe("getAssetMetadata", () => {
+    it("should return cached asset metadata if it is cached", async () => {
+      const mockCachedAsset = {
+        asset: { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
+        branding: { name: "USD Coin" },
+        isFallback: false,
+      };
+      cache.get.mockReturnValue(mockCachedAsset);
+
+      const result = await service.getAssetMetadata("USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN");
+
+      expect(cache.get).toHaveBeenCalledWith("USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN");
+      expect(result.code).toBe("USDC");
+      expect(result.branding.name).toBe("USD Coin");
+    });
+  });
+
+  describe("verifyAsset", () => {
+    it("should upsert asset to database, clear cache and return metadata", async () => {
+      const updatedAsset = {
+        id: "uuid-3",
+        code: "NEWCOIN",
+        issuer: "GBNEWCOIN",
+        type: "credit_alphanum12" as const,
+        decimals: 7,
+        icon_url: "https://example.com/icon.png",
+        verified: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      supabaseService.upsertVerifiedAsset.mockResolvedValue(updatedAsset);
+      supabaseService.fetchVerifiedAssets.mockResolvedValue([updatedAsset]);
+      tomlFetcher.fetchStellarToml.mockResolvedValue({});
+
+      const result = await service.verifyAsset(
+        "NEWCOIN",
+        "GBNEWCOIN",
+        true,
+        {
+          type: "credit_alphanum12",
+          decimals: 7,
+          iconUrl: "https://example.com/icon.png",
+        }
+      );
+
+      expect(supabaseService.upsertVerifiedAsset).toHaveBeenCalledWith({
+        code: "NEWCOIN",
+        issuer: "GBNEWCOIN",
+        type: "credit_alphanum12",
+        decimals: 7,
+        icon_url: "https://example.com/icon.png",
+        verified: true,
+      });
+      expect(cache.clear).toHaveBeenCalled();
+      expect(result.code).toBe("NEWCOIN");
+    });
+  });
+});

--- a/app/backend/src/asset-metadata/cache/asset-metadata.cache.ts
+++ b/app/backend/src/asset-metadata/cache/asset-metadata.cache.ts
@@ -1,15 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { LRUCache } from 'lru-cache';
-import { CachedAssetMetadata } from '../types/asset-metadata.types';
 
 @Injectable()
 export class AssetMetadataCache {
   private readonly logger = new Logger(AssetMetadataCache.name);
-  private readonly cache: LRUCache<string, any>;
+  private readonly cache: LRUCache<string, unknown>;
   private readonly DEFAULT_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
 
   constructor() {
-    this.cache = new LRUCache<string, any>({
+    this.cache = new LRUCache<string, unknown>({
       max: 500, // Maximum 500 assets cached
       ttl: this.DEFAULT_TTL_MS,
       updateAgeOnGet: true,
@@ -21,7 +20,7 @@ export class AssetMetadataCache {
   /**
    * Get cached asset metadata by asset code
    */
-  get(code: string): any | undefined {
+  get(code: string): unknown | undefined {
     const key = this.getCacheKey(code);
     const cached = this.cache.get(key);
     if (cached) {
@@ -33,7 +32,7 @@ export class AssetMetadataCache {
   /**
    * Set asset metadata in cache
    */
-  set(code: string, metadata: any): void {
+  set(code: string, metadata: unknown): void {
     const key = this.getCacheKey(code);
     this.cache.set(key, metadata);
     this.logger.debug(`Cached metadata for asset: ${code}`);

--- a/app/backend/src/asset-metadata/cache/asset-metadata.cache.ts
+++ b/app/backend/src/asset-metadata/cache/asset-metadata.cache.ts
@@ -5,11 +5,11 @@ import { CachedAssetMetadata } from '../types/asset-metadata.types';
 @Injectable()
 export class AssetMetadataCache {
   private readonly logger = new Logger(AssetMetadataCache.name);
-  private readonly cache: LRUCache<string, CachedAssetMetadata>;
+  private readonly cache: LRUCache<string, any>;
   private readonly DEFAULT_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
 
   constructor() {
-    this.cache = new LRUCache<string, CachedAssetMetadata>({
+    this.cache = new LRUCache<string, any>({
       max: 500, // Maximum 500 assets cached
       ttl: this.DEFAULT_TTL_MS,
       updateAgeOnGet: true,
@@ -21,7 +21,7 @@ export class AssetMetadataCache {
   /**
    * Get cached asset metadata by asset code
    */
-  get(code: string): CachedAssetMetadata | undefined {
+  get(code: string): any | undefined {
     const key = this.getCacheKey(code);
     const cached = this.cache.get(key);
     if (cached) {
@@ -33,7 +33,7 @@ export class AssetMetadataCache {
   /**
    * Set asset metadata in cache
    */
-  set(code: string, metadata: CachedAssetMetadata): void {
+  set(code: string, metadata: any): void {
     const key = this.getCacheKey(code);
     this.cache.set(key, metadata);
     this.logger.debug(`Cached metadata for asset: ${code}`);

--- a/app/backend/src/asset-metadata/dto/admin-asset.dto.ts
+++ b/app/backend/src/asset-metadata/dto/admin-asset.dto.ts
@@ -5,7 +5,6 @@ import {
   IsInt,
   IsOptional,
   IsString,
-  IsUrl,
   Max,
   Min,
 } from "class-validator";

--- a/app/backend/src/asset-metadata/dto/admin-asset.dto.ts
+++ b/app/backend/src/asset-metadata/dto/admin-asset.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Max,
+  Min,
+} from "class-validator";
+
+export class AdminVerifyAssetDto {
+  @ApiProperty({ description: "Asset code (e.g., USDC, XLM)", example: "USDC" })
+  @IsString()
+  code: string;
+
+  @ApiPropertyOptional({
+    description: "Asset issuer public key (null for native XLM)",
+    example: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+  })
+  @IsOptional()
+  @IsString()
+  issuer?: string;
+
+  @ApiPropertyOptional({
+    description: "Asset type",
+    enum: ["native", "credit_alphanum4", "credit_alphanum12"],
+    default: "credit_alphanum4",
+  })
+  @IsOptional()
+  @IsEnum(["native", "credit_alphanum4", "credit_alphanum12"])
+  type?: "native" | "credit_alphanum4" | "credit_alphanum12";
+
+  @ApiPropertyOptional({
+    description: "Number of decimal places (typically 7 for Stellar assets)",
+    default: 7,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(14)
+  decimals?: number;
+
+  @ApiPropertyOptional({
+    description: "URL to the asset icon image",
+    example: "https://example.com/icon.png",
+  })
+  @IsOptional()
+  @IsString()
+  iconUrl?: string;
+
+  @ApiProperty({
+    description: "Whether the asset is marked as verified",
+    example: true,
+  })
+  @IsBoolean()
+  verified: boolean;
+}

--- a/app/backend/src/supabase/supabase.service.ts
+++ b/app/backend/src/supabase/supabase.service.ts
@@ -52,6 +52,18 @@ export interface MarketplaceBid {
   updated_at: string;
 }
 
+export interface VerifiedAssetDbRecord {
+  id: string;
+  code: string;
+  issuer: string | null;
+  type: "native" | "credit_alphanum4" | "credit_alphanum12";
+  decimals: number;
+  icon_url: string | null;
+  verified: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 @Injectable()
 export class SupabaseService {
   private readonly logger = new Logger(SupabaseService.name);
@@ -753,5 +765,104 @@ export class SupabaseService {
       p_seller_public_key: sellerPublicKey,
     });
     if (error) this.handleError(error);
+  }
+
+  async fetchVerifiedAssets(): Promise<VerifiedAssetDbRecord[]> {
+    const { data, error } = await this.client
+      .from("verified_assets")
+      .select("*")
+      .order("code", { ascending: true });
+    if (error) this.handleError(error);
+    return (data ?? []) as VerifiedAssetDbRecord[];
+  }
+
+  async searchVerifiedAssets(query: string): Promise<VerifiedAssetDbRecord[]> {
+    const pattern = `%${query.trim().toLowerCase()}%`;
+    const { data, error } = await this.client
+      .from("verified_assets")
+      .select("*")
+      .or(`code.ilike.${pattern},issuer.ilike.${pattern}`)
+      .order("code", { ascending: true });
+    if (error) this.handleError(error);
+    return (data ?? []) as VerifiedAssetDbRecord[];
+  }
+
+  async upsertVerifiedAsset(asset: {
+    code: string;
+    issuer: string | null;
+    type: "native" | "credit_alphanum4" | "credit_alphanum12";
+    decimals: number;
+    icon_url: string | null;
+    verified: boolean;
+  }): Promise<VerifiedAssetDbRecord> {
+    let selectQuery = this.client
+      .from("verified_assets")
+      .select("*")
+      .eq("code", asset.code);
+
+    if (asset.issuer === null) {
+      selectQuery = selectQuery.is("issuer", null);
+    } else {
+      selectQuery = selectQuery.eq("issuer", asset.issuer);
+    }
+
+    const { data: existing, error: selectError } = await selectQuery.maybeSingle();
+    if (selectError) this.handleError(selectError);
+
+    if (existing) {
+      const { data, error } = await this.client
+        .from("verified_assets")
+        .update({
+          type: asset.type,
+          decimals: asset.decimals,
+          icon_url: asset.icon_url,
+          verified: asset.verified,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", existing.id)
+        .select()
+        .single();
+      if (error) this.handleError(error);
+      return data as VerifiedAssetDbRecord;
+    } else {
+      const { data, error } = await this.client
+        .from("verified_assets")
+        .insert({
+          code: asset.code,
+          issuer: asset.issuer,
+          type: asset.type,
+          decimals: asset.decimals,
+          icon_url: asset.icon_url,
+          verified: asset.verified,
+        })
+        .select()
+        .single();
+      if (error) this.handleError(error);
+      return data as VerifiedAssetDbRecord;
+    }
+  }
+
+  async updateAssetVerificationStatus(
+    code: string,
+    issuer: string | null,
+    verified: boolean,
+  ): Promise<VerifiedAssetDbRecord | null> {
+    let query = this.client
+      .from("verified_assets")
+      .update({
+        verified,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("code", code);
+
+    if (issuer === null) {
+      query = query.is("issuer", null);
+    } else {
+      query = query.eq("issuer", issuer);
+    }
+
+    const { data, error } = await query.select().maybeSingle();
+    if (error) this.handleError(error);
+    return data as VerifiedAssetDbRecord | null;
   }
 }

--- a/app/backend/supabase/migrations/20260526000000_create_verified_assets.sql
+++ b/app/backend/supabase/migrations/20260526000000_create_verified_assets.sql
@@ -1,0 +1,38 @@
+-- Create verified_assets table for asset registry (BE-07)
+--
+-- Stores verified assets (XLM, USDC, etc.) plus metadata used by link generators and path payments.
+
+CREATE TABLE IF NOT EXISTS verified_assets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code VARCHAR(12) NOT NULL,
+  issuer VARCHAR(56), -- NULL for XLM (native)
+  type VARCHAR(20) NOT NULL, -- 'native' | 'credit_alphanum4' | 'credit_alphanum12'
+  decimals INTEGER NOT NULL DEFAULT 7,
+  icon_url TEXT,
+  verified BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Index for searching and listing
+CREATE INDEX IF NOT EXISTS idx_verified_assets_code ON verified_assets(code);
+CREATE INDEX IF NOT EXISTS idx_verified_assets_verified ON verified_assets(verified);
+
+-- Custom unique constraints:
+-- 1. Only one native asset (XLM) where issuer is null
+CREATE UNIQUE INDEX IF NOT EXISTS idx_verified_assets_native_uniq ON verified_assets (code) WHERE issuer IS NULL;
+-- 2. Non-native assets must have unique code and issuer pairs
+CREATE UNIQUE INDEX IF NOT EXISTS idx_verified_assets_code_issuer_uniq ON verified_assets (code, issuer) WHERE issuer IS NOT NULL;
+
+-- Seed initial verified assets
+INSERT INTO verified_assets (code, issuer, type, decimals, icon_url, verified)
+VALUES
+  ('XLM', NULL, 'native', 7, 'https://assets.stellar.org/images/logos/xlm-icon.svg', true)
+ON CONFLICT (code) WHERE issuer IS NULL DO NOTHING;
+
+INSERT INTO verified_assets (code, issuer, type, decimals, icon_url, verified)
+VALUES
+  ('USDC', 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN', 'credit_alphanum4', 7, 'https://www.circle.com/usdc-icon', true),
+  ('AQUA', 'GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA', 'credit_alphanum4', 7, NULL, true),
+  ('yXLM', 'GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55', 'credit_alphanum4', 7, NULL, true)
+ON CONFLICT (code, issuer) WHERE issuer IS NOT NULL DO NOTHING;


### PR DESCRIPTION
Created a database migration to define and seed the verified_assets table.
Implemented database querying and upserting operations in SupabaseService.
Updated AssetMetadataService to fetch verified assets dynamically from the database with in-memory caching and resilient static whitelist fallbacks.
Enhanced AssetMetadataController to support a search query parameter, compute and validate ETags for HTTP 304 response caching, and expose a POST /assets/admin/verify admin endpoint to modify asset verification statuses.
Wrote comprehensive unit tests covering the controller caching logic, ETag computation, and service DB query behaviors.

closes #242 