### PR TITLE
feat(backend): add organization context and RBAC enforcement

### DIFF
--- a/app/backend/src/analytics/analytics.controller.ts
+++ b/app/backend/src/analytics/analytics.controller.ts
@@ -1,6 +1,6 @@
-import { Controller, Get, Query, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, Req, Res, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { ApiKeyGuard } from '../auth/guards/api-key.guard';
 import { AnalyticsService } from './analytics.service';
 import {
@@ -21,12 +21,13 @@ export class AnalyticsController {
     summary: 'Fetch dashboard analytics report (summary, asset distribution, and time-series)',
   })
   @ApiResponse({ status: 200, description: 'Analytics report generated' })
-  async getReport(@Query() query: TimeSeriesQueryDto) {
+  async getReport(@Req() req: Request, @Query() query: TimeSeriesQueryDto) {
     return this.analyticsService.getAnalyticsReport(
       query.publicKey,
       query.startDate,
       query.endDate,
       query.interval,
+      req.organizationContext?.organizationId,
     );
   }
 
@@ -35,12 +36,13 @@ export class AnalyticsController {
     summary: 'Fetch only time-series analytics for chart rendering (daily/weekly/monthly)',
   })
   @ApiResponse({ status: 200, description: 'Time-series analytics generated' })
-  async getTimeSeries(@Query() query: TimeSeriesQueryDto) {
+  async getTimeSeries(@Req() req: Request, @Query() query: TimeSeriesQueryDto) {
     const report = await this.analyticsService.getAnalyticsReport(
       query.publicKey,
       query.startDate,
       query.endDate,
       query.interval,
+      req.organizationContext?.organizationId,
     );
     return {
       interval: query.interval,
@@ -54,11 +56,13 @@ export class AnalyticsController {
     summary: 'Fetch asset distribution for payment history',
   })
   @ApiResponse({ status: 200, description: 'Asset distribution generated' })
-  async getAssetDistribution(@Query() query: AnalyticsQueryDto) {
+  async getAssetDistribution(@Req() req: Request, @Query() query: AnalyticsQueryDto) {
     const report = await this.analyticsService.getAnalyticsReport(
       query.publicKey,
       query.startDate,
       query.endDate,
+      undefined,
+      req.organizationContext?.organizationId,
     );
     return {
       window: report.window,
@@ -73,6 +77,7 @@ export class AnalyticsController {
   @ApiResponse({ status: 200, description: 'Report export generated' })
   async exportReport(
     @Query() query: ExportReportQueryDto,
+    @Req() req: Request,
     @Res() res: Response,
   ) {
     const { report, payments } = await this.analyticsService.exportReport(
@@ -82,6 +87,7 @@ export class AnalyticsController {
       query.reportType,
       query.interval,
       query.maxRows,
+      req.organizationContext?.organizationId,
     );
 
     if (query.format === ReportFormat.PDF) {
@@ -107,4 +113,3 @@ export class AnalyticsController {
     return res.send(csv);
   }
 }
-

--- a/app/backend/src/analytics/analytics.service.ts
+++ b/app/backend/src/analytics/analytics.service.ts
@@ -82,6 +82,7 @@ export class AnalyticsService {
     startDate?: string,
     endDate?: string,
     interval: AnalyticsInterval = AnalyticsInterval.DAILY,
+    organizationId?: string,
   ): Promise<AnalyticsReport> {
     const { startIso, endIso } = this.resolveDateWindow(startDate, endDate);
 
@@ -90,12 +91,18 @@ export class AnalyticsService {
       startIso,
       endIso,
       interval,
+      organizationId,
     );
     if (rpcReport) {
       return rpcReport;
     }
 
-    const rows = await this.fetchPaymentRows(publicKey, startIso, endIso);
+    const rows = await this.fetchPaymentRows(
+      publicKey,
+      startIso,
+      endIso,
+      organizationId,
+    );
     const payments = this.normalizeAndFilterRows(rows, publicKey);
 
     return {
@@ -116,9 +123,15 @@ export class AnalyticsService {
     reportType: ReportType,
     interval: AnalyticsInterval,
     maxRows: number,
+    organizationId?: string,
   ): Promise<{ report: AnalyticsReport; payments: NormalizedPayment[] }> {
     const { startIso, endIso } = this.resolveDateWindow(startDate, endDate);
-    const rows = await this.fetchPaymentRows(publicKey, startIso, endIso);
+    const rows = await this.fetchPaymentRows(
+      publicKey,
+      startIso,
+      endIso,
+      organizationId,
+    );
     const payments = this.normalizeAndFilterRows(rows, publicKey).slice(
       0,
       Math.max(1, Math.min(maxRows || 500, 5000)),
@@ -129,6 +142,7 @@ export class AnalyticsService {
       startIso,
       endIso,
       interval,
+      organizationId,
     );
     const report: AnalyticsReport =
       rpcReport ??
@@ -241,16 +255,23 @@ export class AnalyticsService {
     publicKey: string,
     startIso: string,
     endIso: string,
+    organizationId?: string,
   ): Promise<PaymentRow[]> {
     const client = this.supabase.getClient();
 
-    const { data, error } = await client
+    let query = client
       .from('payment_records')
       .select('*')
       .or(`sender_public_key.eq.${publicKey},receiver_public_key.eq.${publicKey}`)
       .gte('created_at', startIso)
       .lte('created_at', endIso)
       .order('created_at', { ascending: true });
+
+    if (organizationId) {
+      query = query.eq('organization_id', organizationId);
+    }
+
+    const { data, error } = await query;
 
     if (error) {
       throw new BadRequestException({
@@ -267,6 +288,7 @@ export class AnalyticsService {
     startIso: string,
     endIso: string,
     interval: AnalyticsInterval,
+    organizationId?: string,
   ): Promise<AnalyticsReport | null> {
     const client = this.supabase.getClient();
     const [summaryResult, assetsResult, timeSeriesResult] = await Promise.all([
@@ -274,17 +296,20 @@ export class AnalyticsService {
         p_public_key: publicKey,
         p_start_date: startIso,
         p_end_date: endIso,
+        p_organization_id: organizationId ?? null,
       }),
       client.rpc('quickex_analytics_asset_distribution', {
         p_public_key: publicKey,
         p_start_date: startIso,
         p_end_date: endIso,
+        p_organization_id: organizationId ?? null,
       }),
       client.rpc('quickex_analytics_time_series', {
         p_public_key: publicKey,
         p_start_date: startIso,
         p_end_date: endIso,
         p_interval: interval,
+        p_organization_id: organizationId ?? null,
       }),
     ]);
 

--- a/app/backend/src/api-keys/api-keys.controller.ts
+++ b/app/backend/src/api-keys/api-keys.controller.ts
@@ -7,11 +7,14 @@ import {
   ParseUUIDPipe,
   Post,
   Query,
+  Req,
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
 import { ApiKeysService } from './api-keys.service';
 import { CreateApiKeyDto } from './dto/create-api-key.dto';
 import { CursorPaginationQueryDto } from '../dto/pagination/pagination.dto';
+import { RequireOrgRole } from '../auth/decorators/require-org-role.decorator';
 
 @ApiTags('api-keys')
 @Controller('api-keys')
@@ -23,8 +26,12 @@ export class ApiKeysController {
    * Creates a new API key. The raw key is returned ONCE in the response.
    */
   @Post()
-  create(@Body() dto: CreateApiKeyDto) {
-    return this.service.create(dto);
+  @RequireOrgRole('admin')
+  create(@Body() dto: CreateApiKeyDto, @Req() req: Request) {
+    return this.service.create({
+      ...dto,
+      organization_id: dto.organization_id ?? req.organizationContext?.organizationId,
+    });
   }
 
   /**
@@ -38,10 +45,16 @@ export class ApiKeysController {
   @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page (1-100)' })
   @ApiResponse({ status: 200, description: 'Paginated list of API keys' })
   list(
+    @Req() req: Request,
     @Query('owner_id') ownerId?: string,
     @Query() pagination?: CursorPaginationQueryDto,
   ) {
-    return this.service.listPaginated(ownerId, pagination?.cursor, pagination?.limit);
+    return this.service.listPaginated(
+      ownerId,
+      req.organizationContext?.organizationId,
+      pagination?.cursor,
+      pagination?.limit,
+    );
   }
 
   /**
@@ -49,8 +62,8 @@ export class ApiKeysController {
    * Returns aggregated usage/quota stats.
    */
   @Get('usage')
-  usage(@Query('owner_id') ownerId?: string) {
-    return this.service.getUsage(ownerId);
+  usage(@Req() req: Request, @Query('owner_id') ownerId?: string) {
+    return this.service.getUsage(ownerId, req.organizationContext?.organizationId);
   }
 
   /**
@@ -58,6 +71,7 @@ export class ApiKeysController {
    * Revokes (soft-deletes) a key.
    */
   @Delete(':id')
+  @RequireOrgRole('admin')
   revoke(@Param('id', ParseUUIDPipe) id: string) {
     return this.service.revoke(id);
   }
@@ -67,6 +81,7 @@ export class ApiKeysController {
    * Invalidates the current key and issues a new one.
    */
   @Post(':id/rotate')
+  @RequireOrgRole('admin')
   rotate(@Param('id', ParseUUIDPipe) id: string) {
     return this.service.rotate(id);
   }

--- a/app/backend/src/api-keys/api-keys.repository.ts
+++ b/app/backend/src/api-keys/api-keys.repository.ts
@@ -17,6 +17,7 @@ export class ApiKeysRepository {
     key_prefix: string;
     scopes: ApiKeyScope[];
     owner_id: string | null;
+    organization_id: string | null;
     monthly_quota: number;
   }): Promise<ApiKeyRecord> {
     const { data: row, error } = await this.client
@@ -29,7 +30,7 @@ export class ApiKeysRepository {
     return row as ApiKeyRecord;
   }
 
-  async findAll(owner_id?: string): Promise<ApiKeyRecord[]> {
+  async findAll(owner_id?: string, organization_id?: string): Promise<ApiKeyRecord[]> {
     let query = this.client
       .from('api_keys')
       .select('*')
@@ -38,6 +39,9 @@ export class ApiKeysRepository {
 
     if (owner_id) {
       query = query.eq('owner_id', owner_id);
+    }
+    if (organization_id) {
+      query = query.eq('organization_id', organization_id);
     }
 
     const { data, error } = await query;
@@ -51,6 +55,7 @@ export class ApiKeysRepository {
    */
   async findAllPaginated(
     owner_id: string | undefined,
+    organization_id: string | undefined,
     cursor: CursorPayload | null,
     limit?: number,
   ): Promise<{ data: ApiKeyRecord[]; next_cursor: string | null; has_more: boolean; limit: number }> {
@@ -63,6 +68,9 @@ export class ApiKeysRepository {
 
     if (owner_id) {
       query = query.eq('owner_id', owner_id);
+    }
+    if (organization_id) {
+      query = query.eq('organization_id', organization_id);
     }
 
     // Apply cursor filter
@@ -182,7 +190,7 @@ export class ApiKeysRepository {
     if (error) throw error;
   }
 
-  async getUsageSummary(owner_id?: string): Promise<{
+  async getUsageSummary(owner_id?: string, organization_id?: string): Promise<{
     total_keys: number;
     total_requests: number;
     quota: number;
@@ -194,6 +202,9 @@ export class ApiKeysRepository {
 
     if (owner_id) {
       query = query.eq('owner_id', owner_id);
+    }
+    if (organization_id) {
+      query = query.eq('organization_id', organization_id);
     }
 
     const { data, error } = await query;

--- a/app/backend/src/api-keys/api-keys.service.ts
+++ b/app/backend/src/api-keys/api-keys.service.ts
@@ -41,6 +41,7 @@ export class ApiKeysService {
       key_prefix: prefix,
       scopes: dto.scopes,
       owner_id: dto.owner_id ?? null,
+      organization_id: dto.organization_id ?? null,
       monthly_quota: DEFAULT_QUOTA,
     });
 
@@ -49,19 +50,25 @@ export class ApiKeysService {
     return { ...this.toPublic(record), key: rawKey };
   }
 
-  async list(owner_id?: string): Promise<ApiKeyPublic[]> {
-    const records = await this.repo.findAll(owner_id);
+  async list(owner_id?: string, organization_id?: string): Promise<ApiKeyPublic[]> {
+    const records = await this.repo.findAll(owner_id, organization_id);
     return records.map((r) => this.toPublic(r));
   }
 
   async listPaginated(
     owner_id: string | undefined,
+    organization_id: string | undefined,
     cursor?: string,
     limit?: number,
   ): Promise<{ data: ApiKeyPublic[]; pagination: PaginationMetaDto }> {
     const decodedCursor = cursor ? decodeCursor(cursor) : null;
     const effectiveLimit = clampLimit(limit);
-    const result = await this.repo.findAllPaginated(owner_id, decodedCursor, effectiveLimit);
+    const result = await this.repo.findAllPaginated(
+      owner_id,
+      organization_id,
+      decodedCursor,
+      effectiveLimit,
+    );
     return {
       data: result.data.map((r) => this.toPublic(r)),
       pagination: {
@@ -116,8 +123,8 @@ export class ApiKeysService {
     return { ...this.toPublic(updated), key: rawKey };
   }
 
-  async getUsage(owner_id?: string) {
-    return this.repo.getUsageSummary(owner_id);
+  async getUsage(owner_id?: string, organization_id?: string) {
+    return this.repo.getUsageSummary(owner_id, organization_id);
   }
 
   // ---------------------------------------------------------------------------

--- a/app/backend/src/api-keys/api-keys.service.unit.spec.ts
+++ b/app/backend/src/api-keys/api-keys.service.unit.spec.ts
@@ -17,6 +17,7 @@ const makeRecord = (overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord => ({
   key_prefix: 'qx_live_abc',
   scopes: ['links:read'],
   owner_id: null,
+  organization_id: null,
   is_active: true,
   request_count: 0,
   monthly_quota: 10000,
@@ -126,7 +127,7 @@ describe('ApiKeysService', () => {
     it('forwards owner_id filter to repository', async () => {
       repo.findAll.mockResolvedValue([]);
       await service.list('wallet-abc');
-      expect(repo.findAll).toHaveBeenCalledWith('wallet-abc');
+      expect(repo.findAll).toHaveBeenCalledWith('wallet-abc', undefined);
     });
   });
 

--- a/app/backend/src/api-keys/api-keys.types.ts
+++ b/app/backend/src/api-keys/api-keys.types.ts
@@ -17,6 +17,7 @@ export interface ApiKeyRecord {
   key_prefix: string;
   scopes: ApiKeyScope[];
   owner_id: string | null;
+  organization_id: string | null;
   is_active: boolean;
   request_count: number;
   monthly_quota: number;

--- a/app/backend/src/api-keys/dto/create-api-key.dto.ts
+++ b/app/backend/src/api-keys/dto/create-api-key.dto.ts
@@ -23,4 +23,8 @@ export class CreateApiKeyDto {
   @IsOptional()
   @IsString()
   owner_id?: string;
+
+  @IsOptional()
+  @IsString()
+  organization_id?: string;
 }

--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { ReconciliationModule } from "./reconciliation/reconciliation.module";
 import { MetricsMiddleware } from "./metrics/metrics.middleware";
 import { MetricsInterceptor } from "./metrics/metrics.interceptor";
 import { CorrelationIdMiddleware } from "./common/middleware/correlation-id.middleware";
+import { OrganizationContextMiddleware } from "./common/middleware/organization-context.middleware";
 import { NotificationsModule } from "./notifications/notifications.module";
 import { IngestionModule } from "./ingestion/ingestion.module";
 import { ApiKeysModule } from "./api-keys/api-keys.module";
@@ -40,6 +41,7 @@ import { AuditModule } from "./audit/audit.module";
 import { FeatureFlagsModule } from "./feature-flags/feature-flags.module";
 import { DeveloperModule } from "./developer/developer.module";
 import { CustomThrottlerGuard } from "./auth/guards/custom-throttler.guard";
+import { OrganizationRoleGuard } from "./auth/guards/organization-role.guard";
 import { throttlerModuleProfiles } from "./config/rate-limit.config";
 
 type AppImport =
@@ -119,10 +121,16 @@ type AppImport =
       provide: APP_INTERCEPTOR,
       useClass: MetricsInterceptor,
     },
+    {
+      provide: APP_GUARD,
+      useClass: OrganizationRoleGuard,
+    },
   ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(MetricsMiddleware, CorrelationIdMiddleware).forRoutes("*");
+    consumer
+      .apply(MetricsMiddleware, CorrelationIdMiddleware, OrganizationContextMiddleware)
+      .forRoutes("*");
   }
 }

--- a/app/backend/src/auth/decorators/require-org-role.decorator.ts
+++ b/app/backend/src/auth/decorators/require-org-role.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from "@nestjs/common";
+
+export type OrganizationRole = "admin" | "member" | "read_only";
+
+export const REQUIRED_ORG_ROLE_KEY = "required_org_role";
+export const RequireOrgRole = (role: OrganizationRole) =>
+  SetMetadata(REQUIRED_ORG_ROLE_KEY, role);

--- a/app/backend/src/auth/guards/api-key.guard.ts
+++ b/app/backend/src/auth/guards/api-key.guard.ts
@@ -34,6 +34,14 @@ export class ApiKeyGuard implements CanActivate {
     }
 
     const { record, hasScope } = result;
+    const headerOrg = request.organizationContext?.organizationId;
+
+    if (headerOrg && record.organization_id && headerOrg !== record.organization_id) {
+      throw new ForbiddenException({
+        error: "ORGANIZATION_MISMATCH",
+        message: "API key is not scoped to the requested organization",
+      });
+    }
 
     if (this.apiKeysService.isOverQuota(record)) {
       throw new ForbiddenException({
@@ -63,6 +71,12 @@ export class ApiKeyGuard implements CanActivate {
       name: record.name,
       scopes: record.scopes,
       rateLimit: throttlerConfig.groups.authenticated.sustained.limit,
+      organization_id: record.organization_id,
+    };
+
+    request.organizationContext = {
+      organizationId: headerOrg ?? record.organization_id ?? undefined,
+      role: record.scopes.includes("admin") ? "admin" : "member",
     };
 
     return true;

--- a/app/backend/src/auth/guards/organization-role.guard.ts
+++ b/app/backend/src/auth/guards/organization-role.guard.ts
@@ -1,0 +1,46 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import {
+  OrganizationRole,
+  REQUIRED_ORG_ROLE_KEY,
+} from "../decorators/require-org-role.decorator";
+
+const priority: Record<OrganizationRole, number> = {
+  read_only: 1,
+  member: 2,
+  admin: 3,
+};
+
+@Injectable()
+export class OrganizationRoleGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRole =
+      this.reflector.getAllAndOverride<OrganizationRole>(REQUIRED_ORG_ROLE_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]);
+
+    if (!requiredRole) return true;
+
+    const request = context.switchToHttp().getRequest();
+    const currentRole =
+      (request.organizationContext?.role as OrganizationRole | undefined) ??
+      "read_only";
+
+    if (priority[currentRole] < priority[requiredRole]) {
+      throw new ForbiddenException({
+        error: "INSUFFICIENT_ORG_ROLE",
+        message: `Organization role "${requiredRole}" is required for this operation`,
+      });
+    }
+
+    return true;
+  }
+}

--- a/app/backend/src/common/middleware/organization-context.middleware.ts
+++ b/app/backend/src/common/middleware/organization-context.middleware.ts
@@ -1,0 +1,25 @@
+import { Injectable, NestMiddleware } from "@nestjs/common";
+import { NextFunction, Request, Response } from "express";
+
+@Injectable()
+export class OrganizationContextMiddleware implements NestMiddleware {
+  use(req: Request, _: Response, next: NextFunction) {
+    const orgHeader =
+      (req.headers["x-organization-id"] as string | undefined) ??
+      (req.headers["x-workspace-id"] as string | undefined);
+
+    const roleHeader = (req.headers["x-organization-role"] as string | undefined)
+      ?.toLowerCase()
+      .trim();
+
+    req.organizationContext = {
+      organizationId: orgHeader?.trim() || undefined,
+      role:
+        roleHeader === "admin" || roleHeader === "member" || roleHeader === "read_only"
+          ? roleHeader
+          : "read_only",
+    };
+
+    next();
+  }
+}

--- a/app/backend/src/types/custom.d.ts
+++ b/app/backend/src/types/custom.d.ts
@@ -2,4 +2,20 @@
 declare module 'nest-winston';
 declare module 'winston';
 
+declare namespace Express {
+  interface Request {
+    apiKey?: {
+      id: string;
+      name: string;
+      scopes: string[];
+      rateLimit: number;
+      organization_id?: string | null;
+    };
+    organizationContext?: {
+      organizationId?: string;
+      role: "admin" | "member" | "read_only";
+    };
+  }
+}
+
 export {};


### PR DESCRIPTION
Closes #393

## Summary
- added organization context middleware that normalizes workspace/org headers on every request
- added organization role metadata decorator and guard with role hierarchy (admin > member > read_only)
- enforced organization matching in API key guard and propagated resolved organization context to request lifecycle
- added organization scoping support for API key creation/list/usage and analytics report queries
- updated API-key and analytics paths to consume organization context and apply scoped behavior

## Validation
- npm run lint (app/backend) passed
- npm run build (app/backend) passed
- npm run test -- src/api-keys/api-keys.service.unit.spec.ts src/auth/guards/api-key.guard.unit.spec.ts src/analytics/analytics.service.unit.spec.ts --runInBand --watchman=false (app/backend) passed
- npm run type-check (app/backend) fails due pre-existing analytics spec typing issues unrelated to this change