### PR TITLE
feat(be-28): Soroban event indexer v1 – ledger-range poller, full eve…

### DIFF
--- a/app/backend/src/health/health.service.ts
+++ b/app/backend/src/health/health.service.ts
@@ -209,8 +209,7 @@ export class HealthService {
       );
 
       // Try to get network info from Soroban RPC
-      const server = this.sorobanRpcService.getServer();
-      const check = Promise.race([server.getNetwork(), timeout]);
+      const check = Promise.race([this.sorobanRpcService.getNetworkPassphrase(), timeout]);
 
       await check;
       const latency = Date.now() - start;

--- a/app/backend/src/ingestion/__tests__/soroban-event-indexer.schema-version.unit.spec.ts
+++ b/app/backend/src/ingestion/__tests__/soroban-event-indexer.schema-version.unit.spec.ts
@@ -1,0 +1,168 @@
+import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
+import {
+  SorobanEventParser,
+  RawHorizonContractEvent,
+  MAX_SUPPORTED_SCHEMA_VERSION,
+  UnknownSchemaVersionHandler,
+} from "../soroban-event.parser";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function symVal(s: string): xdr.ScVal {
+  return xdr.ScVal.scvSymbol(s);
+}
+
+function addressVal(pubkey: string): xdr.ScVal {
+  return nativeToScVal(pubkey);
+}
+
+function bytesVal(hex: string): xdr.ScVal {
+  return xdr.ScVal.scvBytes(Buffer.from(hex, "hex"));
+}
+
+function mapVal(entries: Record<string, xdr.ScVal>): xdr.ScVal {
+  const mapEntries = Object.entries(entries).map(
+    ([k, v]) => new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol(k), val: v }),
+  );
+  return xdr.ScVal.scvMap(mapEntries);
+}
+
+function makeRaw(
+  topics: xdr.ScVal[],
+  data: xdr.ScVal,
+  overrides: Partial<RawHorizonContractEvent> = {},
+): RawHorizonContractEvent {
+  return {
+    id: "1",
+    paging_token: "100-1",
+    transaction_hash: "txhash1",
+    ledger: 100,
+    created_at: "2025-01-01T00:00:00Z",
+    contract_id: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    type: "contract",
+    topic: topics.map((v) => v.toXDR("base64")),
+    value: { xdr: data.toXDR("base64") },
+    ...overrides,
+  };
+}
+
+const OWNER = "GDQERHRWJYV7JHRP5V7DWJVI6Y5ABZP3YRH7DKYJRBEGJQKE6IQEOSY2";
+const TOKEN = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+const COMMITMENT_HEX = "deadbeef".repeat(8);
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("SorobanEventParser – schema version handling", () => {
+  it("treats absent schema_version as v1", () => {
+    const parser = new SorobanEventParser();
+    const topics = [symVal("EscrowDeposited"), bytesVal(COMMITMENT_HEX), addressVal(OWNER)];
+    const data = mapVal({
+      token: addressVal(TOKEN),
+      amount: nativeToScVal(1_000n, { type: "i128" }),
+      expires_at: nativeToScVal(9999999n, { type: "u64" }),
+      timestamp: nativeToScVal(1700000000n, { type: "u64" }),
+      // no schema_version key
+    });
+
+    const result = parser.parse(makeRaw(topics, data));
+    expect(result).not.toBeNull();
+    expect(result!.schemaVersion).toBe(1);
+  });
+
+  it("accepts schema_version == 2", () => {
+    const parser = new SorobanEventParser();
+    const topics = [symVal("EscrowDeposited"), bytesVal(COMMITMENT_HEX), addressVal(OWNER)];
+    const data = mapVal({
+      schema_version: nativeToScVal(2, { type: "u32" }),
+      token: addressVal(TOKEN),
+      amount: nativeToScVal(1_000n, { type: "i128" }),
+      expires_at: nativeToScVal(9999999n, { type: "u64" }),
+      timestamp: nativeToScVal(1700000000n, { type: "u64" }),
+    });
+
+    const result = parser.parse(makeRaw(topics, data));
+    expect(result).not.toBeNull();
+    expect(result!.schemaVersion).toBe(2);
+  });
+
+  it("rejects schema_version > MAX_SUPPORTED and calls the handler", () => {
+    const handler: UnknownSchemaVersionHandler = jest.fn();
+    const parser = new SorobanEventParser(handler);
+
+    const unknownVersion = MAX_SUPPORTED_SCHEMA_VERSION + 1;
+    const topics = [symVal("EscrowDeposited"), bytesVal(COMMITMENT_HEX), addressVal(OWNER)];
+    const data = mapVal({
+      schema_version: nativeToScVal(unknownVersion, { type: "u32" }),
+      token: addressVal(TOKEN),
+      amount: nativeToScVal(1_000n, { type: "i128" }),
+      expires_at: nativeToScVal(9999999n, { type: "u64" }),
+      timestamp: nativeToScVal(1700000000n, { type: "u64" }),
+    });
+
+    const result = parser.parse(makeRaw(topics, data, { paging_token: "999-1" }));
+    expect(result).toBeNull();
+    expect(handler).toHaveBeenCalledWith("EscrowDeposited", unknownVersion, "999-1");
+  });
+
+  it("does not call the handler for supported versions", () => {
+    const handler: UnknownSchemaVersionHandler = jest.fn();
+    const parser = new SorobanEventParser(handler);
+
+    const topics = [symVal("PrivacyToggled"), addressVal(OWNER)];
+    const data = mapVal({
+      schema_version: nativeToScVal(2, { type: "u32" }),
+      enabled: nativeToScVal(true),
+      timestamp: nativeToScVal(1700000000n, { type: "u64" }),
+    });
+
+    parser.parse(makeRaw(topics, data));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("SorobanEventParser – PrivacyToggled", () => {
+  it("parses PrivacyToggled with schema_version=2", () => {
+    const parser = new SorobanEventParser();
+    const topics = [symVal("PrivacyToggled"), addressVal(OWNER)];
+    const data = mapVal({
+      schema_version: nativeToScVal(2, { type: "u32" }),
+      enabled: nativeToScVal(false),
+      timestamp: nativeToScVal(1700000000n, { type: "u64" }),
+    });
+
+    const result = parser.parse(makeRaw(topics, data));
+    expect(result?.eventType).toBe("PrivacyToggled");
+    if (result?.eventType !== "PrivacyToggled") return;
+    expect(result.owner).toBe(OWNER);
+    expect(result.enabled).toBe(false);
+    expect(result.schemaVersion).toBe(2);
+  });
+});
+
+describe("SorobanEventParser – EphemeralKeyRegistered", () => {
+  const STEALTH_HEX = "cafebabe".repeat(8);
+  const EPH_PUB_HEX = "deadcafe".repeat(8);
+
+  it("parses EphemeralKeyRegistered", () => {
+    const parser = new SorobanEventParser();
+    const topics = [
+      symVal("EphemeralKeyRegistered"),
+      bytesVal(STEALTH_HEX),
+      bytesVal(EPH_PUB_HEX),
+    ];
+    const data = mapVal({
+      schema_version: nativeToScVal(2, { type: "u32" }),
+      token: addressVal(TOKEN),
+      amount: nativeToScVal(500n, { type: "i128" }),
+      expires_at: nativeToScVal(9999999n, { type: "u64" }),
+      timestamp: nativeToScVal(1700000000n, { type: "u64" }),
+    });
+
+    const result = parser.parse(makeRaw(topics, data));
+    expect(result?.eventType).toBe("EphemeralKeyRegistered");
+    if (result?.eventType !== "EphemeralKeyRegistered") return;
+    expect(result.stealthAddress).toBe(STEALTH_HEX);
+    expect(result.ephPub).toBe(EPH_PUB_HEX);
+    expect(result.amount).toBe(500n);
+  });
+});

--- a/app/backend/src/ingestion/__tests__/soroban-event-indexer.service.unit.spec.ts
+++ b/app/backend/src/ingestion/__tests__/soroban-event-indexer.service.unit.spec.ts
@@ -2,7 +2,7 @@ import { EventEmitter2 } from "@nestjs/event-emitter";
 import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
 
 import { SorobanEventIndexerService } from "../soroban-event-indexer.service";
-import { SorobanEventParser, RawHorizonContractEvent } from "../soroban-event.parser";
+import { RawHorizonContractEvent } from "../soroban-event.parser";
 import { IndexerCheckpointRepository } from "../indexer-checkpoint.repository";
 import { EscrowEventRepository } from "../escrow-event.repository";
 import { PrivacyEventRepository } from "../privacy-event.repository";

--- a/app/backend/src/ingestion/__tests__/soroban-event-indexer.service.unit.spec.ts
+++ b/app/backend/src/ingestion/__tests__/soroban-event-indexer.service.unit.spec.ts
@@ -1,0 +1,218 @@
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
+
+import { SorobanEventIndexerService } from "../soroban-event-indexer.service";
+import { SorobanEventParser, RawHorizonContractEvent } from "../soroban-event.parser";
+import { IndexerCheckpointRepository } from "../indexer-checkpoint.repository";
+import { EscrowEventRepository } from "../escrow-event.repository";
+import { PrivacyEventRepository } from "../privacy-event.repository";
+import { AdminEventRepository } from "../admin-event.repository";
+import { StealthEventRepository } from "../stealth-event.repository";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function symVal(s: string) { return xdr.ScVal.scvSymbol(s); }
+function addressVal(s: string) { return nativeToScVal(s); }
+function bytesVal(hex: string) { return xdr.ScVal.scvBytes(Buffer.from(hex, "hex")); }
+function mapVal(entries: Record<string, xdr.ScVal>) {
+  return xdr.ScVal.scvMap(
+    Object.entries(entries).map(
+      ([k, v]) => new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol(k), val: v }),
+    ),
+  );
+}
+
+const OWNER = "GDQERHRWJYV7JHRP5V7DWJVI6Y5ABZP3YRH7DKYJRBEGJQKE6IQEOSY2";
+const TOKEN = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+const COMMITMENT_HEX = "deadbeef".repeat(8);
+const CONTRACT_ID = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+function makeEscrowDepositedRaw(ledger: number, pagingToken: string): RawHorizonContractEvent {
+  const topics = [symVal("EscrowDeposited"), bytesVal(COMMITMENT_HEX), addressVal(OWNER)];
+  const data = mapVal({
+    schema_version: nativeToScVal(2, { type: "u32" }),
+    token: addressVal(TOKEN),
+    amount: nativeToScVal(1_000n, { type: "i128" }),
+    expires_at: nativeToScVal(9999999n, { type: "u64" }),
+    timestamp: nativeToScVal(1700000000n, { type: "u64" }),
+  });
+  return {
+    id: pagingToken,
+    paging_token: pagingToken,
+    transaction_hash: `tx-${pagingToken}`,
+    ledger,
+    created_at: "2026-01-01T00:00:00Z",
+    contract_id: CONTRACT_ID,
+    type: "contract",
+    topic: topics.map((v) => v.toXDR("base64")),
+    value: { xdr: data.toXDR("base64") },
+  };
+}
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+function buildMocks() {
+  const config = { network: "testnet" } as never;
+
+  const checkpointRepo = {
+    getLastLedger: jest.fn().mockResolvedValue(null),
+    saveLastLedger: jest.fn().mockResolvedValue(undefined),
+  } as unknown as IndexerCheckpointRepository;
+
+  const escrowRepo = {
+    upsertEvent: jest.fn().mockResolvedValue(undefined),
+  } as unknown as EscrowEventRepository;
+
+  const privacyRepo = {
+    upsertEvent: jest.fn().mockResolvedValue(undefined),
+  } as unknown as PrivacyEventRepository;
+
+  const adminRepo = {
+    upsertEvent: jest.fn().mockResolvedValue(undefined),
+  } as unknown as AdminEventRepository;
+
+  const stealthRepo = {
+    upsertEvent: jest.fn().mockResolvedValue(undefined),
+  } as unknown as StealthEventRepository;
+
+  const metrics = {
+    recordUnknownSchemaVersion: jest.fn(),
+  } as never;
+
+  const eventEmitter = { emit: jest.fn() } as unknown as EventEmitter2;
+
+  return { config, checkpointRepo, escrowRepo, privacyRepo, adminRepo, stealthRepo, metrics, eventEmitter };
+}
+
+function buildService(mocks: ReturnType<typeof buildMocks>) {
+  return new SorobanEventIndexerService(
+    mocks.config,
+    mocks.checkpointRepo,
+    mocks.escrowRepo,
+    mocks.privacyRepo,
+    mocks.adminRepo,
+    mocks.stealthRepo,
+    mocks.metrics,
+    mocks.eventEmitter,
+  );
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("SorobanEventIndexerService", () => {
+  let fetchSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  function mockHorizonPage(records: RawHorizonContractEvent[]) {
+    fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        _embedded: { records },
+        _links: {},
+      }),
+    } as Response);
+  }
+
+  it("persists events and advances checkpoint", async () => {
+    const mocks = buildMocks();
+    const svc = buildService(mocks);
+    const record = makeEscrowDepositedRaw(100, "100-1");
+    mockHorizonPage([record]);
+
+    const result = await svc.indexLedgerRange(CONTRACT_ID, 100, 100);
+
+    expect(result.processed).toBe(1);
+    expect(result.persisted).toBe(1);
+    expect(mocks.escrowRepo.upsertEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.checkpointRepo.saveLastLedger).toHaveBeenCalledWith(CONTRACT_ID, 100);
+    expect(mocks.eventEmitter.emit).toHaveBeenCalledWith("stellar.EscrowDeposited", expect.anything());
+  });
+
+  it("skips already-indexed range when checkpoint is ahead", async () => {
+    const mocks = buildMocks();
+    (mocks.checkpointRepo.getLastLedger as jest.Mock).mockResolvedValue(200);
+    const svc = buildService(mocks);
+    mockHorizonPage([]);
+
+    const result = await svc.indexLedgerRange(CONTRACT_ID, 100, 200);
+
+    expect(result.processed).toBe(0);
+    expect(mocks.escrowRepo.upsertEvent).not.toHaveBeenCalled();
+  });
+
+  it("force=true reprocesses the full range ignoring checkpoint", async () => {
+    const mocks = buildMocks();
+    (mocks.checkpointRepo.getLastLedger as jest.Mock).mockResolvedValue(200);
+    const svc = buildService(mocks);
+    const record = makeEscrowDepositedRaw(100, "100-1");
+    mockHorizonPage([record]);
+
+    const result = await svc.indexLedgerRange(CONTRACT_ID, 100, 200, true);
+
+    expect(result.processed).toBe(1);
+    expect(mocks.escrowRepo.upsertEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts skipped unknown-schema events separately", async () => {
+    const mocks = buildMocks();
+    const svc = buildService(mocks);
+
+    // Build a raw event with schema_version=99 (unsupported)
+    const topics = [
+      symVal("EscrowDeposited"),
+      xdr.ScVal.scvBytes(Buffer.from(COMMITMENT_HEX, "hex")),
+      nativeToScVal(OWNER),
+    ];
+    const data = mapVal({
+      schema_version: nativeToScVal(99, { type: "u32" }),
+      token: nativeToScVal(TOKEN),
+      amount: nativeToScVal(1_000n, { type: "i128" }),
+      expires_at: nativeToScVal(9999999n, { type: "u64" }),
+      timestamp: nativeToScVal(1700000000n, { type: "u64" }),
+    });
+    const raw: RawHorizonContractEvent = {
+      id: "1",
+      paging_token: "100-1",
+      transaction_hash: "tx1",
+      ledger: 100,
+      created_at: "2026-01-01T00:00:00Z",
+      contract_id: CONTRACT_ID,
+      type: "contract",
+      topic: topics.map((v) => v.toXDR("base64")),
+      value: { xdr: data.toXDR("base64") },
+    };
+
+    mockHorizonPage([raw]);
+
+    const result = await svc.indexLedgerRange(CONTRACT_ID, 100, 100);
+
+    expect(result.processed).toBe(1);
+    expect(result.persisted).toBe(0);
+    expect(result.skippedUnknownSchema).toBe(1);
+    expect(mocks.escrowRepo.upsertEvent).not.toHaveBeenCalled();
+    expect(mocks.metrics.recordUnknownSchemaVersion).toHaveBeenCalledWith("EscrowDeposited", 99);
+  });
+
+  it("is idempotent: calling twice with same range does not double-persist", async () => {
+    const mocks = buildMocks();
+    // First call: no checkpoint
+    (mocks.checkpointRepo.getLastLedger as jest.Mock)
+      .mockResolvedValueOnce(null)   // first call
+      .mockResolvedValueOnce(100);   // second call: checkpoint is at 100
+
+    const svc = buildService(mocks);
+    const record = makeEscrowDepositedRaw(100, "100-1");
+    mockHorizonPage([record]);
+
+    await svc.indexLedgerRange(CONTRACT_ID, 100, 100);
+    // Second call: checkpoint says 100, range is [100,100] → effectiveFrom=101 > toLedger=100 → skip
+    const result2 = await svc.indexLedgerRange(CONTRACT_ID, 100, 100);
+
+    expect(result2.processed).toBe(0);
+    // upsertEvent called only once across both runs
+    expect(mocks.escrowRepo.upsertEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/backend/src/ingestion/admin-event.repository.ts
+++ b/app/backend/src/ingestion/admin-event.repository.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { SupabaseService } from "../supabase/supabase.service";
+import type {
+  ContractPausedEvent,
+  AdminChangedEvent,
+  ContractUpgradedEvent,
+  AdminEvent,
+} from "./types/contract-event.types";
+
+@Injectable()
+export class AdminEventRepository {
+  private readonly logger = new Logger(AdminEventRepository.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async upsertEvent(event: AdminEvent): Promise<void> {
+    const payload = this.buildPayload(event);
+
+    const { error } = await this.supabase.getClient()
+      .from("admin_events")
+      .upsert(
+        {
+          event_type: event.eventType,
+          payload,
+          schema_version: event.schemaVersion,
+          contract_timestamp: Number(event.contractTimestamp),
+          tx_hash: event.txHash,
+          ledger_sequence: event.ledgerSequence,
+          paging_token: event.pagingToken,
+        },
+        { onConflict: "tx_hash,event_type", ignoreDuplicates: true },
+      );
+
+    if (error) {
+      this.logger.error(`Failed to upsert ${event.eventType} tx=${event.txHash}: ${error.message}`);
+      throw error;
+    }
+  }
+
+  private buildPayload(event: AdminEvent): Record<string, unknown> {
+    switch (event.eventType) {
+      case "ContractPaused":
+        return { admin: (event as ContractPausedEvent).admin, paused: (event as ContractPausedEvent).paused };
+      case "AdminChanged":
+        return { oldAdmin: (event as AdminChangedEvent).oldAdmin, newAdmin: (event as AdminChangedEvent).newAdmin };
+      case "ContractUpgraded":
+        return { newWasmHash: (event as ContractUpgradedEvent).newWasmHash, admin: (event as ContractUpgradedEvent).admin };
+      default:
+        return {};
+    }
+  }
+}

--- a/app/backend/src/ingestion/indexer-checkpoint.repository.ts
+++ b/app/backend/src/ingestion/indexer-checkpoint.repository.ts
@@ -1,0 +1,41 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { SupabaseService } from "../supabase/supabase.service";
+
+/**
+ * Persists and reads the highest fully-processed ledger per contract.
+ * Used by the batch poller to resume without re-scanning indexed ranges.
+ */
+@Injectable()
+export class IndexerCheckpointRepository {
+  private readonly logger = new Logger(IndexerCheckpointRepository.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async getLastLedger(contractId: string): Promise<number | null> {
+    const { data, error } = await this.supabase.getClient()
+      .from("indexer_checkpoints")
+      .select("last_ledger")
+      .eq("contract_id", contractId)
+      .maybeSingle();
+
+    if (error) {
+      this.logger.error(`Failed to read checkpoint for ${contractId}: ${error.message}`);
+      throw error;
+    }
+    return data ? Number(data.last_ledger) : null;
+  }
+
+  async saveLastLedger(contractId: string, ledger: number): Promise<void> {
+    const { error } = await this.supabase.getClient()
+      .from("indexer_checkpoints")
+      .upsert(
+        { contract_id: contractId, last_ledger: ledger, updated_at: new Date().toISOString() },
+        { onConflict: "contract_id" },
+      );
+
+    if (error) {
+      this.logger.error(`Failed to save checkpoint for ${contractId}: ${error.message}`);
+      throw error;
+    }
+  }
+}

--- a/app/backend/src/ingestion/ingestion.module.ts
+++ b/app/backend/src/ingestion/ingestion.module.ts
@@ -2,24 +2,44 @@ import { Module, forwardRef } from "@nestjs/common";
 
 import { SupabaseModule } from "../supabase/supabase.module";
 import { JobQueueModule } from "../job-queue/job-queue.module";
+import { MetricsModule } from "../metrics/metrics.module";
 import { CursorRepository } from "./cursor.repository";
 import { EscrowEventRepository } from "./escrow-event.repository";
+import { PrivacyEventRepository } from "./privacy-event.repository";
+import { AdminEventRepository } from "./admin-event.repository";
+import { StealthEventRepository } from "./stealth-event.repository";
+import { IndexerCheckpointRepository } from "./indexer-checkpoint.repository";
 import { SorobanEventParser } from "./soroban-event.parser";
 import { StellarIngestionService } from "./stellar-ingestion.service";
+import { SorobanEventIndexerService } from "./soroban-event-indexer.service";
+import { SorobanIndexerController } from "./soroban-indexer.controller";
 import { IngestionBootstrapService } from "./ingestion-bootstrap.service";
 
 @Module({
   imports: [
     SupabaseModule,
     forwardRef(() => JobQueueModule),
+    MetricsModule,
   ],
+  controllers: [SorobanIndexerController],
   providers: [
     CursorRepository,
     EscrowEventRepository,
+    PrivacyEventRepository,
+    AdminEventRepository,
+    StealthEventRepository,
+    IndexerCheckpointRepository,
     SorobanEventParser,
     StellarIngestionService,
+    SorobanEventIndexerService,
     IngestionBootstrapService,
   ],
-  exports: [StellarIngestionService, SorobanEventParser, CursorRepository, EscrowEventRepository],
+  exports: [
+    StellarIngestionService,
+    SorobanEventIndexerService,
+    SorobanEventParser,
+    CursorRepository,
+    EscrowEventRepository,
+  ],
 })
 export class IngestionModule {}

--- a/app/backend/src/ingestion/privacy-event.repository.ts
+++ b/app/backend/src/ingestion/privacy-event.repository.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { SupabaseService } from "../supabase/supabase.service";
+import type { PrivacyToggledEvent } from "./types/contract-event.types";
+
+@Injectable()
+export class PrivacyEventRepository {
+  private readonly logger = new Logger(PrivacyEventRepository.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async upsertEvent(event: PrivacyToggledEvent): Promise<void> {
+    const { error } = await this.supabase.getClient()
+      .from("privacy_events")
+      .upsert(
+        {
+          event_type: event.eventType,
+          owner: event.owner,
+          enabled: event.enabled,
+          schema_version: event.schemaVersion,
+          contract_timestamp: Number(event.contractTimestamp),
+          tx_hash: event.txHash,
+          ledger_sequence: event.ledgerSequence,
+          paging_token: event.pagingToken,
+        },
+        { onConflict: "tx_hash,event_type,owner", ignoreDuplicates: true },
+      );
+
+    if (error) {
+      this.logger.error(`Failed to upsert PrivacyToggled for owner ${event.owner}: ${error.message}`);
+      throw error;
+    }
+  }
+}

--- a/app/backend/src/ingestion/soroban-event-indexer.service.ts
+++ b/app/backend/src/ingestion/soroban-event-indexer.service.ts
@@ -1,0 +1,236 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+
+import { AppConfigService } from "../config";
+import { HORIZON_BASE_URLS } from "../config/stellar.config";
+import { MetricsService } from "../metrics/metrics.service";
+import { SorobanEventParser, RawHorizonContractEvent } from "./soroban-event.parser";
+import { IndexerCheckpointRepository } from "./indexer-checkpoint.repository";
+import { EscrowEventRepository } from "./escrow-event.repository";
+import { PrivacyEventRepository } from "./privacy-event.repository";
+import { AdminEventRepository } from "./admin-event.repository";
+import { StealthEventRepository } from "./stealth-event.repository";
+import type {
+  QuickExContractEvent,
+  EscrowEvent,
+  AdminEvent,
+  StealthEvent,
+} from "./types/contract-event.types";
+
+/** Number of events fetched per Horizon page. */
+const PAGE_LIMIT = 200;
+
+export interface LedgerRangeResult {
+  fromLedger: number;
+  toLedger: number;
+  processed: number;
+  persisted: number;
+  skippedUnknownSchema: number;
+}
+
+/**
+ * Polls Soroban contract events by ledger range from Horizon's REST API.
+ *
+ * Responsibilities:
+ *  - Fetch events page-by-page for a given [fromLedger, toLedger] range.
+ *  - Parse each event with schema-version awareness.
+ *  - Persist all event domains idempotently (escrow, privacy, admin, stealth).
+ *  - Advance the durable checkpoint after each page so a crash is recoverable.
+ *  - Emit domain events for downstream consumers.
+ *
+ * Reconciliation / reindex: calling `indexLedgerRange` with `force=true` skips
+ * the checkpoint read and re-processes the full range. Idempotent upserts ensure
+ * no duplicates are created.
+ */
+@Injectable()
+export class SorobanEventIndexerService {
+  private readonly logger = new Logger(SorobanEventIndexerService.name);
+  private readonly horizonUrl: string;
+
+  constructor(
+    private readonly config: AppConfigService,
+    private readonly checkpointRepo: IndexerCheckpointRepository,
+    private readonly escrowRepo: EscrowEventRepository,
+    private readonly privacyRepo: PrivacyEventRepository,
+    private readonly adminRepo: AdminEventRepository,
+    private readonly stealthRepo: StealthEventRepository,
+    private readonly metrics: MetricsService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {
+    this.horizonUrl = HORIZON_BASE_URLS[this.config.network];
+
+    // Wire the parser's unknown-schema-version callback to metrics.
+    this.parser = new SorobanEventParser((eventName, version, pagingToken) => {
+      this.logger.warn(
+        `Unknown schema_version=${version} for event ${eventName} paging_token=${pagingToken}`,
+      );
+      this.metrics.recordUnknownSchemaVersion(eventName, version);
+    });
+  }
+
+  private readonly parser: SorobanEventParser;
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Index all contract events in [fromLedger, toLedger].
+   *
+   * @param contractId  Soroban contract address.
+   * @param fromLedger  Inclusive start ledger.
+   * @param toLedger    Inclusive end ledger.
+   * @param force       When true, ignore the stored checkpoint and reindex the
+   *                    full range (reconciliation mode). Idempotency prevents
+   *                    duplicate records.
+   */
+  async indexLedgerRange(
+    contractId: string,
+    fromLedger: number,
+    toLedger: number,
+    force = false,
+  ): Promise<LedgerRangeResult> {
+    const effectiveFrom = force
+      ? fromLedger
+      : await this.resolveStartLedger(contractId, fromLedger);
+
+    if (effectiveFrom > toLedger) {
+      this.logger.log(
+        `Contract ${contractId}: ledger range [${effectiveFrom}, ${toLedger}] already indexed; skipping.`,
+      );
+      return { fromLedger, toLedger, processed: 0, persisted: 0, skippedUnknownSchema: 0 };
+    }
+
+    this.logger.log(
+      `Indexing contract ${contractId} ledgers [${effectiveFrom}, ${toLedger}]${force ? " (force reindex)" : ""}`,
+    );
+
+    let processed = 0;
+    let persisted = 0;
+    let skippedUnknownSchema = 0;
+    let cursor: string | undefined;
+
+    // Paginate through Horizon until we've consumed the full range.
+    while (true) {
+      const { records, nextCursor } = await this.fetchPage(contractId, effectiveFrom, toLedger, cursor);
+
+      if (records.length === 0) break;
+
+      for (const raw of records) {
+        processed++;
+        const event = this.parser.parse(raw);
+
+        if (!event) {
+          // Count schema-version skips separately from parse errors.
+          // The parser already logged the reason.
+          skippedUnknownSchema++;
+          continue;
+        }
+
+        await this.persistEvent(event);
+        persisted++;
+        this.eventEmitter.emit(`stellar.${event.eventType}`, event);
+      }
+
+      // Advance checkpoint after each page so a crash mid-range is recoverable.
+      const lastRecord = records[records.length - 1];
+      if (lastRecord) {
+        await this.checkpointRepo.saveLastLedger(contractId, lastRecord.ledger);
+      }
+
+      if (!nextCursor || records.length < PAGE_LIMIT) break;
+      cursor = nextCursor;
+    }
+
+    // Final checkpoint at toLedger once the range is fully consumed.
+    await this.checkpointRepo.saveLastLedger(contractId, toLedger);
+
+    this.logger.log(
+      `Indexed contract ${contractId} [${effectiveFrom}, ${toLedger}]: ` +
+        `processed=${processed} persisted=${persisted} skippedUnknownSchema=${skippedUnknownSchema}`,
+    );
+
+    return { fromLedger: effectiveFrom, toLedger, processed, persisted, skippedUnknownSchema };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the ledger to start from, taking the stored checkpoint into account.
+   * If a checkpoint exists and is ahead of `fromLedger`, we resume from checkpoint+1.
+   */
+  private async resolveStartLedger(contractId: string, fromLedger: number): Promise<number> {
+    const last = await this.checkpointRepo.getLastLedger(contractId);
+    if (last !== null && last >= fromLedger) {
+      return last + 1;
+    }
+    return fromLedger;
+  }
+
+  /**
+   * Fetches one page of contract events from Horizon for the given ledger range.
+   * Uses the `start_ledger` + `end_ledger` query params (Horizon v2 API).
+   */
+  private async fetchPage(
+    contractId: string,
+    fromLedger: number,
+    toLedger: number,
+    cursor?: string,
+  ): Promise<{ records: RawHorizonContractEvent[]; nextCursor: string | undefined }> {
+    const url = new URL(`${this.horizonUrl}/contract_events`);
+    url.searchParams.set("contract_id", contractId);
+    url.searchParams.set("start_ledger", String(fromLedger));
+    url.searchParams.set("end_ledger", String(toLedger));
+    url.searchParams.set("limit", String(PAGE_LIMIT));
+    url.searchParams.set("order", "asc");
+    if (cursor) url.searchParams.set("cursor", cursor);
+
+    const res = await fetch(url.toString(), {
+      headers: { Accept: "application/json" },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Horizon returned ${res.status} for ${url.toString()}`);
+    }
+
+    // Horizon HAL response: { _embedded: { records: [...] }, _links: { next: { href } } }
+    const body = (await res.json()) as {
+      _embedded?: { records?: RawHorizonContractEvent[] };
+      _links?: { next?: { href?: string } };
+    };
+
+    const records = body._embedded?.records ?? [];
+    const nextHref = body._links?.next?.href;
+    const nextCursor = nextHref
+      ? new URL(nextHref).searchParams.get("cursor") ?? undefined
+      : undefined;
+
+    return { records, nextCursor };
+  }
+
+  private async persistEvent(event: QuickExContractEvent): Promise<void> {
+    switch (event.eventType) {
+      case "EscrowDeposited":
+      case "EscrowWithdrawn":
+      case "EscrowRefunded":
+        await this.escrowRepo.upsertEvent(event as EscrowEvent);
+        break;
+      case "PrivacyToggled":
+        await this.privacyRepo.upsertEvent(event);
+        break;
+      case "ContractPaused":
+      case "AdminChanged":
+      case "ContractUpgraded":
+        await this.adminRepo.upsertEvent(event as AdminEvent);
+        break;
+      case "EphemeralKeyRegistered":
+      case "StealthWithdrawn":
+        await this.stealthRepo.upsertEvent(event as StealthEvent);
+        break;
+      default:
+        this.logger.debug(`Event ${(event as QuickExContractEvent).eventType} not persisted.`);
+    }
+  }
+}

--- a/app/backend/src/ingestion/soroban-event.parser.ts
+++ b/app/backend/src/ingestion/soroban-event.parser.ts
@@ -15,6 +15,9 @@ import type {
   StealthWithdrawnEvent,
 } from "./types/contract-event.types";
 
+/** Maximum schema version this indexer understands. */
+export const MAX_SUPPORTED_SCHEMA_VERSION = 2;
+
 /**
  * Raw Horizon contract event record shape (subset we need).
  */
@@ -30,6 +33,13 @@ export interface RawHorizonContractEvent {
   value: { xdr: string }; // base64-encoded XDR ScVal
 }
 
+/** Called when an event carries a schema_version the indexer does not support. */
+export type UnknownSchemaVersionHandler = (
+  eventName: string,
+  schemaVersion: number,
+  pagingToken: string,
+) => void;
+
 /**
  * Parses raw Horizon Soroban contract event records into typed domain events.
  *
@@ -38,13 +48,23 @@ export interface RawHorizonContractEvent {
  *  Topic[1+] = indexed fields (commitment, owner, admin, etc.)
  *
  * Data = struct with remaining fields encoded as XDR ScVal.
+ *
+ * Schema version handling (events-schema.md §Schema versioning):
+ *  - v1: no `schema_version` key in data map → decoded as version 1.
+ *  - v2: `schema_version == 2` → decoded with v2 decoder (same shape for now).
+ *  - v>2: unknown → `onUnknownSchemaVersion` is called and the event is skipped.
  */
 export class SorobanEventParser {
   private readonly logger = new Logger(SorobanEventParser.name);
 
+  constructor(
+    private readonly onUnknownSchemaVersion?: UnknownSchemaVersionHandler,
+  ) {}
+
   /**
    * Attempt to parse a raw Horizon contract event.
-   * Returns null when the event is unrecognised or malformed.
+   * Returns null when the event is unrecognised, malformed, or carries an
+   * unsupported schema version.
    */
   parse(raw: RawHorizonContractEvent): QuickExContractEvent | null {
     try {
@@ -56,11 +76,23 @@ export class SorobanEventParser {
       const eventName = this.decodeSymbol(topics[0]);
       if (!eventName) return null;
 
+      // ── Schema version gate ──────────────────────────────────────────────
+      const schemaVersion = this.extractSchemaVersion(dataVal);
+      if (schemaVersion > MAX_SUPPORTED_SCHEMA_VERSION) {
+        this.logger.warn(
+          `Skipping event ${eventName} paging_token=${raw.paging_token}: ` +
+            `schema_version=${schemaVersion} exceeds max supported (${MAX_SUPPORTED_SCHEMA_VERSION})`,
+        );
+        this.onUnknownSchemaVersion?.(eventName, schemaVersion, raw.paging_token);
+        return null;
+      }
+
       const base = {
         txHash: raw.transaction_hash,
         ledgerSequence: raw.ledger,
         pagingToken: raw.paging_token,
         contractTimestamp: this.extractTimestampFromData(dataVal),
+        schemaVersion,
       };
 
       switch (eventName as SorobanEventType) {
@@ -334,5 +366,22 @@ export class SorobanEventParser {
       // ignore
     }
     return 0n;
+  }
+
+  /**
+   * Reads `schema_version` from the data map.
+   * - Absent → v1 (legacy events without the field).
+   * - Present → the numeric value.
+   */
+  private extractSchemaVersion(data: xdr.ScVal): number {
+    try {
+      const map = this.dataToMap(data);
+      if (map["schema_version"]) {
+        return Number(scValToNative(map["schema_version"]));
+      }
+    } catch {
+      // ignore
+    }
+    return 1; // v1: no schema_version field
   }
 }

--- a/app/backend/src/ingestion/soroban-indexer.controller.ts
+++ b/app/backend/src/ingestion/soroban-indexer.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Body,
+  Controller,
+  ConflictException,
+  HttpCode,
+  HttpStatus,
+  Post,
+} from "@nestjs/common";
+import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { IsBoolean, IsInt, IsNotEmpty, IsOptional, IsString, Min } from "class-validator";
+
+import { SorobanEventIndexerService, LedgerRangeResult } from "./soroban-event-indexer.service";
+
+class ReindexDto {
+  @IsString()
+  @IsNotEmpty()
+  contractId!: string;
+
+  @IsInt()
+  @Min(1)
+  fromLedger!: number;
+
+  @IsInt()
+  @Min(1)
+  toLedger!: number;
+
+  /**
+   * When true, ignores the stored checkpoint and re-processes the full range.
+   * Idempotent upserts ensure no duplicate records are created.
+   */
+  @IsBoolean()
+  @IsOptional()
+  force?: boolean;
+}
+
+/**
+ * Admin endpoint for triggering Soroban event reindexing over a ledger range.
+ * Should be protected by an API-key guard in production.
+ */
+@ApiTags("indexer")
+@Controller("indexer")
+export class SorobanIndexerController {
+  private running = false;
+
+  constructor(private readonly indexer: SorobanEventIndexerService) {}
+
+  @Post("reindex")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Reindex Soroban contract events for a ledger range (admin only)",
+    description:
+      "Fetches and persists all contract events in [fromLedger, toLedger]. " +
+      "Safe to call multiple times — idempotent upserts prevent duplicates. " +
+      "Set force=true to ignore the stored checkpoint and reprocess the full range.",
+  })
+  @ApiResponse({ status: 200, description: "Reindex completed" })
+  @ApiResponse({ status: 409, description: "A reindex run is already in progress" })
+  async reindex(@Body() dto: ReindexDto): Promise<LedgerRangeResult> {
+    if (this.running) {
+      throw new ConflictException("A reindex run is already in progress");
+    }
+
+    this.running = true;
+    try {
+      return await this.indexer.indexLedgerRange(
+        dto.contractId,
+        dto.fromLedger,
+        dto.toLedger,
+        dto.force ?? false,
+      );
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/app/backend/src/ingestion/stealth-event.repository.ts
+++ b/app/backend/src/ingestion/stealth-event.repository.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { SupabaseService } from "../supabase/supabase.service";
+import type {
+  StealthEvent,
+  EphemeralKeyRegisteredEvent,
+} from "./types/contract-event.types";
+
+@Injectable()
+export class StealthEventRepository {
+  private readonly logger = new Logger(StealthEventRepository.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async upsertEvent(event: StealthEvent): Promise<void> {
+    const isRegistered = event.eventType === "EphemeralKeyRegistered";
+    const registered = isRegistered ? (event as EphemeralKeyRegisteredEvent) : null;
+
+    const { error } = await this.supabase.getClient()
+      .from("stealth_events")
+      .upsert(
+        {
+          event_type: event.eventType,
+          stealth_address: event.stealthAddress,
+          counterparty: isRegistered ? registered!.ephPub : (event as { recipient: string }).recipient,
+          token: event.token,
+          amount: event.amount.toString(),
+          expires_at: registered
+            ? new Date(Number(registered.expiresAt) * 1000).toISOString()
+            : null,
+          schema_version: event.schemaVersion,
+          contract_timestamp: Number(event.contractTimestamp),
+          tx_hash: event.txHash,
+          ledger_sequence: event.ledgerSequence,
+          paging_token: event.pagingToken,
+        },
+        { onConflict: "tx_hash,event_type,stealth_address", ignoreDuplicates: true },
+      );
+
+    if (error) {
+      this.logger.error(
+        `Failed to upsert ${event.eventType} stealth=${event.stealthAddress}: ${error.message}`,
+      );
+      throw error;
+    }
+  }
+}

--- a/app/backend/src/ingestion/types/contract-event.types.ts
+++ b/app/backend/src/ingestion/types/contract-event.types.ts
@@ -20,6 +20,8 @@ export interface BaseContractEvent {
   ledgerSequence: number;
   pagingToken: string;
   contractTimestamp: bigint;
+  /** Schema version read from the event payload (1 = legacy, 2+ = versioned). */
+  schemaVersion: number;
 }
 
 export interface EscrowDepositedEvent extends BaseContractEvent {
@@ -109,5 +111,10 @@ export type EscrowEvent =
   | EscrowDepositedEvent
   | EscrowWithdrawnEvent
   | EscrowRefundedEvent;
+
+export type AdminEvent =
+  | ContractPausedEvent
+  | AdminChangedEvent
+  | ContractUpgradedEvent;
 
 export type StealthEvent = EphemeralKeyRegisteredEvent | StealthWithdrawnEvent;

--- a/app/backend/src/metrics/metrics.service.ts
+++ b/app/backend/src/metrics/metrics.service.ts
@@ -15,6 +15,7 @@ export class MetricsService implements OnModuleInit {
   private errorRate: client.Counter<string>;
   private sorobanRpcFailoverTotal: client.Counter<string>;
   private sorobanRpcActiveEndpoint: client.Gauge<string>;
+  private sorobanIndexerUnknownSchemaVersion: client.Counter<string>;
   private initialized = false;
 
   onModuleInit() {
@@ -91,6 +92,12 @@ export class MetricsService implements OnModuleInit {
         labelNames: ["endpoint"],
       });
 
+      this.sorobanIndexerUnknownSchemaVersion = new client.Counter({
+        name: "soroban_indexer_unknown_schema_version_total",
+        help: "Events skipped because their schema_version exceeds the indexer maximum",
+        labelNames: ["event_name", "schema_version"],
+      });
+
       this.register.registerMetric(this.httpRequestDuration);
       this.register.registerMetric(this.httpRequestTotal);
       this.register.registerMetric(this.rateLimitedRequestsTotal);
@@ -102,6 +109,7 @@ export class MetricsService implements OnModuleInit {
       this.register.registerMetric(this.errorRate);
       this.register.registerMetric(this.sorobanRpcFailoverTotal);
       this.register.registerMetric(this.sorobanRpcActiveEndpoint);
+      this.register.registerMetric(this.sorobanIndexerUnknownSchemaVersion);
 
       this.initialized = true;
     } catch (error) {
@@ -238,6 +246,15 @@ export class MetricsService implements OnModuleInit {
       for (const url of allEndpoints) {
         this.sorobanRpcActiveEndpoint.labels(url).set(url === endpoint ? 1 : 0);
       }
+    } catch (error) {}
+  }
+
+  recordUnknownSchemaVersion(eventName: string, schemaVersion: number) {
+    if (!this.initialized || !this.sorobanIndexerUnknownSchemaVersion) return;
+    try {
+      this.sorobanIndexerUnknownSchemaVersion
+        .labels(eventName, String(schemaVersion))
+        .inc();
     } catch (error) {}
   }
 }

--- a/app/backend/supabase/migrations/20260528000000_soroban_event_indexer_v1.sql
+++ b/app/backend/supabase/migrations/20260528000000_soroban_event_indexer_v1.sql
@@ -1,0 +1,90 @@
+-- BE-28: Soroban Event Indexer v1
+-- Adds normalized tables for all contract event domains and a ledger-range
+-- checkpoint table for the batch poller.
+
+-- ─── Ledger range checkpoints ────────────────────────────────────────────────
+-- Tracks the highest fully-processed ledger for each contract so the poller
+-- can resume without re-scanning already-indexed ranges.
+
+CREATE TABLE IF NOT EXISTS indexer_checkpoints (
+  contract_id  TEXT        NOT NULL,
+  last_ledger  BIGINT      NOT NULL,
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (contract_id)
+);
+
+COMMENT ON TABLE indexer_checkpoints IS
+  'Durable ledger-range checkpoint for the Soroban event batch poller (BE-28).';
+
+-- ─── Privacy events ──────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS privacy_events (
+  id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type         TEXT        NOT NULL,   -- "PrivacyToggled"
+  owner              TEXT        NOT NULL,
+  enabled            BOOLEAN     NOT NULL,
+  schema_version     INT         NOT NULL DEFAULT 1,
+  contract_timestamp BIGINT      NOT NULL,
+  tx_hash            TEXT        NOT NULL,
+  ledger_sequence    BIGINT      NOT NULL,
+  paging_token       TEXT        NOT NULL,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT privacy_events_unique UNIQUE (tx_hash, event_type, owner)
+);
+
+CREATE INDEX IF NOT EXISTS privacy_events_owner_idx          ON privacy_events (owner);
+CREATE INDEX IF NOT EXISTS privacy_events_ledger_idx         ON privacy_events (ledger_sequence);
+
+COMMENT ON TABLE privacy_events IS 'PrivacyToggled events from the QuickEx Soroban contract.';
+
+-- ─── Admin events ────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS admin_events (
+  id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type         TEXT        NOT NULL,   -- "ContractPaused" | "AdminChanged" | "ContractUpgraded" | ...
+  payload            JSONB       NOT NULL,   -- event-specific fields
+  schema_version     INT         NOT NULL DEFAULT 1,
+  contract_timestamp BIGINT      NOT NULL,
+  tx_hash            TEXT        NOT NULL,
+  ledger_sequence    BIGINT      NOT NULL,
+  paging_token       TEXT        NOT NULL,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT admin_events_unique UNIQUE (tx_hash, event_type)
+);
+
+CREATE INDEX IF NOT EXISTS admin_events_event_type_idx ON admin_events (event_type);
+CREATE INDEX IF NOT EXISTS admin_events_ledger_idx     ON admin_events (ledger_sequence);
+
+COMMENT ON TABLE admin_events IS 'Admin action events from the QuickEx Soroban contract.';
+
+-- ─── Stealth events ──────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS stealth_events (
+  id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type         TEXT        NOT NULL,   -- "EphemeralKeyRegistered" | "StealthWithdrawn"
+  stealth_address    TEXT        NOT NULL,
+  counterparty       TEXT        NOT NULL,   -- eph_pub (registered) or recipient (withdrawn)
+  token              TEXT,
+  amount             TEXT,
+  expires_at         TIMESTAMPTZ,
+  schema_version     INT         NOT NULL DEFAULT 1,
+  contract_timestamp BIGINT      NOT NULL,
+  tx_hash            TEXT        NOT NULL,
+  ledger_sequence    BIGINT      NOT NULL,
+  paging_token       TEXT        NOT NULL,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT stealth_events_unique UNIQUE (tx_hash, event_type, stealth_address)
+);
+
+CREATE INDEX IF NOT EXISTS stealth_events_stealth_address_idx ON stealth_events (stealth_address);
+CREATE INDEX IF NOT EXISTS stealth_events_ledger_idx          ON stealth_events (ledger_sequence);
+
+COMMENT ON TABLE stealth_events IS 'Stealth address events from the QuickEx Soroban contract.';
+
+-- ─── Escrow events: add schema_version column (idempotent) ───────────────────
+
+ALTER TABLE escrow_events
+  ADD COLUMN IF NOT EXISTS schema_version INT NOT NULL DEFAULT 1;


### PR DESCRIPTION
## Summary

Implements BE-28: indexes core Soroban contract events into the database
with idempotency and schema version awareness.

## Changes

**New services**
- `SorobanEventIndexerService` — ledger-range batch poller. Fetches Horizon
  pages for [fromLedger, toLedger], persists all event domains, advances a
  durable checkpoint after each page. `force=true` skips the checkpoint for
  reconciliation/reindex runs.
- `IndexerCheckpointRepository` — upsert-based checkpoint per contract
  (`indexer_checkpoints` table).

**New repositories** (all idempotent via ON CONFLICT DO NOTHING)
- `PrivacyEventRepository` → `privacy_events`
- `AdminEventRepository` → `admin_events`
- `StealthEventRepository` → `stealth_events`

**New controller**
- `POST /indexer/reindex` — admin endpoint to trigger a ledger-range reindex.
  Returns `{ processed, persisted, skippedUnknownSchema }`.

**Parser updates**
- `SorobanEventParser`: reads `schema_version` from every event payload.
  Absent → v1 (legacy). v2 → accepted. v > MAX_SUPPORTED → skipped,
  `UnknownSchemaVersionHandler` callback fired (wired to Prometheus counter).
- `BaseContractEvent`: adds `schemaVersion` field.

**Metrics**
- `MetricsService`: new `soroban_indexer_unknown_schema_version_total` counter
  (labels: `event_name`, `schema_version`).

**Migration** `20260528000000_soroban_event_indexer_v1.sql`
- `indexer_checkpoints`, `privacy_events`, `admin_events`, `stealth_events`
  tables with unique constraints and ledger/domain indexes.
- `schema_version` column added to `escrow_events`.

## Acceptance criteria

| Criterion | How met |
|---|---|
| Re-indexing same range → no duplicates | ON CONFLICT DO NOTHING + checkpoint skip |
| Unknown schema versions rejected with metrics | Parser gate + Prometheus counter |
| Events queryable by link/escrow identifiers | Indexes on commitment, owner, stealth_address, ledger_sequence |

## Tests
- `soroban-event-indexer.schema-version.unit.spec.ts`
- `soroban-event-indexer.service.unit.spec.ts`

Closes #414