### PR TITLE
feat(backend): single-source stellar network runtime config

### DIFF
--- a/app/backend/src/config/app-config.service.ts
+++ b/app/backend/src/config/app-config.service.ts
@@ -138,6 +138,14 @@ export class AppConfigService {
     return this.configService.get('HORIZON_URL', { infer: true });
   }
 
+  get sorobanRpcUrl(): string | undefined {
+    return this.configService.get('SOROBAN_RPC_URL', { infer: true });
+  }
+
+  get stellarExplorerUrl(): string | undefined {
+    return this.configService.get('STELLAR_EXPLORER_URL', { infer: true });
+  }
+
   /**
    * Stellar secret key (optional). Required for signing transactions.
    */

--- a/app/backend/src/config/config.module.ts
+++ b/app/backend/src/config/config.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 
 import { AppConfigService } from './app-config.service';
 import { envSchema } from './env.schema';
+import { NetworkController } from './network.controller';
 import { stellarConfig } from './stellar.config';
 
 /**
@@ -23,6 +24,7 @@ import { stellarConfig } from './stellar.config';
       },
     }),
   ],
+  controllers: [NetworkController],
   providers: [AppConfigService],
   exports: [AppConfigService],
 })

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -18,6 +18,11 @@ export const envSchema = Joi.object({
     .required()
     .description("Stellar network to connect to (testnet or mainnet)"),
 
+  STELLAR_NETWORK: Joi.string()
+    .valid("testnet", "mainnet")
+    .optional()
+    .description("Optional alias for NETWORK; must match NETWORK when both are set"),
+
   // Supabase configuration (required for database operations)
   SUPABASE_URL: Joi.string()
     .uri({ scheme: ["http", "https"] })
@@ -38,6 +43,16 @@ export const envSchema = Joi.object({
     .uri({ scheme: ["http", "https"] })
     .optional()
     .description("Custom Horizon URL (overrides network default)"),
+
+  SOROBAN_RPC_URL: Joi.string()
+    .uri({ scheme: ["http", "https"] })
+    .optional()
+    .description("Custom Soroban RPC URL (overrides network default)"),
+
+  STELLAR_EXPLORER_URL: Joi.string()
+    .uri({ scheme: ["http", "https"] })
+    .optional()
+    .description("Custom Stellar explorer URL (overrides network default)"),
 
   // Stellar signing keys (required for payment operations)
   STELLAR_SECRET_KEY: Joi.string()
@@ -251,10 +266,13 @@ export const envSchema = Joi.object({
 export interface EnvConfig {
   PORT: number;
   NETWORK: "testnet" | "mainnet";
+  STELLAR_NETWORK?: "testnet" | "mainnet";
   SUPABASE_URL: string;
   SUPABASE_ANON_KEY: string;
   SUPABASE_SERVICE_ROLE_KEY?: string;
   HORIZON_URL?: string;
+  SOROBAN_RPC_URL?: string;
+  STELLAR_EXPLORER_URL?: string;
   STELLAR_SECRET_KEY?: string;
   STELLAR_PUBLIC_KEY?: string;
   NODE_ENV: "development" | "production" | "test";

--- a/app/backend/src/config/network.config.ts
+++ b/app/backend/src/config/network.config.ts
@@ -1,0 +1,96 @@
+import * as StellarSdk from '@stellar/stellar-sdk';
+
+export type StellarNetwork = 'testnet' | 'mainnet';
+
+export type NetworkSnapshot = {
+  network: StellarNetwork;
+  passphrase: string;
+  horizonUrl: string;
+  sorobanRpcUrl: string;
+  explorerUrl: string;
+};
+
+const NETWORK_ALIASES = ['NETWORK', 'STELLAR_NETWORK'] as const;
+
+const DEFAULT_NETWORK: StellarNetwork = 'testnet';
+
+const DEFAULT_ENDPOINTS: Record<
+  StellarNetwork,
+  Omit<NetworkSnapshot, 'network'>
+> = {
+  testnet: {
+    passphrase: StellarSdk.Networks.TESTNET,
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+    explorerUrl: 'https://stellar.expert/explorer/testnet',
+  },
+  mainnet: {
+    passphrase: StellarSdk.Networks.PUBLIC,
+    horizonUrl: 'https://horizon.stellar.org',
+    sorobanRpcUrl: 'https://soroban-rpc.mainnet.stellar.gateway.fm',
+    explorerUrl: 'https://stellar.expert/explorer/public',
+  },
+};
+
+function normalizeNetworkValue(value?: string): StellarNetwork | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'testnet' || normalized === 'mainnet') return normalized;
+  throw new Error(
+    `Invalid network value "${value}". Use "testnet" or "mainnet".`,
+  );
+}
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function resolveNetworkSnapshot(
+  env: Record<string, string | undefined> = process.env,
+): NetworkSnapshot {
+  const aliasValues = NETWORK_ALIASES.map((key) => ({
+    key,
+    value: normalizeNetworkValue(env[key]),
+  })).filter((entry) => entry.value !== undefined);
+
+  const unique = new Set(aliasValues.map((entry) => entry.value));
+  if (unique.size > 1) {
+    throw new Error(
+      'NETWORK and STELLAR_NETWORK are both set but conflict. Use a single network value.',
+    );
+  }
+
+  const network = aliasValues[0]?.value ?? DEFAULT_NETWORK;
+  const defaults = DEFAULT_ENDPOINTS[network];
+
+  const horizonUrl = env.HORIZON_URL?.trim() || defaults.horizonUrl;
+  const sorobanRpcUrl = env.SOROBAN_RPC_URL?.trim() || defaults.sorobanRpcUrl;
+  const explorerUrl = env.STELLAR_EXPLORER_URL?.trim() || defaults.explorerUrl;
+
+  if (!isValidHttpUrl(horizonUrl)) {
+    throw new Error(`Invalid HORIZON_URL "${horizonUrl}". Expected http/https URL.`);
+  }
+  if (!isValidHttpUrl(sorobanRpcUrl)) {
+    throw new Error(
+      `Invalid SOROBAN_RPC_URL "${sorobanRpcUrl}". Expected http/https URL.`,
+    );
+  }
+  if (!isValidHttpUrl(explorerUrl)) {
+    throw new Error(
+      `Invalid STELLAR_EXPLORER_URL "${explorerUrl}". Expected http/https URL.`,
+    );
+  }
+
+  return {
+    network,
+    passphrase: defaults.passphrase,
+    horizonUrl,
+    sorobanRpcUrl,
+    explorerUrl,
+  };
+}

--- a/app/backend/src/config/network.config.unit.spec.ts
+++ b/app/backend/src/config/network.config.unit.spec.ts
@@ -1,0 +1,36 @@
+import { resolveNetworkSnapshot } from './network.config';
+
+describe('network config resolver', () => {
+  it('defaults to testnet with safe defaults', () => {
+    const snapshot = resolveNetworkSnapshot({});
+
+    expect(snapshot.network).toBe('testnet');
+    expect(snapshot.horizonUrl).toContain('horizon-testnet');
+    expect(snapshot.sorobanRpcUrl).toContain('soroban-testnet');
+    expect(snapshot.explorerUrl).toContain('/testnet');
+  });
+
+  it('supports mainnet via NETWORK', () => {
+    const snapshot = resolveNetworkSnapshot({ NETWORK: 'mainnet' });
+    expect(snapshot.network).toBe('mainnet');
+    expect(snapshot.passphrase).toBeTruthy();
+  });
+
+  it('fails when NETWORK and STELLAR_NETWORK conflict', () => {
+    expect(() =>
+      resolveNetworkSnapshot({
+        NETWORK: 'testnet',
+        STELLAR_NETWORK: 'mainnet',
+      }),
+    ).toThrow('conflict');
+  });
+
+  it('fails on malformed endpoint override', () => {
+    expect(() =>
+      resolveNetworkSnapshot({
+        NETWORK: 'testnet',
+        SOROBAN_RPC_URL: 'not-a-url',
+      }),
+    ).toThrow('Invalid SOROBAN_RPC_URL');
+  });
+});

--- a/app/backend/src/config/network.controller.ts
+++ b/app/backend/src/config/network.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
+
+@ApiTags('network')
+@Controller('v1/network')
+export class NetworkController {
+  constructor(private readonly configService: ConfigService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Read-only network runtime configuration',
+    description:
+      'Returns active Stellar network and public endpoints for client sanity checks.',
+  })
+  getNetworkConfig() {
+    const stellarConfig = this.configService.get<{
+      network: 'testnet' | 'mainnet';
+      networkPassphrase: string;
+      horizonBaseUrl: string;
+      sorobanRpcUrl: string;
+      explorerUrl: string;
+    }>('stellar');
+
+    return {
+      network: stellarConfig?.network,
+      passphrase: stellarConfig?.networkPassphrase,
+      horizonUrl: stellarConfig?.horizonBaseUrl,
+      sorobanRpcUrl: stellarConfig?.sorobanRpcUrl,
+      explorerUrl: stellarConfig?.explorerUrl,
+    };
+  }
+}

--- a/app/backend/src/config/stellar.config.ts
+++ b/app/backend/src/config/stellar.config.ts
@@ -1,4 +1,5 @@
 import { registerAs } from '@nestjs/config';
+import { resolveNetworkSnapshot } from './network.config';
 
 export type Network = 'testnet' | 'mainnet';
 
@@ -165,11 +166,15 @@ export function syncNetworkFromEnv(
 }
 
 export const stellarConfig = registerAs('stellar', () => {
-  const network = syncNetworkFromEnv();
+  const snapshot = resolveNetworkSnapshot();
+  const network = syncNetworkFromEnv(snapshot.network);
 
   return {
     network,
-    horizonBaseUrl: HORIZON_BASE_URLS[network],
+    horizonBaseUrl: snapshot.horizonUrl,
+    sorobanRpcUrl: snapshot.sorobanRpcUrl,
+    explorerUrl: snapshot.explorerUrl,
+    networkPassphrase: snapshot.passphrase,
     supportedAssets: SUPPORTED_ASSETS,
   };
 });

--- a/app/backend/src/config/stellar.config.unit.spec.ts
+++ b/app/backend/src/config/stellar.config.unit.spec.ts
@@ -81,6 +81,8 @@ describe('stellar config', () => {
 
     expect(config.network).toBe('testnet');
     expect(config.horizonBaseUrl).toBe(HORIZON_BASE_URLS.testnet);
+    expect(config.sorobanRpcUrl).toContain('soroban-testnet');
+    expect(config.networkPassphrase).toBeTruthy();
     expect(config.supportedAssets).toBe(SUPPORTED_ASSETS);
     expect(NETWORK).toBe('testnet');
     expect(HORIZON_BASE_URL).toBe(HORIZON_BASE_URLS.testnet);

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -16,6 +16,7 @@ import { LoggingInterceptor } from "./common/interceptors/logging.interceptor";
 
 import { AppModule } from "./app.module";
 import { AppConfigService } from "./config";
+import { resolveNetworkSnapshot } from "./config/network.config";
 import { GlobalHttpExceptionFilter } from "./common/filters/global-http-exception.filter";
 import { mapValidationErrors } from "./common/utils/validation-error.mapper";
 import { SentryExceptionFilter, SentryService } from "./sentry";
@@ -46,6 +47,12 @@ function validateCriticalConfig(
   // Network is required
   if (!config.network) {
     errors.push('NETWORK is required (must be "testnet" or "mainnet")');
+  }
+
+  try {
+    resolveNetworkSnapshot();
+  } catch (error) {
+    errors.push(`Network config invalid: ${(error as Error).message}`);
   }
 
   // If there are critical errors, fail fast
@@ -81,10 +88,16 @@ async function bootstrap() {
     SUPABASE_ANON_KEY: configService.supabaseAnonKey,
     NETWORK: configService.network,
     HORIZON_URL: configService.horizonUrl,
+    SOROBAN_RPC_URL: configService.sorobanRpcUrl,
+    STELLAR_EXPLORER_URL: configService.stellarExplorerUrl,
     STELLAR_SECRET_KEY: configService.stellarSecretKey,
     STELLAR_PUBLIC_KEY: configService.stellarPublicKey,
   });
   logger.log(envSummary);
+  const networkSnapshot = resolveNetworkSnapshot();
+  logger.log(
+    `Active network: ${networkSnapshot.network} (${networkSnapshot.passphrase}); horizon=${networkSnapshot.horizonUrl}; soroban=${networkSnapshot.sorobanRpcUrl}; explorer=${networkSnapshot.explorerUrl}`,
+  );
 
   // Use Helmet for security headers
   app.use(helmet());

--- a/app/backend/src/transactions/soroban-rpc.service.ts
+++ b/app/backend/src/transactions/soroban-rpc.service.ts
@@ -10,10 +10,9 @@ export class SorobanRpcService {
   private readonly rpcUrl: string;
 
   constructor(private readonly configService: ConfigService) {
-    this.rpcUrl = this.configService.get<string>(
-      "SOROBAN_RPC_URL",
-      "https://soroban-testnet.stellar.org",
-    );
+    this.rpcUrl =
+      this.configService.get<string>('stellar.sorobanRpcUrl') ??
+      'https://soroban-testnet.stellar.org';
   }
 
   getServer(): SorobanRpc.Server {


### PR DESCRIPTION
Closes #412

## Summary
- add a single network snapshot resolver for Stellar runtime settings (network, passphrase, Horizon, Soroban RPC, explorer)
- enforce startup sanity checks for conflicting or malformed network configuration
- expose read-only GET /v1/network so clients can verify runtime network config
- route Soroban RPC service to resolved stellar config instead of ad hoc env defaults

## Validation
- npm run lint (app/backend) passed
- npm run build (app/backend) passed
- npm run test -- src/config/stellar.config.unit.spec.ts src/config/env.schema.unit.spec.ts src/config/network.config.unit.spec.ts --runInBand --watchman=false (app/backend) passed
- npm run type-check (app/backend) fails due pre-existing analytics spec typing errors unrelated to this change