### PR TITLE
feat(backend): privacy v2 stealth envelope + shared-secret helpers

### DIFF
--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -39,6 +39,7 @@ import { JobQueueModule } from "./job-queue/job-queue.module";
 import { AuditModule } from "./audit/audit.module";
 import { FeatureFlagsModule } from "./feature-flags/feature-flags.module";
 import { DeveloperModule } from "./developer/developer.module";
+import { PrivacyModule } from "./privacy/privacy.module";
 import { CustomThrottlerGuard } from "./auth/guards/custom-throttler.guard";
 import { throttlerModuleProfiles } from "./config/rate-limit.config";
 
@@ -80,6 +81,7 @@ type AppImport =
       JobQueueModule,
       AuditModule,
       FeatureFlagsModule,
+      PrivacyModule,
     ];
 
     // In development, if SUPABASE_URL points to a localhost placeholder (i.e. you don't

--- a/app/backend/src/dto/link/link-metadata-request.dto.ts
+++ b/app/backend/src/dto/link/link-metadata-request.dto.ts
@@ -157,4 +157,13 @@ export class LinkMetadataRequestDto {
   @IsString({ each: true })
   @Validate(IsStellarAsset, { each: true })
   acceptedAssets?: string[];
+
+  @ApiPropertyOptional({
+    description:
+      'Recipient view public key (PEM) used to encrypt recipient metadata for stealth privacy flows.',
+    example: '-----BEGIN PUBLIC KEY-----\\n...\\n-----END PUBLIC KEY-----',
+  })
+  @IsOptional()
+  @IsString()
+  recipientViewPublicKeyPem?: string;
 }

--- a/app/backend/src/links/links.module.ts
+++ b/app/backend/src/links/links.module.ts
@@ -15,6 +15,7 @@ import { StellarModule } from "../stellar/stellar.module";
 import { ApiKeysModule } from "../api-keys/api-keys.module";
 import { JobQueueModule } from "../job-queue/job-queue.module";
 import { FeatureFlagsModule } from "../feature-flags/feature-flags.module";
+import { PrivacyModule } from "../privacy/privacy.module";
 
 @Module({
   controllers: [
@@ -45,6 +46,7 @@ import { FeatureFlagsModule } from "../feature-flags/feature-flags.module";
     StellarModule,
     ApiKeysModule,
     FeatureFlagsModule,
+    PrivacyModule,
     forwardRef(() => JobQueueModule),
   ],
 })

--- a/app/backend/src/links/links.service.ts
+++ b/app/backend/src/links/links.service.ts
@@ -6,6 +6,7 @@ import {
   PathPreviewService,
   type PathPreviewRow,
 } from '../stellar/path-preview.service';
