### PR TITLE
feat(backend): soroban rpc failover, backoff, and endpoint metrics

### DIFF
--- a/app/backend/src/config/app-config.service.ts
+++ b/app/backend/src/config/app-config.service.ts
@@ -138,6 +138,14 @@ export class AppConfigService {
     return this.configService.get('HORIZON_URL', { infer: true });
   }
 
+  get sorobanRpcUrl(): string | undefined {
+    return this.configService.get('SOROBAN_RPC_URL', { infer: true });
+  }
+
+  get stellarExplorerUrl(): string | undefined {
+    return this.configService.get('STELLAR_EXPLORER_URL', { infer: true });
+  }
+
   /**
    * Stellar secret key (optional). Required for signing transactions.
    */

--- a/app/backend/src/config/config.module.ts
+++ b/app/backend/src/config/config.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 
 import { AppConfigService } from './app-config.service';
 import { envSchema } from './env.schema';
+import { NetworkController } from './network.controller';
 import { stellarConfig } from './stellar.config';
 
 /**
@@ -23,6 +24,7 @@ import { stellarConfig } from './stellar.config';
       },
     }),
   ],
+  controllers: [NetworkController],
   providers: [AppConfigService],
   exports: [AppConfigService],
 })

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -49,6 +49,23 @@ export const envSchema = Joi.object({
     .optional()
     .description("Custom Soroban RPC URL (overrides network default)"),
 
+  SOROBAN_RPC_URLS: Joi.string()
+    .optional()
+    .description("Comma-separated fallback Soroban RPC URLs for failover"),
+
+  SOROBAN_RPC_TIMEOUT_MS: Joi.number()
+    .integer()
+    .min(1000)
+    .default(10000)
+    .description("Timeout in milliseconds for Soroban RPC requests"),
+
+  SOROBAN_RPC_MAX_RETRIES: Joi.number()
+    .integer()
+    .min(1)
+    .max(10)
+    .default(3)
+    .description("Max retry attempts for transient Soroban RPC failures"),
+
   STELLAR_EXPLORER_URL: Joi.string()
     .uri({ scheme: ["http", "https"] })
     .optional()
@@ -272,6 +289,9 @@ export interface EnvConfig {
   SUPABASE_SERVICE_ROLE_KEY?: string;
   HORIZON_URL?: string;
   SOROBAN_RPC_URL?: string;
+  SOROBAN_RPC_URLS?: string;
+  SOROBAN_RPC_TIMEOUT_MS: number;
+  SOROBAN_RPC_MAX_RETRIES: number;
   STELLAR_EXPLORER_URL?: string;
   STELLAR_SECRET_KEY?: string;
   STELLAR_PUBLIC_KEY?: string;

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -18,6 +18,11 @@ export const envSchema = Joi.object({
     .required()
     .description("Stellar network to connect to (testnet or mainnet)"),
 
+  STELLAR_NETWORK: Joi.string()
+    .valid("testnet", "mainnet")
+    .optional()
+    .description("Optional alias for NETWORK; must match NETWORK when both are set"),
+
   // Supabase configuration (required for database operations)
   SUPABASE_URL: Joi.string()
     .uri({ scheme: ["http", "https"] })
@@ -38,6 +43,16 @@ export const envSchema = Joi.object({
     .uri({ scheme: ["http", "https"] })
     .optional()
     .description("Custom Horizon URL (overrides network default)"),
+
+  SOROBAN_RPC_URL: Joi.string()
+    .uri({ scheme: ["http", "https"] })
+    .optional()
+    .description("Custom Soroban RPC URL (overrides network default)"),
+
+  STELLAR_EXPLORER_URL: Joi.string()
+    .uri({ scheme: ["http", "https"] })
+    .optional()
+    .description("Custom Stellar explorer URL (overrides network default)"),
 
   // Stellar signing keys (required for payment operations)
   STELLAR_SECRET_KEY: Joi.string()
@@ -251,10 +266,13 @@ export const envSchema = Joi.object({
 export interface EnvConfig {
   PORT: number;
   NETWORK: "testnet" | "mainnet";
+  STELLAR_NETWORK?: "testnet" | "mainnet";
   SUPABASE_URL: string;
   SUPABASE_ANON_KEY: string;
   SUPABASE_SERVICE_ROLE_KEY?: string;
   HORIZON_URL?: string;
+  SOROBAN_RPC_URL?: string;
+  STELLAR_EXPLORER_URL?: string;
   STELLAR_SECRET_KEY?: string;
   STELLAR_PUBLIC_KEY?: string;
   NODE_ENV: "development" | "production" | "test";

--- a/app/backend/src/config/network.config.ts
+++ b/app/backend/src/config/network.config.ts
@@ -7,6 +7,7 @@ export type NetworkSnapshot = {
   passphrase: string;
   horizonUrl: string;
   sorobanRpcUrl: string;
+  sorobanRpcUrls: string[];
   explorerUrl: string;
 };
 
@@ -22,12 +23,14 @@ const DEFAULT_ENDPOINTS: Record<
     passphrase: StellarSdk.Networks.TESTNET,
     horizonUrl: 'https://horizon-testnet.stellar.org',
     sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+    sorobanRpcUrls: ['https://soroban-testnet.stellar.org'],
     explorerUrl: 'https://stellar.expert/explorer/testnet',
   },
   mainnet: {
     passphrase: StellarSdk.Networks.PUBLIC,
     horizonUrl: 'https://horizon.stellar.org',
     sorobanRpcUrl: 'https://soroban-rpc.mainnet.stellar.gateway.fm',
+    sorobanRpcUrls: ['https://soroban-rpc.mainnet.stellar.gateway.fm'],
     explorerUrl: 'https://stellar.expert/explorer/public',
   },
 };
@@ -70,6 +73,13 @@ export function resolveNetworkSnapshot(
 
   const horizonUrl = env.HORIZON_URL?.trim() || defaults.horizonUrl;
   const sorobanRpcUrl = env.SOROBAN_RPC_URL?.trim() || defaults.sorobanRpcUrl;
+  const sorobanRpcUrls = [
+    sorobanRpcUrl,
+    ...(env.SOROBAN_RPC_URLS ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean),
+  ];
   const explorerUrl = env.STELLAR_EXPLORER_URL?.trim() || defaults.explorerUrl;
 
   if (!isValidHttpUrl(horizonUrl)) {
@@ -91,6 +101,7 @@ export function resolveNetworkSnapshot(
     passphrase: defaults.passphrase,
     horizonUrl,
     sorobanRpcUrl,
+    sorobanRpcUrls: Array.from(new Set(sorobanRpcUrls)),
     explorerUrl,
   };
 }

--- a/app/backend/src/config/network.config.ts
+++ b/app/backend/src/config/network.config.ts
@@ -1,0 +1,96 @@
+import * as StellarSdk from '@stellar/stellar-sdk';
+
+export type StellarNetwork = 'testnet' | 'mainnet';
+
+export type NetworkSnapshot = {
+  network: StellarNetwork;
+  passphrase: string;
+  horizonUrl: string;
+  sorobanRpcUrl: string;
+  explorerUrl: string;
+};
+
+const NETWORK_ALIASES = ['NETWORK', 'STELLAR_NETWORK'] as const;
+
+const DEFAULT_NETWORK: StellarNetwork = 'testnet';
+
+const DEFAULT_ENDPOINTS: Record<
+  StellarNetwork,
+  Omit<NetworkSnapshot, 'network'>
+> = {
+  testnet: {
+    passphrase: StellarSdk.Networks.TESTNET,
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+    explorerUrl: 'https://stellar.expert/explorer/testnet',
+  },
+  mainnet: {
+    passphrase: StellarSdk.Networks.PUBLIC,
+    horizonUrl: 'https://horizon.stellar.org',
+    sorobanRpcUrl: 'https://soroban-rpc.mainnet.stellar.gateway.fm',
+    explorerUrl: 'https://stellar.expert/explorer/public',
+  },
+};
+
+function normalizeNetworkValue(value?: string): StellarNetwork | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'testnet' || normalized === 'mainnet') return normalized;
+  throw new Error(
+    `Invalid network value "${value}". Use "testnet" or "mainnet".`,
+  );
+}
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function resolveNetworkSnapshot(
+  env: Record<string, string | undefined> = process.env,
+): NetworkSnapshot {
+  const aliasValues = NETWORK_ALIASES.map((key) => ({
+    key,
+    value: normalizeNetworkValue(env[key]),
+  })).filter((entry) => entry.value !== undefined);
+
+  const unique = new Set(aliasValues.map((entry) => entry.value));
+  if (unique.size > 1) {
+    throw new Error(
+      'NETWORK and STELLAR_NETWORK are both set but conflict. Use a single network value.',
+    );
+  }
+
+  const network = aliasValues[0]?.value ?? DEFAULT_NETWORK;
+  const defaults = DEFAULT_ENDPOINTS[network];
+
+  const horizonUrl = env.HORIZON_URL?.trim() || defaults.horizonUrl;
+  const sorobanRpcUrl = env.SOROBAN_RPC_URL?.trim() || defaults.sorobanRpcUrl;
+  const explorerUrl = env.STELLAR_EXPLORER_URL?.trim() || defaults.explorerUrl;
+
+  if (!isValidHttpUrl(horizonUrl)) {
+    throw new Error(`Invalid HORIZON_URL "${horizonUrl}". Expected http/https URL.`);
+  }
+  if (!isValidHttpUrl(sorobanRpcUrl)) {
+    throw new Error(
+      `Invalid SOROBAN_RPC_URL "${sorobanRpcUrl}". Expected http/https URL.`,
+    );
+  }
+  if (!isValidHttpUrl(explorerUrl)) {
+    throw new Error(
+      `Invalid STELLAR_EXPLORER_URL "${explorerUrl}". Expected http/https URL.`,
+    );
+  }
+
+  return {
+    network,
+    passphrase: defaults.passphrase,
+    horizonUrl,
+    sorobanRpcUrl,
+    explorerUrl,
+  };
+}

--- a/app/backend/src/config/network.config.unit.spec.ts
+++ b/app/backend/src/config/network.config.unit.spec.ts
@@ -1,0 +1,36 @@
+import { resolveNetworkSnapshot } from './network.config';
+
+describe('network config resolver', () => {
+  it('defaults to testnet with safe defaults', () => {
+    const snapshot = resolveNetworkSnapshot({});
+
+    expect(snapshot.network).toBe('testnet');
+    expect(snapshot.horizonUrl).toContain('horizon-testnet');
+    expect(snapshot.sorobanRpcUrl).toContain('soroban-testnet');
+    expect(snapshot.explorerUrl).toContain('/testnet');
+  });
+
+  it('supports mainnet via NETWORK', () => {
+    const snapshot = resolveNetworkSnapshot({ NETWORK: 'mainnet' });
+    expect(snapshot.network).toBe('mainnet');
+    expect(snapshot.passphrase).toBeTruthy();
+  });
+
+  it('fails when NETWORK and STELLAR_NETWORK conflict', () => {
+    expect(() =>
+      resolveNetworkSnapshot({
+        NETWORK: 'testnet',
+        STELLAR_NETWORK: 'mainnet',
+      }),
+    ).toThrow('conflict');
+  });
+
+  it('fails on malformed endpoint override', () => {
+    expect(() =>
+      resolveNetworkSnapshot({
+        NETWORK: 'testnet',
+        SOROBAN_RPC_URL: 'not-a-url',
+      }),
+    ).toThrow('Invalid SOROBAN_RPC_URL');
+  });
+});

--- a/app/backend/src/config/network.controller.ts
+++ b/app/backend/src/config/network.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
+
+@ApiTags('network')
+@Controller('v1/network')
+export class NetworkController {
+  constructor(private readonly configService: ConfigService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Read-only network runtime configuration',
+    description:
+      'Returns active Stellar network and public endpoints for client sanity checks.',
+  })
+  getNetworkConfig() {
+    const stellarConfig = this.configService.get<{
+      network: 'testnet' | 'mainnet';
+      networkPassphrase: string;
+      horizonBaseUrl: string;
+      sorobanRpcUrl: string;
+      explorerUrl: string;
+    }>('stellar');
+
+    return {
+      network: stellarConfig?.network,
+      passphrase: stellarConfig?.networkPassphrase,
+      horizonUrl: stellarConfig?.horizonBaseUrl,
+      sorobanRpcUrl: stellarConfig?.sorobanRpcUrl,
+      explorerUrl: stellarConfig?.explorerUrl,
+    };
+  }
+}

--- a/app/backend/src/config/stellar.config.ts
+++ b/app/backend/src/config/stellar.config.ts
@@ -173,6 +173,7 @@ export const stellarConfig = registerAs('stellar', () => {
     network,
     horizonBaseUrl: snapshot.horizonUrl,
     sorobanRpcUrl: snapshot.sorobanRpcUrl,
+    sorobanRpcUrls: snapshot.sorobanRpcUrls,
     explorerUrl: snapshot.explorerUrl,
     networkPassphrase: snapshot.passphrase,
     supportedAssets: SUPPORTED_ASSETS,

--- a/app/backend/src/config/stellar.config.ts
+++ b/app/backend/src/config/stellar.config.ts
@@ -1,4 +1,5 @@
 import { registerAs } from '@nestjs/config';
+import { resolveNetworkSnapshot } from './network.config';
 
 export type Network = 'testnet' | 'mainnet';
 
@@ -165,11 +166,15 @@ export function syncNetworkFromEnv(
 }
 
 export const stellarConfig = registerAs('stellar', () => {
-  const network = syncNetworkFromEnv();
+  const snapshot = resolveNetworkSnapshot();
+  const network = syncNetworkFromEnv(snapshot.network);
 
   return {
     network,
-    horizonBaseUrl: HORIZON_BASE_URLS[network],
+    horizonBaseUrl: snapshot.horizonUrl,
+    sorobanRpcUrl: snapshot.sorobanRpcUrl,
+    explorerUrl: snapshot.explorerUrl,
+    networkPassphrase: snapshot.passphrase,
     supportedAssets: SUPPORTED_ASSETS,
   };
 });

--- a/app/backend/src/config/stellar.config.unit.spec.ts
+++ b/app/backend/src/config/stellar.config.unit.spec.ts
@@ -81,6 +81,8 @@ describe('stellar config', () => {
 
     expect(config.network).toBe('testnet');
     expect(config.horizonBaseUrl).toBe(HORIZON_BASE_URLS.testnet);
+    expect(config.sorobanRpcUrl).toContain('soroban-testnet');
+    expect(config.networkPassphrase).toBeTruthy();
     expect(config.supportedAssets).toBe(SUPPORTED_ASSETS);
     expect(NETWORK).toBe('testnet');
     expect(HORIZON_BASE_URL).toBe(HORIZON_BASE_URLS.testnet);

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -16,6 +16,7 @@ import { LoggingInterceptor } from "./common/interceptors/logging.interceptor";
 
 import { AppModule } from "./app.module";
 import { AppConfigService } from "./config";
+import { resolveNetworkSnapshot } from "./config/network.config";
 import { GlobalHttpExceptionFilter } from "./common/filters/global-http-exception.filter";
 import { mapValidationErrors } from "./common/utils/validation-error.mapper";
 import { SentryExceptionFilter, SentryService } from "./sentry";
@@ -46,6 +47,12 @@ function validateCriticalConfig(
   // Network is required
   if (!config.network) {
     errors.push('NETWORK is required (must be "testnet" or "mainnet")');
+  }
+
+  try {
+    resolveNetworkSnapshot();
+  } catch (error) {
+    errors.push(`Network config invalid: ${(error as Error).message}`);
   }
 
   // If there are critical errors, fail fast
@@ -81,10 +88,16 @@ async function bootstrap() {
     SUPABASE_ANON_KEY: configService.supabaseAnonKey,
     NETWORK: configService.network,
     HORIZON_URL: configService.horizonUrl,
+    SOROBAN_RPC_URL: configService.sorobanRpcUrl,
+    STELLAR_EXPLORER_URL: configService.stellarExplorerUrl,
     STELLAR_SECRET_KEY: configService.stellarSecretKey,
     STELLAR_PUBLIC_KEY: configService.stellarPublicKey,
   });
   logger.log(envSummary);
+  const networkSnapshot = resolveNetworkSnapshot();
+  logger.log(
+    `Active network: ${networkSnapshot.network} (${networkSnapshot.passphrase}); horizon=${networkSnapshot.horizonUrl}; soroban=${networkSnapshot.sorobanRpcUrl}; explorer=${networkSnapshot.explorerUrl}`,
+  );
 
   // Use Helmet for security headers
   app.use(helmet());

--- a/app/backend/src/metrics/metrics.service.ts
+++ b/app/backend/src/metrics/metrics.service.ts
@@ -13,6 +13,8 @@ export class MetricsService implements OnModuleInit {
   private webhookDeliveryDuration: client.Histogram<string>;
   private externalCallDuration: client.Histogram<string>;
   private errorRate: client.Counter<string>;
+  private sorobanRpcFailoverTotal: client.Counter<string>;
+  private sorobanRpcActiveEndpoint: client.Gauge<string>;
   private initialized = false;
 
   onModuleInit() {
@@ -77,6 +79,18 @@ export class MetricsService implements OnModuleInit {
         labelNames: ["service", "error_type"],
       });
 
+      this.sorobanRpcFailoverTotal = new client.Counter({
+        name: "soroban_rpc_failover_total",
+        help: "Total number of Soroban RPC failover events",
+        labelNames: ["from_endpoint", "to_endpoint", "reason"],
+      });
+
+      this.sorobanRpcActiveEndpoint = new client.Gauge({
+        name: "soroban_rpc_active_endpoint",
+        help: "Currently active Soroban RPC endpoint (1=active, 0=inactive)",
+        labelNames: ["endpoint"],
+      });
+
       this.register.registerMetric(this.httpRequestDuration);
       this.register.registerMetric(this.httpRequestTotal);
       this.register.registerMetric(this.rateLimitedRequestsTotal);
@@ -86,6 +100,8 @@ export class MetricsService implements OnModuleInit {
       this.register.registerMetric(this.webhookDeliveryDuration);
       this.register.registerMetric(this.externalCallDuration);
       this.register.registerMetric(this.errorRate);
+      this.register.registerMetric(this.sorobanRpcFailoverTotal);
+      this.register.registerMetric(this.sorobanRpcActiveEndpoint);
 
       this.initialized = true;
     } catch (error) {
@@ -202,6 +218,26 @@ export class MetricsService implements OnModuleInit {
 
     try {
       this.errorRate.labels(service, errorType).inc();
+    } catch (error) {}
+  }
+
+  recordSorobanRpcFailover(fromEndpoint: string, toEndpoint: string, reason: string) {
+    if (!this.initialized || !this.sorobanRpcFailoverTotal) {
+      return;
+    }
+    try {
+      this.sorobanRpcFailoverTotal.labels(fromEndpoint, toEndpoint, reason).inc();
+    } catch (error) {}
+  }
+
+  setSorobanRpcActiveEndpoint(endpoint: string, allEndpoints: string[]) {
+    if (!this.initialized || !this.sorobanRpcActiveEndpoint) {
+      return;
+    }
+    try {
+      for (const url of allEndpoints) {
+        this.sorobanRpcActiveEndpoint.labels(url).set(url === endpoint ? 1 : 0);
+      }
     } catch (error) {}
   }
 }

--- a/app/backend/src/transactions/soroban-rpc.service.ts
+++ b/app/backend/src/transactions/soroban-rpc.service.ts
@@ -3,26 +3,141 @@ import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
+import { MetricsService } from "../metrics/metrics.service";
 
 @Injectable()
 export class SorobanRpcService {
   private readonly logger = new Logger(SorobanRpcService.name);
-  private readonly rpcUrl: string;
+  private readonly rpcUrls: string[];
+  private readonly requestTimeoutMs: number;
+  private readonly maxRetries: number;
+  private activeIndex = 0;
 
-  constructor(private readonly configService: ConfigService) {
-    this.rpcUrl =
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly metricsService: MetricsService,
+  ) {
+    const configuredUrls =
+      this.configService.get<string[]>('stellar.sorobanRpcUrls') ?? [];
+    const primaryUrl =
       this.configService.get<string>('stellar.sorobanRpcUrl') ??
       'https://soroban-testnet.stellar.org';
+    this.rpcUrls = Array.from(new Set([primaryUrl, ...configuredUrls]));
+
+    this.requestTimeoutMs = Number(
+      this.configService.get<string>('SOROBAN_RPC_TIMEOUT_MS') ?? 10_000,
+    );
+    this.maxRetries = Math.max(
+      1,
+      Number(this.configService.get<string>('SOROBAN_RPC_MAX_RETRIES') ?? 3),
+    );
+
+    this.metricsService.setSorobanRpcActiveEndpoint(
+      this.rpcUrls[this.activeIndex],
+      this.rpcUrls,
+    );
+    this.logger.log(
+      `Soroban RPC initialized with ${this.rpcUrls.length} endpoint(s). Active: ${this.rpcUrls[this.activeIndex]}`,
+    );
   }
 
-  getServer(): SorobanRpc.Server {
-    return new SorobanRpc.Server(this.rpcUrl, { allowHttp: false });
+  private createServer(url: string): SorobanRpc.Server {
+    return new SorobanRpc.Server(url, { allowHttp: false });
+  }
+
+  private getActiveUrl(): string {
+    return this.rpcUrls[this.activeIndex];
+  }
+
+  private rotateEndpoint(reason: string): void {
+    if (this.rpcUrls.length <= 1) return;
+    const previous = this.getActiveUrl();
+    this.activeIndex = (this.activeIndex + 1) % this.rpcUrls.length;
+    const next = this.getActiveUrl();
+    this.metricsService.recordSorobanRpcFailover(previous, next, reason);
+    this.metricsService.setSorobanRpcActiveEndpoint(next, this.rpcUrls);
+    this.logger.warn(`Soroban RPC failover: ${previous} -> ${next} (${reason})`);
+  }
+
+  private isTransientError(error: unknown): boolean {
+    const message = String((error as Error)?.message ?? error).toLowerCase();
+    return (
+      message.includes('timeout') ||
+      message.includes('network') ||
+      message.includes('fetch') ||
+      message.includes('econn') ||
+      message.includes('429') ||
+      message.includes('503') ||
+      message.includes('502') ||
+      message.includes('500')
+    );
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, operation: string): Promise<T> {
+    let timeout: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<T>((_, reject) => {
+      timeout = setTimeout(() => {
+        reject(
+          new Error(
+            `Soroban RPC ${operation} timed out after ${this.requestTimeoutMs}ms`,
+          ),
+        );
+      }, this.requestTimeoutMs);
+    });
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+
+  private async executeWithFailover<T>(
+    operation: string,
+    call: (server: SorobanRpc.Server) => Promise<T>,
+  ): Promise<T> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= this.maxRetries; attempt += 1) {
+      const url = this.getActiveUrl();
+      const startedAt = Date.now();
+      try {
+        const server = this.createServer(url);
+        const result = await this.withTimeout(call(server), operation);
+        this.metricsService.recordExternalCall(
+          'soroban_rpc',
+          `${operation}:${url}`,
+          (Date.now() - startedAt) / 1000,
+        );
+        return result;
+      } catch (error) {
+        lastError = error;
+        this.metricsService.recordError(
+          'soroban_rpc',
+          this.isTransientError(error) ? 'transient' : 'non_transient',
+        );
+        if (!this.isTransientError(error) || attempt >= this.maxRetries) {
+          break;
+        }
+
+        const backoffMs = Math.min(
+          250 * 2 ** (attempt - 1) + Math.floor(Math.random() * 200),
+          3000,
+        );
+        this.rotateEndpoint((error as Error).message ?? 'transient-error');
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`Soroban RPC ${operation} failed`);
   }
 
   async getAccount(publicKey: string): Promise<StellarSdk.Account> {
-    const server = this.getServer();
     try {
-      return await server.getAccount(publicKey);
+      return await this.executeWithFailover("getAccount", (server) =>
+        server.getAccount(publicKey),
+      );
     } catch (err) {
       throw new Error(`account "${publicKey}" does not exist on the network`);
     }
@@ -31,13 +146,15 @@ export class SorobanRpcService {
   async simulateTransaction(
     tx: StellarSdk.Transaction,
   ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
-    const server = this.getServer();
-    return server.simulateTransaction(tx);
+    return this.executeWithFailover("simulateTransaction", (server) =>
+      server.simulateTransaction(tx),
+    );
   }
 
   async getNetworkPassphrase(): Promise<string> {
-    const server = this.getServer();
-    const network = await server.getNetwork();
+    const network = await this.executeWithFailover("getNetwork", (server) =>
+      server.getNetwork(),
+    );
     return network.passphrase;
   }
 }

--- a/app/backend/src/transactions/soroban-rpc.service.ts
+++ b/app/backend/src/transactions/soroban-rpc.service.ts
@@ -10,10 +10,9 @@ export class SorobanRpcService {
   private readonly rpcUrl: string;
 
   constructor(private readonly configService: ConfigService) {
-    this.rpcUrl = this.configService.get<string>(
-      "SOROBAN_RPC_URL",
-      "https://soroban-testnet.stellar.org",
-    );
+    this.rpcUrl =
+      this.configService.get<string>('stellar.sorobanRpcUrl') ??
+      'https://soroban-testnet.stellar.org';
   }
 
   getServer(): SorobanRpc.Server {

--- a/app/backend/src/transactions/soroban-rpc.service.unit.spec.ts
+++ b/app/backend/src/transactions/soroban-rpc.service.unit.spec.ts
@@ -1,0 +1,61 @@
+import { ConfigService } from "@nestjs/config";
+import { MetricsService } from "../metrics/metrics.service";
+import { SorobanRpcService } from "./soroban-rpc.service";
+
+describe("SorobanRpcService", () => {
+  function createConfig(overrides: Record<string, unknown> = {}) {
+    const values: Record<string, unknown> = {
+      "stellar.sorobanRpcUrl": "https://rpc-1.example.com",
+      "stellar.sorobanRpcUrls": [
+        "https://rpc-1.example.com",
+        "https://rpc-2.example.com",
+      ],
+      SOROBAN_RPC_TIMEOUT_MS: "50",
+      SOROBAN_RPC_MAX_RETRIES: "2",
+      ...overrides,
+    };
+
+    return {
+      get: jest.fn((key: string) => values[key]),
+    } as unknown as ConfigService;
+  }
+
+  function createMetrics() {
+    return {
+      setSorobanRpcActiveEndpoint: jest.fn(),
+      recordSorobanRpcFailover: jest.fn(),
+      recordExternalCall: jest.fn(),
+      recordError: jest.fn(),
+    } as unknown as MetricsService;
+  }
+
+  it("fails over to secondary RPC endpoint on transient error", async () => {
+    const service = new SorobanRpcService(createConfig(), createMetrics());
+    const firstServer = {
+      getNetwork: jest.fn().mockRejectedValue(new Error("network timeout")),
+    };
+    const secondServer = {
+      getNetwork: jest.fn().mockResolvedValue({ passphrase: "TESTNET" }),
+    };
+    const serviceInternals = service as unknown as { createServer: jest.Mock };
+
+    serviceInternals.createServer = jest
+      .fn()
+      .mockReturnValueOnce(firstServer)
+      .mockReturnValueOnce(secondServer);
+
+    await expect(service.getNetworkPassphrase()).resolves.toBe("TESTNET");
+    expect(serviceInternals.createServer).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after max retries for persistent transient failures", async () => {
+    const service = new SorobanRpcService(createConfig(), createMetrics());
+    const serviceInternals = service as unknown as { createServer: jest.Mock };
+    serviceInternals.createServer = jest.fn().mockReturnValue({
+      getNetwork: jest.fn().mockRejectedValue(new Error("503 unavailable")),
+    });
+
+    await expect(service.getNetworkPassphrase()).rejects.toThrow("503");
+    expect(serviceInternals.createServer).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #411

## Summary
- added multi-endpoint Soroban RPC support with automatic failover rotation
- implemented transient-failure retry with exponential backoff + jitter
- added request-level timeout protection for RPC operations
- added metrics for active RPC endpoint and failover events
- added targeted unit tests for failover behavior and retry exhaustion

## Validation
- npm run lint (app/backend) passed
- npm run build (app/backend) passed
- npm run test -- src/transactions/soroban-rpc.service.unit.spec.ts src/config/network.config.unit.spec.ts --runInBand --watchman=false (app/backend) passed
- npm run type-check (app/backend) fails due pre-existing analytics spec typing issues unrelated to this change