### PR TITLE
feat(BE-47): unified Soroban contract error mapping (#506)

### DIFF
--- a/app/backend/src/common/soroban-errors/index.ts
+++ b/app/backend/src/common/soroban-errors/index.ts
@@ -1,0 +1,3 @@
+export { SorobanErrorCode } from './soroban-error.codes';
+export { mapSorobanError } from './soroban-error.mapper';
+export type { MappedSorobanError } from './soroban-error.mapper';

--- a/app/backend/src/common/soroban-errors/soroban-error.codes.ts
+++ b/app/backend/src/common/soroban-errors/soroban-error.codes.ts
@@ -1,0 +1,63 @@
+/**
+ * Stable API error codes for Soroban contract failures.
+ *
+ * These codes are part of the public API contract — clients can rely on them
+ * for deterministic error handling and UX messaging.
+ *
+ * Grouped by domain: Auth, Contract State, Balance, Admin, Version, Generic.
+ */
+export enum SorobanErrorCode {
+  // ── Auth ──────────────────────────────────────────────────────────────────
+  /** Caller is not authorised to perform this operation. */
+  UNAUTHORIZED = 'CONTRACT_UNAUTHORIZED',
+  /** Required auth entry is missing from the transaction. */
+  AUTH_MISSING = 'CONTRACT_AUTH_MISSING',
+
+  // ── Contract state ────────────────────────────────────────────────────────
+  /** Contract is paused; all mutating operations are blocked. */
+  CONTRACT_PAUSED = 'CONTRACT_PAUSED',
+  /** Escrow / resource entry not found in contract storage. */
+  ESCROW_NOT_FOUND = 'CONTRACT_ESCROW_NOT_FOUND',
+  /** Escrow has already been withdrawn or refunded. */
+  ESCROW_ALREADY_SETTLED = 'CONTRACT_ESCROW_ALREADY_SETTLED',
+  /** Escrow has not yet expired; refund is not allowed. */
+  ESCROW_NOT_EXPIRED = 'CONTRACT_ESCROW_NOT_EXPIRED',
+  /** Escrow has expired; withdrawal is no longer allowed. */
+  ESCROW_EXPIRED = 'CONTRACT_ESCROW_EXPIRED',
+  /** Required contract storage entry is missing (MissingValue). */
+  STORAGE_MISSING = 'CONTRACT_STORAGE_MISSING',
+  /** Ledger entry has expired and must be restored before use. */
+  RESTORE_REQUIRED = 'CONTRACT_RESTORE_REQUIRED',
+
+  // ── Balance ───────────────────────────────────────────────────────────────
+  /** Account or escrow has insufficient token balance. */
+  INSUFFICIENT_BALANCE = 'CONTRACT_INSUFFICIENT_BALANCE',
+  /** Amount provided is zero or negative. */
+  INVALID_AMOUNT = 'CONTRACT_INVALID_AMOUNT',
+
+  // ── Version / upgrade ─────────────────────────────────────────────────────
+  /** Contract schema version is not supported by this client. */
+  VERSION_MISMATCH = 'CONTRACT_VERSION_MISMATCH',
+  /** WASM hash provided for upgrade is invalid. */
+  INVALID_WASM_HASH = 'CONTRACT_INVALID_WASM_HASH',
+
+  // ── Admin ─────────────────────────────────────────────────────────────────
+  /** Caller is not the contract admin. */
+  NOT_ADMIN = 'CONTRACT_NOT_ADMIN',
+  /** Admin address provided is invalid. */
+  INVALID_ADMIN = 'CONTRACT_INVALID_ADMIN',
+
+  // ── Input / params ────────────────────────────────────────────────────────
+  /** One or more input values are invalid for this contract call. */
+  INVALID_INPUT = 'CONTRACT_INVALID_INPUT',
+  /** Contract or account does not exist on the network. */
+  NOT_FOUND = 'CONTRACT_NOT_FOUND',
+
+  // ── Resource limits ───────────────────────────────────────────────────────
+  /** Transaction exceeds Soroban compute budget. */
+  BUDGET_EXCEEDED = 'CONTRACT_BUDGET_EXCEEDED',
+
+  // ── Generic fallback ──────────────────────────────────────────────────────
+  /** An unexpected contract error occurred. */
+  UNKNOWN = 'CONTRACT_UNKNOWN_ERROR',
+}

--- a/app/backend/src/common/soroban-errors/soroban-error.mapper.ts
+++ b/app/backend/src/common/soroban-errors/soroban-error.mapper.ts
@@ -1,0 +1,197 @@
+import { SorobanErrorCode } from './soroban-error.codes';
+
+export interface MappedSorobanError {
+  /** Stable API error code clients can switch on. */
+  code: SorobanErrorCode;
+  /** Human-readable message safe to surface in UI. */
+  message: string;
+  /** Raw Soroban error string — included in non-production responses only. */
+  technicalError: string;
+  /** Optional structured details (error type / code from HostError). */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Each entry maps a regex pattern against the raw Soroban error string to a
+ * stable API error code and a user-friendly message.
+ *
+ * Patterns are tested in order; the first match wins.
+ */
+const ERROR_MAPPINGS: Array<{
+  pattern: RegExp;
+  code: SorobanErrorCode;
+  message: string;
+}> = [
+  // ── Auth ──────────────────────────────────────────────────────────────────
+  {
+    pattern: /HostError.*Error.*Auth.*NotAuthorized/i,
+    code: SorobanErrorCode.UNAUTHORIZED,
+    message: 'You are not authorised to perform this operation.',
+  },
+  {
+    pattern: /HostError.*Error.*Auth.*InvalidAction/i,
+    code: SorobanErrorCode.AUTH_MISSING,
+    message: 'A required authorisation entry is missing from the transaction.',
+  },
+  {
+    pattern: /not\s+authorized/i,
+    code: SorobanErrorCode.UNAUTHORIZED,
+    message: 'You are not authorised to perform this operation.',
+  },
+
+  // ── Contract paused ───────────────────────────────────────────────────────
+  {
+    pattern: /contract.*paused/i,
+    code: SorobanErrorCode.CONTRACT_PAUSED,
+    message: 'The contract is currently paused. Please try again later.',
+  },
+  {
+    pattern: /paused/i,
+    code: SorobanErrorCode.CONTRACT_PAUSED,
+    message: 'The contract is currently paused. Please try again later.',
+  },
+
+  // ── Escrow state ──────────────────────────────────────────────────────────
+  {
+    pattern: /escrow.*not.*found|escrow.*missing/i,
+    code: SorobanErrorCode.ESCROW_NOT_FOUND,
+    message: 'The escrow entry was not found. It may have already been settled or never created.',
+  },
+  {
+    pattern: /escrow.*already.*settled|already.*withdrawn|already.*refunded/i,
+    code: SorobanErrorCode.ESCROW_ALREADY_SETTLED,
+    message: 'This escrow has already been settled and cannot be modified.',
+  },
+  {
+    pattern: /escrow.*not.*expired|not.*yet.*expired/i,
+    code: SorobanErrorCode.ESCROW_NOT_EXPIRED,
+    message: 'The escrow has not yet expired. Refunds are only available after expiry.',
+  },
+  {
+    pattern: /escrow.*expired|payment.*expired/i,
+    code: SorobanErrorCode.ESCROW_EXPIRED,
+    message: 'The escrow has expired and can no longer be withdrawn.',
+  },
+
+  // ── Storage ───────────────────────────────────────────────────────────────
+  {
+    pattern: /HostError.*Error.*Storage.*MissingValue/i,
+    code: SorobanErrorCode.STORAGE_MISSING,
+    message: 'A required contract state entry does not exist. The resource may not have been initialised.',
+  },
+  {
+    pattern: /restore.*required|entry.*expired.*restore/i,
+    code: SorobanErrorCode.RESTORE_REQUIRED,
+    message: 'Some contract state entries have expired and must be restored before this transaction can proceed.',
+  },
+
+  // ── Balance ───────────────────────────────────────────────────────────────
+  {
+    pattern: /insufficient.*balance|balance.*insufficient/i,
+    code: SorobanErrorCode.INSUFFICIENT_BALANCE,
+    message: 'Insufficient balance to complete this operation.',
+  },
+  {
+    pattern: /invalid.*amount|amount.*invalid|amount.*zero|zero.*amount/i,
+    code: SorobanErrorCode.INVALID_AMOUNT,
+    message: 'The amount provided is invalid. It must be a positive non-zero value.',
+  },
+
+  // ── Version mismatch ──────────────────────────────────────────────────────
+  {
+    pattern: /version.*mismatch|schema.*version|unsupported.*version/i,
+    code: SorobanErrorCode.VERSION_MISMATCH,
+    message: 'The contract version is not compatible with this operation.',
+  },
+  {
+    pattern: /invalid.*wasm|wasm.*invalid/i,
+    code: SorobanErrorCode.INVALID_WASM_HASH,
+    message: 'The WASM hash provided for the contract upgrade is invalid.',
+  },
+
+  // ── Admin ─────────────────────────────────────────────────────────────────
+  {
+    pattern: /not.*admin|caller.*not.*admin/i,
+    code: SorobanErrorCode.NOT_ADMIN,
+    message: 'Only the contract admin can perform this operation.',
+  },
+  {
+    pattern: /invalid.*admin|admin.*invalid/i,
+    code: SorobanErrorCode.INVALID_ADMIN,
+    message: 'The admin address provided is invalid.',
+  },
+
+  // ── Input / params ────────────────────────────────────────────────────────
+  {
+    pattern: /HostError.*Error.*Value.*InvalidInput/i,
+    code: SorobanErrorCode.INVALID_INPUT,
+    message: 'One or more input values are invalid for this contract operation.',
+  },
+  {
+    pattern: /HostError.*Error.*WasmVm.*InvalidAction/i,
+    code: SorobanErrorCode.INVALID_INPUT,
+    message: 'The smart contract encountered an invalid operation. Check the transaction parameters.',
+  },
+  {
+    pattern: /account.*does not exist|account.*not.*found/i,
+    code: SorobanErrorCode.NOT_FOUND,
+    message: 'The source account does not exist on the network. Ensure it is funded and activated.',
+  },
+  {
+    pattern: /contract.*does not exist|contract.*not.*found/i,
+    code: SorobanErrorCode.NOT_FOUND,
+    message: 'The specified contract does not exist on this network. Check the contract ID.',
+  },
+
+  // ── Resource limits ───────────────────────────────────────────────────────
+  {
+    pattern: /HostError.*Error.*Budget.*ExceededLimit/i,
+    code: SorobanErrorCode.BUDGET_EXCEEDED,
+    message: 'The transaction exceeds Soroban compute limits. Try simplifying the operation.',
+  },
+  {
+    pattern: /transaction.*too large/i,
+    code: SorobanErrorCode.BUDGET_EXCEEDED,
+    message: 'The transaction is too large. Consider reducing the complexity of the operation.',
+  },
+];
+
+/**
+ * Maps a raw Soroban / simulation error string to a stable {@link MappedSorobanError}.
+ *
+ * Strategy:
+ * 1. Test each pattern in order; return the first match.
+ * 2. If no pattern matches but a HostError code is present, extract the type
+ *    and code for structured details and return UNKNOWN.
+ * 3. Fall back to a generic UNKNOWN response so clients always get a stable code.
+ *
+ * The `technicalError` field always carries the raw string for server-side
+ * logging; it should be omitted from production API responses.
+ */
+export function mapSorobanError(rawError: string): MappedSorobanError {
+  for (const { pattern, code, message } of ERROR_MAPPINGS) {
+    if (pattern.test(rawError)) {
+      return { code, message, technicalError: rawError };
+    }
+  }
+
+  // Parse structured HostError codes even when no pattern matched.
+  const hostErrorMatch = rawError.match(/Error\((\w+),\s*(\w+)\)/);
+  if (hostErrorMatch) {
+    return {
+      code: SorobanErrorCode.UNKNOWN,
+      message: 'An unexpected contract error occurred. Please verify the transaction parameters and try again.',
+      technicalError: rawError,
+      details: {
+        errorType: hostErrorMatch[1],
+        errorCode: hostErrorMatch[2],
+      },
+    };
+  }
+
+  return {
+    code: SorobanErrorCode.UNKNOWN,
+    message: 'An unexpected contract error occurred. Please try again or contact support.',
+    technicalError: rawError,
+  };
+}

--- a/app/backend/src/common/soroban-errors/soroban-error.mapper.unit.spec.ts
+++ b/app/backend/src/common/soroban-errors/soroban-error.mapper.unit.spec.ts
@@ -1,0 +1,185 @@
+import { mapSorobanError } from './soroban-error.mapper';
+import { SorobanErrorCode } from './soroban-error.codes';
+
+describe('mapSorobanError', () => {
+  // ── Auth ────────────────────────────────────────────────────────────────
+
+  it('maps Auth.NotAuthorized HostError to UNAUTHORIZED', () => {
+    const raw = 'HostError: Error(Auth, NotAuthorized)';
+    const result = mapSorobanError(raw);
+    expect(result.code).toBe(SorobanErrorCode.UNAUTHORIZED);
+    expect(result.technicalError).toBe(raw);
+    expect(result.message).toBeTruthy();
+  });
+
+  it('maps "not authorized" plain text to UNAUTHORIZED', () => {
+    const result = mapSorobanError('caller is not authorized to withdraw');
+    expect(result.code).toBe(SorobanErrorCode.UNAUTHORIZED);
+  });
+
+  it('maps Auth.InvalidAction HostError to AUTH_MISSING', () => {
+    const result = mapSorobanError('HostError: Error(Auth, InvalidAction)');
+    expect(result.code).toBe(SorobanErrorCode.AUTH_MISSING);
+  });
+
+  // ── Contract paused ─────────────────────────────────────────────────────
+
+  it('maps "contract paused" to CONTRACT_PAUSED', () => {
+    const result = mapSorobanError('Error: contract is paused');
+    expect(result.code).toBe(SorobanErrorCode.CONTRACT_PAUSED);
+  });
+
+  it('maps bare "paused" to CONTRACT_PAUSED', () => {
+    const result = mapSorobanError('operation rejected: paused');
+    expect(result.code).toBe(SorobanErrorCode.CONTRACT_PAUSED);
+  });
+
+  // ── Escrow state ────────────────────────────────────────────────────────
+
+  it('maps "escrow not found" to ESCROW_NOT_FOUND', () => {
+    const result = mapSorobanError('escrow not found for commitment 0xabc');
+    expect(result.code).toBe(SorobanErrorCode.ESCROW_NOT_FOUND);
+  });
+
+  it('maps "already withdrawn" to ESCROW_ALREADY_SETTLED', () => {
+    const result = mapSorobanError('escrow already withdrawn');
+    expect(result.code).toBe(SorobanErrorCode.ESCROW_ALREADY_SETTLED);
+  });
+
+  it('maps "already refunded" to ESCROW_ALREADY_SETTLED', () => {
+    const result = mapSorobanError('escrow already refunded');
+    expect(result.code).toBe(SorobanErrorCode.ESCROW_ALREADY_SETTLED);
+  });
+
+  it('maps "escrow not expired" to ESCROW_NOT_EXPIRED', () => {
+    const result = mapSorobanError('escrow not yet expired');
+    expect(result.code).toBe(SorobanErrorCode.ESCROW_NOT_EXPIRED);
+  });
+
+  it('maps "escrow expired" to ESCROW_EXPIRED', () => {
+    const result = mapSorobanError('escrow expired, withdrawal not allowed');
+    expect(result.code).toBe(SorobanErrorCode.ESCROW_EXPIRED);
+  });
+
+  // ── Storage ─────────────────────────────────────────────────────────────
+
+  it('maps Storage.MissingValue HostError to STORAGE_MISSING', () => {
+    const result = mapSorobanError('HostError: Error(Storage, MissingValue)');
+    expect(result.code).toBe(SorobanErrorCode.STORAGE_MISSING);
+  });
+
+  it('maps "restore required" to RESTORE_REQUIRED', () => {
+    const result = mapSorobanError('restore required before proceeding');
+    expect(result.code).toBe(SorobanErrorCode.RESTORE_REQUIRED);
+  });
+
+  // ── Balance ─────────────────────────────────────────────────────────────
+
+  it('maps "insufficient balance" to INSUFFICIENT_BALANCE', () => {
+    const result = mapSorobanError('insufficient balance for transfer');
+    expect(result.code).toBe(SorobanErrorCode.INSUFFICIENT_BALANCE);
+  });
+
+  it('maps "balance insufficient" to INSUFFICIENT_BALANCE', () => {
+    const result = mapSorobanError('balance insufficient');
+    expect(result.code).toBe(SorobanErrorCode.INSUFFICIENT_BALANCE);
+  });
+
+  it('maps "invalid amount" to INVALID_AMOUNT', () => {
+    const result = mapSorobanError('invalid amount: must be positive');
+    expect(result.code).toBe(SorobanErrorCode.INVALID_AMOUNT);
+  });
+
+  it('maps "zero amount" to INVALID_AMOUNT', () => {
+    const result = mapSorobanError('zero amount not allowed');
+    expect(result.code).toBe(SorobanErrorCode.INVALID_AMOUNT);
+  });
+
+  // ── Version mismatch ────────────────────────────────────────────────────
+
+  it('maps "version mismatch" to VERSION_MISMATCH', () => {
+    const result = mapSorobanError('schema version mismatch: expected 2, got 3');
+    expect(result.code).toBe(SorobanErrorCode.VERSION_MISMATCH);
+  });
+
+  it('maps "unsupported version" to VERSION_MISMATCH', () => {
+    const result = mapSorobanError('unsupported version 5');
+    expect(result.code).toBe(SorobanErrorCode.VERSION_MISMATCH);
+  });
+
+  it('maps "invalid wasm" to INVALID_WASM_HASH', () => {
+    const result = mapSorobanError('invalid wasm hash provided');
+    expect(result.code).toBe(SorobanErrorCode.INVALID_WASM_HASH);
+  });
+
+  // ── Admin ───────────────────────────────────────────────────────────────
+
+  it('maps "not admin" to NOT_ADMIN', () => {
+    const result = mapSorobanError('caller is not admin');
+    expect(result.code).toBe(SorobanErrorCode.NOT_ADMIN);
+  });
+
+  it('maps "invalid admin" to INVALID_ADMIN', () => {
+    const result = mapSorobanError('invalid admin address');
+    expect(result.code).toBe(SorobanErrorCode.INVALID_ADMIN);
+  });
+
+  // ── Input / params ──────────────────────────────────────────────────────
+
+  it('maps Value.InvalidInput HostError to INVALID_INPUT', () => {
+    const result = mapSorobanError('HostError: Error(Value, InvalidInput)');
+    expect(result.code).toBe(SorobanErrorCode.INVALID_INPUT);
+  });
+
+  it('maps WasmVm.InvalidAction HostError to INVALID_INPUT', () => {
+    const result = mapSorobanError('HostError: Error(WasmVm, InvalidAction)');
+    expect(result.code).toBe(SorobanErrorCode.INVALID_INPUT);
+  });
+
+  it('maps "account does not exist" to NOT_FOUND', () => {
+    const result = mapSorobanError('account does not exist on the network');
+    expect(result.code).toBe(SorobanErrorCode.NOT_FOUND);
+  });
+
+  it('maps "contract does not exist" to NOT_FOUND', () => {
+    const result = mapSorobanError('contract does not exist');
+    expect(result.code).toBe(SorobanErrorCode.NOT_FOUND);
+  });
+
+  // ── Resource limits ─────────────────────────────────────────────────────
+
+  it('maps Budget.ExceededLimit HostError to BUDGET_EXCEEDED', () => {
+    const result = mapSorobanError('HostError: Error(Budget, ExceededLimit)');
+    expect(result.code).toBe(SorobanErrorCode.BUDGET_EXCEEDED);
+  });
+
+  it('maps "transaction too large" to BUDGET_EXCEEDED', () => {
+    const result = mapSorobanError('transaction too large');
+    expect(result.code).toBe(SorobanErrorCode.BUDGET_EXCEEDED);
+  });
+
+  // ── Unknown / generic ───────────────────────────────────────────────────
+
+  it('returns UNKNOWN for unrecognised errors', () => {
+    const result = mapSorobanError('some completely unknown contract error xyz');
+    expect(result.code).toBe(SorobanErrorCode.UNKNOWN);
+    expect(result.message).toBeTruthy();
+  });
+
+  it('extracts HostError type and code for unknown structured errors', () => {
+    const result = mapSorobanError('HostError: Error(Foo, BarBaz)');
+    expect(result.code).toBe(SorobanErrorCode.UNKNOWN);
+    expect(result.details).toEqual({ errorType: 'Foo', errorCode: 'BarBaz' });
+  });
+
+  it('always includes technicalError in the result', () => {
+    const raw = 'some raw error string';
+    const result = mapSorobanError(raw);
+    expect(result.technicalError).toBe(raw);
+  });
+
+  it('always returns a non-empty message', () => {
+    const result = mapSorobanError('');
+    expect(result.message.length).toBeGreaterThan(0);
+  });
+});

--- a/app/backend/src/transactions/transaction.service.ts
+++ b/app/backend/src/transactions/transaction.service.ts
@@ -15,7 +15,8 @@ import {
 } from "./dto/compose-transaction-response.dto";
 import { buildScVal } from "./utils/param-builder";
 import { SorobanRpcService } from "./soroban-rpc.service";
-import { mapSimulationError } from "./simulation-error.mapper";
+import { mapSorobanError } from "../common/soroban-errors";
+import { SorobanErrorCode } from "../common/soroban-errors";
 
 const STROOPS_PER_XLM = 10_000_000;
 const BASE_FEE = 100; // stroops
@@ -88,12 +89,12 @@ export class TransactionsService {
 
     // 7. Handle simulation failure
     if (SorobanRpc.Api.isSimulationError(simulationResult)) {
-      const mapped = mapSimulationError(simulationResult.error);
-      this.logger.warn(`Simulation failed: ${simulationResult.error}`);
+      const mapped = mapSorobanError(simulationResult.error);
+      this.logger.warn(`Simulation failed [${mapped.code}]: ${simulationResult.error}`);
       return {
         success: false,
-        error: mapped.technicalError,
-        userMessage: mapped.userMessage,
+        error: mapped.code,
+        userMessage: mapped.message,
         details: mapped.details,
       };
     }
@@ -102,7 +103,7 @@ export class TransactionsService {
     if (SorobanRpc.Api.isSimulationRestore(simulationResult)) {
       return {
         success: false,
-        error: "RESTORE_REQUIRED",
+        error: SorobanErrorCode.RESTORE_REQUIRED,
         userMessage:
           "Some contract state entries have expired and must be restored before this transaction can proceed. Please run a restore operation first.",
         details: {


### PR DESCRIPTION
Map Soroban contract failures to stable API error codes so frontend/mobile can show clear, consistent error UX.

- Add SorobanErrorCode enum covering auth, pause, escrow state, balance, version mismatch, admin, input validation, budget, and unknown errors
- Implement mapSorobanError() replacing the old mapSimulationError() with stable codes clients can switch on
- Wire transaction.service to use the new mapper; RESTORE_REQUIRED now uses SorobanErrorCode enum value
- Add 30 unit tests covering all top-level contract error scenarios plus unknown/unexpected failures
- request_id is always present via GlobalHttpExceptionFilter (unchanged)

Closes #506