+import { PrivacyService } from '../privacy/privacy.service';
 
 @Injectable()
 export class LinksService {
@@ -13,6 +14,7 @@ export class LinksService {
 
   constructor(
     @Optional() private readonly pathPreviewService?: PathPreviewService,
+    @Optional() private readonly privacyService?: PrivacyService,
   ) {}
 
   async generateMetadata(request: LinkMetadataRequestDto): Promise<LinkMetadataResponseDto> {
@@ -68,6 +70,16 @@ export class LinksService {
 
     // Additional metadata fields for frontend
     const additionalMetadata = this.deriveAdditionalMetadata(request, normalizedAsset);
+    const stealthRecipientEnvelope =
+      request.privacy &&
+      request.recipientViewPublicKeyPem &&
+      destination &&
+      this.privacyService
+        ? this.privacyService.encryptRecipientForViewKey(
+            destination,
+            request.recipientViewPublicKeyPem,
+          )
+        : undefined;
 
     // Compute swap options for accepted assets that differ from the destination asset
     let swapOptions: PathPreviewRow[] | null = null;
@@ -91,6 +103,7 @@ export class LinksService {
       metadata: {
         normalized,
         warnings: warnings.length > 0 ? warnings : undefined,
+        stealthRecipientEnvelope,
         ...additionalMetadata,
       },
     };

--- a/app/backend/src/privacy/privacy.controller.ts
+++ b/app/backend/src/privacy/privacy.controller.ts
@@ -1,0 +1,61 @@
+import { Body, Controller, Post } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { PrivacyService, StealthEnvelope } from "./privacy.service";
+
+class EncryptRecipientDto {
+  recipientAddress!: string;
+  recipientViewPublicKeyPem!: string;
+}
+
+class DeriveSecretDto {
+  privateKeyPem!: string;
+  publicKeyPem!: string;
+}
+
+class DecryptEnvelopeDto {
+  envelope!: StealthEnvelope;
+  recipientViewPrivateKeyPem!: string;
+}
+
+@ApiTags("privacy")
+@Controller("privacy")
+export class PrivacyController {
+  constructor(private readonly privacyService: PrivacyService) {}
+
+  @Post("encrypt-recipient")
+  @ApiOperation({
+    summary: "Encrypt recipient metadata using recipient view public key",
+  })
+  encryptRecipient(@Body() body: EncryptRecipientDto) {
+    return this.privacyService.encryptRecipientForViewKey(
+      body.recipientAddress,
+      body.recipientViewPublicKeyPem,
+    );
+  }
+
+  @Post("derive-shared-secret")
+  @ApiOperation({
+    summary: "Derive X25519 shared secret for non-custodial stealth flows",
+  })
+  deriveSharedSecret(@Body() body: DeriveSecretDto) {
+    return {
+      sharedSecretHex: this.privacyService.deriveSharedSecretHex(
+        body.privateKeyPem,
+        body.publicKeyPem,
+      ),
+    };
+  }
+
+  @Post("decrypt-recipient")
+  @ApiOperation({
+    summary: "Decrypt recipient metadata envelope (for local integration testing)",
+  })
+  decryptRecipient(@Body() body: DecryptEnvelopeDto) {
+    return {
+      recipientAddress: this.privacyService.decryptRecipientEnvelope(
+        body.envelope,
+        body.recipientViewPrivateKeyPem,
+      ),
+    };
+  }
+}

--- a/app/backend/src/privacy/privacy.module.ts
+++ b/app/backend/src/privacy/privacy.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { PrivacyController } from "./privacy.controller";
+import { PrivacyService } from "./privacy.service";
+
+@Module({
+  controllers: [PrivacyController],
+  providers: [PrivacyService],
+  exports: [PrivacyService],
+})
+export class PrivacyModule {}

--- a/app/backend/src/privacy/privacy.service.ts
+++ b/app/backend/src/privacy/privacy.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from "@nestjs/common";
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  diffieHellman,
+  generateKeyPairSync,
+  KeyObject,
+  randomBytes,
+  createPrivateKey,
+  createPublicKey,
+} from "crypto";
+
+export type StealthEnvelope = {
+  ephPublicKeyPem: string;
+  ivBase64: string;
+  authTagBase64: string;
+  ciphertextBase64: string;
+  algorithm: "aes-256-gcm";
+};
+
+@Injectable()
+export class PrivacyService {
+  encryptRecipientForViewKey(
+    recipientAddress: string,
+    recipientViewPublicKeyPem: string,
+  ): StealthEnvelope {
+    const { privateKey: ephPrivateKey, publicKey: ephPublicKey } =
+      generateKeyPairSync("x25519");
+    const recipientKey = createPublicKey(recipientViewPublicKeyPem);
+    const shared = diffieHellman({ privateKey: ephPrivateKey, publicKey: recipientKey });
+    const encryptionKey = createHash("sha256").update(shared).digest();
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", encryptionKey, iv);
+    const ciphertext = Buffer.concat([
+      cipher.update(recipientAddress, "utf8"),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+
+    return {
+      ephPublicKeyPem: ephPublicKey.export({ format: "pem", type: "spki" }).toString(),
+      ivBase64: iv.toString("base64"),
+      authTagBase64: authTag.toString("base64"),
+      ciphertextBase64: ciphertext.toString("base64"),
+      algorithm: "aes-256-gcm",
+    };
+  }
+
+  deriveSharedSecretHex(
+    privateKeyPem: string,
+    publicKeyPem: string,
+  ): string {
+    const privateKey: KeyObject = createPrivateKey(privateKeyPem);
+    const publicKey: KeyObject = createPublicKey(publicKeyPem);
+    return diffieHellman({ privateKey, publicKey }).toString("hex");
+  }
+
+  decryptRecipientEnvelope(
+    envelope: StealthEnvelope,
+    recipientViewPrivateKeyPem: string,
+  ): string {
+    const privateKey = createPrivateKey(recipientViewPrivateKeyPem);
+    const ephPublic = createPublicKey(envelope.ephPublicKeyPem);
+    const shared = diffieHellman({ privateKey, publicKey: ephPublic });
+    const encryptionKey = createHash("sha256").update(shared).digest();
+    const decipher = createDecipheriv(
+      "aes-256-gcm",
+      encryptionKey,
+      Buffer.from(envelope.ivBase64, "base64"),
+    );
+    decipher.setAuthTag(Buffer.from(envelope.authTagBase64, "base64"));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(envelope.ciphertextBase64, "base64")),
+      decipher.final(),
+    ]);
+    return plaintext.toString("utf8");
+  }
+}

--- a/app/backend/src/privacy/privacy.service.unit.spec.ts
+++ b/app/backend/src/privacy/privacy.service.unit.spec.ts
@@ -1,0 +1,44 @@
+import { generateKeyPairSync } from "crypto";
+import { PrivacyService } from "./privacy.service";
+
+describe("PrivacyService", () => {
+  const service = new PrivacyService();
+
+  it("encrypts and decrypts recipient metadata with recipient view key", () => {
+    const { privateKey, publicKey } = generateKeyPairSync("x25519");
+    const recipientAddress = "GDSTESTRECIPIENTADDRESS00000000000000000000000000000000000";
+    const recipientPublicPem = publicKey
+      .export({ format: "pem", type: "spki" })
+      .toString();
+    const recipientPrivatePem = privateKey
+      .export({ format: "pem", type: "pkcs8" })
+      .toString();
+
+    const envelope = service.encryptRecipientForViewKey(
+      recipientAddress,
+      recipientPublicPem,
+    );
+    const decrypted = service.decryptRecipientEnvelope(
+      envelope,
+      recipientPrivatePem,
+    );
+
+    expect(decrypted).toBe(recipientAddress);
+  });
+
+  it("derives matching shared secret from counterpart key pairs", () => {
+    const alice = generateKeyPairSync("x25519");
+    const bob = generateKeyPairSync("x25519");
+
+    const aliceSecret = service.deriveSharedSecretHex(
+      alice.privateKey.export({ format: "pem", type: "pkcs8" }).toString(),
+      bob.publicKey.export({ format: "pem", type: "spki" }).toString(),
+    );
+    const bobSecret = service.deriveSharedSecretHex(
+      bob.privateKey.export({ format: "pem", type: "pkcs8" }).toString(),
+      alice.publicKey.export({ format: "pem", type: "spki" }).toString(),
+    );
+
+    expect(aliceSecret).toBe(bobSecret);
+  });
+});


### PR DESCRIPTION
Closes #226

## Summary
- added a dedicated privacy module with backend helpers for stealth flows
- implemented recipient metadata encryption using ephemeral X25519 + AES-256-GCM envelopes
- added shared-secret derivation helper endpoint for non-custodial client integration flows
- integrated optional encrypted recipient envelope generation into link metadata when privacy is enabled
- added unit tests for envelope encryption/decryption and shared-secret symmetry

## Validation
- npm run lint (app/backend) passed
- npm run build (app/backend) passed
- npm run test -- src/privacy/privacy.service.unit.spec.ts src/links/links.service.enhanced.unit.spec.ts --runInBand --watchman=false (app/backend) passed
- npm run type-check (app/backend) fails due pre-existing analytics spec typing issues unrelated to this change