### PR TITLE
Add Soroban deployment tooling, registry bootstrap, and unsigned XDR builder

### DIFF
--- a/app/backend/package-lock.json
+++ b/app/backend/package-lock.json
@@ -46,6 +46,7 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8.0.0",
+        "fast-check": "^4.8.0",
         "jest": "^29.7.0",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.0",
@@ -5988,6 +5989,44 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -3,18 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "description": "QuickEx NestJS backend API",
-  "scripts": {
-    "dev": "nest start --watch",
-    "start:dev": "nest start --watch",
-    "build": "nest build",
-    "start": "node dist/main",
-    "lint": "eslint \"{src,test}/**/*.ts\"",
-    "type-check": "tsc --noEmit",
-    "test": "jest",
-    "test:unit": "jest --config jest.unit.config.ts",
-    "test:int": "jest --config jest.int.config.ts",
-    "test:e2e": "jest --config jest.e2e.config.ts"
-  },
   "dependencies": {
     "@nestjs/common": "^10.4.22",
     "@nestjs/config": "^3.3.0",
@@ -77,8 +65,8 @@
     "test:unit": "jest --config jest.unit.config.ts",
     "test:int": "jest --config jest.int.config.ts",
     "test:e2e": "jest --config jest.e2e.config.ts",
+    "soroban:deploy": "ts-node scripts/soroban-deploy.ts",
     "test:fuzz": "jest --config jest.fuzz.config.ts",
     "test:fuzz:ci": "jest --config jest.fuzz.config.ts --runInBand"
   }
 }
-

--- a/app/backend/scripts/soroban-deploy.ts
+++ b/app/backend/scripts/soroban-deploy.ts
@@ -1,0 +1,133 @@
+import { createHash } from 'crypto';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import * as path from 'path';
+
+interface Args {
+  network: 'testnet' | 'mainnet';
+  source: string;
+  admin?: string;
+  wasm: string;
+  contractName: string;
+  dryRun: boolean;
+  registryUrl?: string;
+  apiKey?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const map = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith('--')) {
+      map.set(key, 'true');
+    } else {
+      map.set(key, next);
+      index += 1;
+    }
+  }
+
+  const network = (map.get('network') ?? 'testnet') as 'testnet' | 'mainnet';
+  const source = map.get('source');
+  const wasm = map.get('wasm') ?? 'app/contract/target/wasm32-unknown-unknown/release/quickex.wasm';
+  const contractName = map.get('contract-name') ?? 'quickex';
+  if (!source) {
+    throw new Error('--source is required');
+  }
+
+  return {
+    network,
+    source,
+    admin: map.get('admin'),
+    wasm,
+    contractName,
+    dryRun: map.get('dry-run') === 'true',
+    registryUrl: map.get('registry-url'),
+    apiKey: map.get('api-key'),
+  };
+}
+
+function run(command: string, args: string[], dryRun: boolean): string {
+  if (dryRun) return [command, ...args].join(' ');
+  return execFileSync(command, args, { encoding: 'utf8' }).trim();
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const wasmPath = path.resolve(args.wasm);
+  if (!existsSync(wasmPath)) {
+    throw new Error(`WASM file not found at ${wasmPath}`);
+  }
+
+  const networkPassphrase =
+    args.network === 'mainnet'
+      ? 'Public Global Stellar Network ; September 2015'
+      : 'Test SDF Network ; September 2015';
+  const wasmHash = createHash('sha256').update(readFileSync(wasmPath)).digest('hex');
+  const installCommand = ['contract', 'install', '--network', args.network, '--source', args.source, '--wasm', wasmPath];
+  const deployCommand = ['contract', 'deploy', '--network', args.network, '--source', args.source, '--wasm-hash', wasmHash];
+
+  const installResult = run('soroban', installCommand, args.dryRun);
+  const contractId = run('soroban', deployCommand, args.dryRun) || '<contract-id>';
+
+  let initResult: string | null = null;
+  if (args.admin) {
+    initResult = run(
+      'soroban',
+      ['contract', 'invoke', '--network', args.network, '--source', args.source, '--id', contractId, '--', 'initialize', args.admin],
+      args.dryRun,
+    );
+  }
+
+  const artifact = {
+    deployedAt: new Date().toISOString(),
+    network: args.network,
+    networkPassphrase,
+    contractName: args.contractName,
+    contractId,
+    wasmHash,
+    installResult,
+    initResult,
+  };
+
+  const outputDir = path.resolve('app/backend/deployments');
+  mkdirSync(outputDir, { recursive: true });
+  const artifactPath = path.join(outputDir, `${args.network}-${args.contractName}.json`);
+  writeFileSync(artifactPath, JSON.stringify(artifact, null, 2));
+
+  if (args.registryUrl) {
+    const response = await fetch(`${args.registryUrl.replace(/\/$/, '')}/contracts/registry/publish`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(args.apiKey ? { 'X-API-Key': args.apiKey } : {}),
+      },
+      body: JSON.stringify({
+        networkPassphrase,
+        deploymentId: `${args.network}-${args.contractName}-${Date.now()}`,
+        contracts: [
+          {
+            name: args.contractName,
+            contractId,
+            wasmHash,
+            contractVersion: 1,
+            metadata: {
+              artifactPath,
+              dryRun: args.dryRun,
+            },
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Registry publish failed with status ${response.status}`);
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify({ artifactPath, artifact }, null, 2)}\n`);
+}
+
+void main();

--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -42,6 +42,8 @@ import { AuditModule } from "./audit/audit.module";
 import { FeatureFlagsModule } from "./feature-flags/feature-flags.module";
 import { DeveloperModule } from "./developer/developer.module";
 import { PrivacyModule } from "./privacy/privacy.module";
+import { ContractsModule } from "./contracts/contracts.module";
+import { SorobanToolingModule } from "./soroban-tooling/soroban-tooling.module";
 import { CustomThrottlerGuard } from "./auth/guards/custom-throttler.guard";
 import { OrganizationRoleGuard } from "./auth/guards/organization-role.guard";
 import { throttlerModuleProfiles } from "./config/rate-limit.config";
@@ -84,8 +86,10 @@ type AppImport =
       ExportsModule,
       JobQueueModule,
       AuditModule,
+      ContractsModule,
       FeatureFlagsModule,
       PrivacyModule,
+      SorobanToolingModule,
       EnvironmentParityModule,
     ];
 

--- a/app/backend/src/contracts/contract-registry.controller.ts
+++ b/app/backend/src/contracts/contract-registry.controller.ts
@@ -1,0 +1,52 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { ApiKeyGuard } from '../auth/guards/api-key.guard';
+import { RequireScopes } from '../auth/decorators/require-scopes.decorator';
+import { ContractRegistryService } from './contract-registry.service';
+import {
+  ContractRegistryResponseDto,
+  PublishContractRegistryDto,
+  RollbackContractRegistryDto,
+} from './dto/contract-registry.dto';
+
+@ApiTags('contracts')
+@ApiHeader({
+  name: 'X-API-Key',
+  description: 'Optional API key. Publishing requires an admin-scoped key.',
+  required: false,
+})
+@UseGuards(ApiKeyGuard)
+@Controller('contracts')
+export class ContractRegistryController {
+  constructor(private readonly contractRegistryService: ContractRegistryService) {}
+
+  @Get('registry')
+  @ApiOperation({
+    summary: 'Fetch the authoritative contract registry for the active network',
+  })
+  @ApiResponse({ status: 200, type: ContractRegistryResponseDto })
+  getRegistry() {
+    return this.contractRegistryService.getRegistry();
+  }
+
+  @Post('registry/publish')
+  @HttpCode(HttpStatus.OK)
+  @RequireScopes('admin')
+  @ApiOperation({
+    summary: 'Publish deployment artifacts into the contract registry',
+  })
+  publish(@Body() body: PublishContractRegistryDto) {
+    return this.contractRegistryService.publish(body, 'api');
+  }
+
+  @Post('registry/rollback')
+  @HttpCode(HttpStatus.OK)
+  @RequireScopes('admin')
+  @ApiOperation({
+    summary: 'Rollback the active registry entry for a contract to a previous version',
+  })
+  rollback(@Body() body: RollbackContractRegistryDto) {
+    return this.contractRegistryService.rollback(body, 'api');
+  }
+}

--- a/app/backend/src/contracts/contract-registry.service.ts
+++ b/app/backend/src/contracts/contract-registry.service.ts
@@ -1,0 +1,315 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { AuditService } from '../audit/audit.service';
+import { AppConfigService } from '../config';
+import { SupabaseService } from '../supabase/supabase.service';
+import {
+  ContractRegistryEntryDto,
+  PublishContractRegistryDto,
+  RollbackContractRegistryDto,
+} from './dto/contract-registry.dto';
+
+interface RegistryRecord {
+  name: string;
+  network: string;
+  contractId: string;
+  wasmHash: string;
+  contractVersion: number;
+  deploymentId?: string;
+  metadata?: Record<string, unknown>;
+  publishedBy: string;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  networkPassphrase: string;
+  active: boolean;
+}
+
+@Injectable()
+export class ContractRegistryService {
+  private readonly logger = new Logger(ContractRegistryService.name);
+  private readonly fallbackStore = new Map<string, RegistryRecord[]>();
+  private readonly expectedContracts: string[];
+  private fallbackVersion = 0;
+
+  constructor(
+    private readonly supabaseService: SupabaseService,
+    private readonly auditService: AuditService,
+    private readonly configService: AppConfigService,
+  ) {
+    this.expectedContracts = (process.env.CONTRACT_REGISTRY_EXPECTED_SET ?? 'quickex')
+      .split(',')
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+  }
+
+  async getRegistry() {
+    const records = await this.readRecords();
+    const active = records.filter((record) => record.active);
+    const data = Object.fromEntries(
+      active.map((record) => [
+        record.name,
+        {
+          id: record.contractId,
+          wasmHash: record.wasmHash,
+          version: record.contractVersion,
+          deploymentId: record.deploymentId,
+          updatedAt: record.updatedAt,
+          metadata: record.metadata ?? {},
+        },
+      ]),
+    );
+
+    const version = active.reduce(
+      (max, record) => Math.max(max, record.version),
+      this.fallbackVersion,
+    );
+
+    return {
+      network: this.configService.network,
+      authoritative: true,
+      version,
+      etag: this.buildEtag(version),
+      data,
+    };
+  }
+
+  async publish(
+    dto: PublishContractRegistryDto,
+    actor = 'deployment_automation',
+  ) {
+    this.validatePassphrase(dto.networkPassphrase);
+    this.validateContractSet(dto.contracts);
+
+    const current = await this.readRecords();
+    let nextVersion = current.reduce(
+      (max, record) => Math.max(max, record.version),
+      this.fallbackVersion,
+    );
+
+    const now = new Date().toISOString();
+    const names = new Set(dto.contracts.map((contract) => contract.name.toLowerCase()));
+    const retained = current.map((record) =>
+      names.has(record.name) ? { ...record, active: false, updatedAt: now } : record,
+    );
+
+    const published: RegistryRecord[] = dto.contracts.map((contract) => {
+      nextVersion += 1;
+      return this.toRecord(contract, dto, actor, nextVersion, now);
+    });
+
+    const merged = [...retained, ...published];
+    this.fallbackVersion = nextVersion;
+    this.writeFallback(merged);
+    await this.persistSnapshot(merged);
+    await this.auditService.log(
+      'contract_registry',
+      'registry.publish',
+      dto.deploymentId,
+      {
+        actor,
+        version: nextVersion,
+        contracts: published.map((record) => ({
+          name: record.name,
+          contractId: record.contractId,
+          wasmHash: record.wasmHash,
+          contractVersion: record.contractVersion,
+        })),
+      },
+    );
+
+    this.logger.log(
+      `Published ${published.length} contract registry entr${published.length === 1 ? 'y' : 'ies'} at version ${nextVersion}`,
+    );
+
+    return this.getRegistry();
+  }
+
+  async rollback(
+    dto: RollbackContractRegistryDto,
+    actor = 'deployment_automation',
+  ) {
+    const records = await this.readRecords();
+    const targetName = dto.name.toLowerCase();
+    const candidate = records.find(
+      (record) => record.name === targetName && record.contractVersion === dto.version,
+    );
+
+    if (!candidate) {
+      throw new NotFoundException(
+        `No registry entry found for ${dto.name} at version ${dto.version}`,
+      );
+    }
+
+    const now = new Date().toISOString();
+    const nextVersion = records.reduce(
+      (max, record) => Math.max(max, record.version),
+      this.fallbackVersion,
+    ) + 1;
+
+    const updated = records.map((record) => {
+      if (record.name !== targetName) return record;
+      return {
+        ...record,
+        active: record.contractVersion === dto.version,
+        updatedAt: now,
+        version: record.contractVersion === dto.version ? nextVersion : record.version,
+      };
+    });
+
+    this.fallbackVersion = Math.max(this.fallbackVersion, nextVersion);
+    this.writeFallback(updated);
+    await this.persistSnapshot(updated);
+    await this.auditService.log(
+      'contract_registry',
+      'registry.rollback',
+      dto.name,
+      { actor, requestedVersion: dto.version, registryVersion: nextVersion },
+    );
+
+    return this.getRegistry();
+  }
+
+  private validatePassphrase(passphrase: string): void {
+    const expected =
+      this.configService.network === 'mainnet'
+        ? 'Public Global Stellar Network ; September 2015'
+        : 'Test SDF Network ; September 2015';
+
+    if (passphrase !== expected) {
+      throw new BadRequestException(
+        `networkPassphrase does not match the active ${this.configService.network} network`,
+      );
+    }
+  }
+
+  private validateContractSet(contracts: ContractRegistryEntryDto[]): void {
+    const normalized = contracts.map((contract) => contract.name.toLowerCase()).sort();
+    const expected = [...this.expectedContracts].sort();
+
+    if (normalized.length !== expected.length) {
+      throw new BadRequestException(
+        `Expected ${expected.length} contract entries (${expected.join(', ')}) but received ${normalized.length}`,
+      );
+    }
+
+    for (let index = 0; index < expected.length; index += 1) {
+      if (normalized[index] !== expected[index]) {
+        throw new BadRequestException(
+          `Unexpected contract set. Expected ${expected.join(', ')}`,
+        );
+      }
+    }
+  }
+
+  private toRecord(
+    contract: ContractRegistryEntryDto,
+    dto: PublishContractRegistryDto,
+    actor: string,
+    version: number,
+    timestamp: string,
+  ): RegistryRecord {
+    return {
+      name: contract.name.toLowerCase(),
+      network: this.configService.network,
+      contractId: contract.contractId,
+      wasmHash: contract.wasmHash,
+      contractVersion: contract.contractVersion ?? 1,
+      deploymentId: dto.deploymentId,
+      metadata: contract.metadata,
+      publishedBy: actor,
+      version,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      networkPassphrase: dto.networkPassphrase,
+      active: true,
+    };
+  }
+
+  private buildEtag(version: number): string {
+    return `W/\"contract-registry-${this.configService.network}-${version}\"`;
+  }
+
+  private fallbackKey(): string {
+    return `contract-registry:${this.configService.network}`;
+  }
+
+  private writeFallback(records: RegistryRecord[]): void {
+    this.fallbackStore.set(this.fallbackKey(), records);
+  }
+
+  private async readRecords(): Promise<RegistryRecord[]> {
+    const fallback = this.fallbackStore.get(this.fallbackKey()) ?? [];
+
+    try {
+      const client = this.supabaseService.getClient();
+      const { data, error } = await client
+        .from('contract_registry_entries')
+        .select('*')
+        .eq('network', this.configService.network)
+        .order('version', { ascending: true });
+
+      if (error) throw error;
+      if (!data || data.length === 0) return fallback;
+
+      return data.map((row) => ({
+        name: String(row.contract_name),
+        network: String(row.network),
+        contractId: String(row.contract_id),
+        wasmHash: String(row.wasm_hash),
+        contractVersion: Number(row.contract_version),
+        deploymentId: row.deployment_id ? String(row.deployment_id) : undefined,
+        metadata:
+          row.metadata && typeof row.metadata === 'object'
+            ? (row.metadata as Record<string, unknown>)
+            : undefined,
+        publishedBy: String(row.published_by ?? 'unknown'),
+        version: Number(row.version),
+        createdAt: String(row.created_at),
+        updatedAt: String(row.updated_at),
+        networkPassphrase: String(row.network_passphrase),
+        active: Boolean(row.is_active),
+      }));
+    } catch (error) {
+      this.logger.warn(
+        `Falling back to in-memory contract registry: ${(error as Error).message}`,
+      );
+      return fallback;
+    }
+  }
+
+  private async persistSnapshot(records: RegistryRecord[]): Promise<void> {
+    try {
+      const client = this.supabaseService.getClient();
+      await client.from('contract_registry_entries').delete().eq('network', this.configService.network);
+      const { error } = await client.from('contract_registry_entries').insert(
+        records.map((record) => ({
+          contract_name: record.name,
+          network: record.network,
+          contract_id: record.contractId,
+          wasm_hash: record.wasmHash,
+          contract_version: record.contractVersion,
+          deployment_id: record.deploymentId ?? null,
+          metadata: record.metadata ?? {},
+          published_by: record.publishedBy,
+          version: record.version,
+          created_at: record.createdAt,
+          updated_at: record.updatedAt,
+          network_passphrase: record.networkPassphrase,
+          is_active: record.active,
+        })),
+      );
+
+      if (error) throw error;
+    } catch (error) {
+      this.logger.warn(
+        `Unable to persist contract registry snapshot: ${(error as Error).message}`,
+      );
+    }
+  }
+}

--- a/app/backend/src/contracts/contract-registry.service.unit.spec.ts
+++ b/app/backend/src/contracts/contract-registry.service.unit.spec.ts
@@ -1,0 +1,123 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+
+import { AppConfigService } from '../config';
+import { SupabaseService } from '../supabase/supabase.service';
+import { AuditService } from '../audit/audit.service';
+import { ContractRegistryService } from './contract-registry.service';
+
+describe('ContractRegistryService', () => {
+  let service: ContractRegistryService;
+  let mockSupabaseService: jest.Mocked<Partial<SupabaseService>>;
+  let mockAuditService: jest.Mocked<Partial<AuditService>>;
+  let mockAppConfigService: Partial<AppConfigService>;
+
+  beforeEach(() => {
+    const mockClient = {
+      from: jest.fn(() => ({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockResolvedValue({ data: [], error: null }),
+        delete: jest.fn().mockReturnThis(),
+        insert: jest.fn().mockResolvedValue({ error: null }),
+      })),
+    };
+
+    mockSupabaseService = {
+      getClient: jest.fn(() => mockClient as never),
+    };
+
+    mockAuditService = {
+      log: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockAppConfigService = {
+      network: 'testnet',
+    };
+
+    service = new ContractRegistryService(
+      mockSupabaseService as unknown as SupabaseService,
+      mockAuditService as unknown as AuditService,
+      mockAppConfigService as AppConfigService,
+    );
+  });
+
+  it('publishes and returns the active registry', async () => {
+    const result = await service.publish({
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      deploymentId: 'deploy-1',
+      contracts: [
+        {
+          name: 'quickex',
+          contractId: 'C123',
+          wasmHash: 'abc123',
+          contractVersion: 1,
+        },
+      ],
+    });
+
+    expect(result.data.quickex).toEqual(
+      expect.objectContaining({ id: 'C123', wasmHash: 'abc123', version: 1 }),
+    );
+    expect(result.version).toBeGreaterThan(0);
+    expect(mockAuditService.log).toHaveBeenCalledWith(
+      'contract_registry',
+      'registry.publish',
+      'deploy-1',
+      expect.any(Object),
+    );
+  });
+
+  it('rejects a mismatched passphrase', async () => {
+    await expect(
+      service.publish({
+        networkPassphrase: 'Public Global Stellar Network ; September 2015',
+        contracts: [
+          {
+            name: 'quickex',
+            contractId: 'C123',
+            wasmHash: 'abc123',
+          },
+        ],
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rolls back to a previous contract version', async () => {
+    await service.publish({
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      deploymentId: 'deploy-1',
+      contracts: [
+        {
+          name: 'quickex',
+          contractId: 'C123',
+          wasmHash: 'abc123',
+          contractVersion: 1,
+        },
+      ],
+    });
+
+    await service.publish({
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      deploymentId: 'deploy-2',
+      contracts: [
+        {
+          name: 'quickex',
+          contractId: 'C456',
+          wasmHash: 'def456',
+          contractVersion: 2,
+        },
+      ],
+    });
+
+    const result = await service.rollback({ name: 'quickex', version: 1 });
+    expect(result.data.quickex).toEqual(
+      expect.objectContaining({ id: 'C123', wasmHash: 'abc123', version: 1 }),
+    );
+  });
+
+  it('throws when rolling back a missing version', async () => {
+    await expect(service.rollback({ name: 'quickex', version: 99 })).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});

--- a/app/backend/src/contracts/contracts.module.ts
+++ b/app/backend/src/contracts/contracts.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+
+import { ApiKeysModule } from '../api-keys/api-keys.module';
+import { AuditModule } from '../audit/audit.module';
+import { ApiKeyGuard } from '../auth/guards/api-key.guard';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { ContractRegistryController } from './contract-registry.controller';
+import { ContractRegistryService } from './contract-registry.service';
+
+@Module({
+  imports: [ApiKeysModule, AuditModule, SupabaseModule],
+  controllers: [ContractRegistryController],
+  providers: [ContractRegistryService, ApiKeyGuard],
+  exports: [ContractRegistryService],
+})
+export class ContractsModule {}

--- a/app/backend/src/contracts/dto/contract-registry.dto.ts
+++ b/app/backend/src/contracts/dto/contract-registry.dto.ts
@@ -1,0 +1,105 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Matches,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ContractRegistryEntryDto {
+  @ApiProperty({ example: 'quickex' })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[a-z0-9_-]+$/i)
+  name: string;
+
+  @ApiProperty({ example: 'CD2J6K7T3YJ77QXZP3EXAMPLE' })
+  @IsString()
+  @IsNotEmpty()
+  contractId: string;
+
+  @ApiProperty({ example: 'abcdef1234567890' })
+  @IsString()
+  @IsNotEmpty()
+  wasmHash: string;
+
+  @ApiPropertyOptional({ example: 1, default: 1 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100_000)
+  contractVersion?: number;
+
+  @ApiPropertyOptional({ example: { source: 'testnet-deploy' } })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}
+
+export class PublishContractRegistryDto {
+  @ApiProperty({ example: 'Test SDF Network ; September 2015' })
+  @IsString()
+  @IsNotEmpty()
+  networkPassphrase: string;
+
+  @ApiPropertyOptional({ example: 'deploy-2026-05-30T18:00:00Z' })
+  @IsOptional()
+  @IsString()
+  deploymentId?: string;
+
+  @ApiProperty({ type: [ContractRegistryEntryDto] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(10)
+  @ValidateNested({ each: true })
+  @Type(() => ContractRegistryEntryDto)
+  contracts: ContractRegistryEntryDto[];
+}
+
+export class RollbackContractRegistryDto {
+  @ApiProperty({ example: 'quickex' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ example: 1 })
+  @IsInt()
+  @Min(1)
+  version: number;
+}
+
+export class ContractRegistryResponseDto {
+  @ApiProperty({ example: 'testnet' })
+  network: string;
+
+  @ApiProperty({ example: 'W/"contract-registry-testnet-2"' })
+  etag: string;
+
+  @ApiProperty({ example: 2 })
+  version: number;
+
+  @ApiProperty({ example: true })
+  @IsBoolean()
+  authoritative: boolean;
+
+  @ApiProperty({
+    example: {
+      quickex: {
+        id: 'CD2J6K7T3YJ77QXZP3EXAMPLE',
+        wasmHash: 'abcdef1234567890',
+        version: 1,
+      },
+    },
+  })
+  data: Record<string, unknown>;
+}

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -180,6 +180,7 @@ async function bootstrap() {
     .addTag("analytics", "Dashboard analytics, time-series insights, and report exports")
     .addTag("metrics", "Application performance and health metrics")
     .addTag("stellar", "Verified assets, path preview, Soroban preflight")
+    .addTag("contracts", "Contract registry publication and discovery")
     .addTag("developer", "Developer self-service: ping, webhook testing, key management, health score")
     .build();
 

--- a/app/backend/src/soroban-tooling/deployment.service.ts
+++ b/app/backend/src/soroban-tooling/deployment.service.ts
@@ -1,0 +1,90 @@
+import { createHash } from 'crypto';
+import { Injectable } from '@nestjs/common';
+import { existsSync, readFileSync } from 'fs';
+import * as path from 'path';
+
+import { AppConfigService } from '../config';
+import { ContractRegistryService } from '../contracts/contract-registry.service';
+import { DeploymentPlanDto } from './dto/testnet-tooling.dto';
+import { FundingHelperService } from './funding-helper.service';
+
+@Injectable()
+export class DeploymentService {
+  constructor(
+    private readonly configService: AppConfigService,
+    private readonly fundingHelperService: FundingHelperService,
+    private readonly contractRegistryService: ContractRegistryService,
+  ) {}
+
+  async planDeployment(dto: DeploymentPlanDto) {
+    const dryRun = dto.dryRun ?? true;
+    const publishRegistry = dto.publishRegistry ?? true;
+    const funding = dto.adminPublicKey
+      ? await this.fundingHelperService.checkFunding({
+          accountId: dto.adminPublicKey,
+          minBalanceXlm: 5,
+        })
+      : null;
+
+    const registry = await this.contractRegistryService.getRegistry();
+    const plannedContracts = dto.contracts.map((contract) => {
+      const absoluteWasmPath = path.resolve(contract.wasmPath);
+      const exists = existsSync(absoluteWasmPath);
+      const wasmHash = exists
+        ? createHash('sha256').update(readFileSync(absoluteWasmPath)).digest('hex')
+        : null;
+      const currentRegistry = registry.data[contract.name] as
+        | { id?: string; wasmHash?: string; version?: number }
+        | undefined;
+      const alreadyInstalled = Boolean(currentRegistry?.wasmHash && currentRegistry.wasmHash === wasmHash);
+      const alreadyDeployed = Boolean(currentRegistry?.id && alreadyInstalled);
+
+      return {
+        name: contract.name,
+        wasmPath: absoluteWasmPath,
+        wasmExists: exists,
+        wasmHash,
+        initMethod: contract.initMethod ?? 'initialize',
+        initArgs: contract.initArgs ?? (dto.adminPublicKey ? [dto.adminPublicKey] : []),
+        actions: [
+          { step: 'install', skipped: alreadyInstalled, reason: alreadyInstalled ? 'same wasm hash already active in registry' : undefined },
+          { step: 'deploy', skipped: alreadyDeployed, reason: alreadyDeployed ? 'same contract already active in registry' : undefined },
+          {
+            step: 'initialize',
+            skipped: alreadyDeployed && (contract.initMethod ?? 'initialize') === 'initialize',
+            reason:
+              alreadyDeployed && (contract.initMethod ?? 'initialize') === 'initialize'
+                ? 'active registry entry implies contract was already initialized'
+                : undefined,
+          },
+        ],
+      };
+    });
+
+    return {
+      network: dto.network,
+      dryRun,
+      publishRegistry,
+      networkPassphrase:
+        dto.network === 'mainnet'
+          ? 'Public Global Stellar Network ; September 2015'
+          : 'Test SDF Network ; September 2015',
+      funding,
+      commands: plannedContracts.flatMap((contract) => {
+        const commands: string[] = [];
+        commands.push(`soroban contract install --network ${dto.network} --source ${dto.source} --wasm ${contract.wasmPath}`);
+        commands.push(`soroban contract deploy --network ${dto.network} --source ${dto.source} --wasm-hash ${contract.wasmHash ?? '<missing-wasm>'}`);
+        if (contract.initMethod) {
+          commands.push(
+            `soroban contract invoke --network ${dto.network} --source ${dto.source} --id <contract-id> -- ${contract.initMethod} ${contract.initArgs.join(' ')}`.trim(),
+          );
+        }
+        return commands;
+      }),
+      contracts: plannedContracts,
+      ready:
+        plannedContracts.every((contract) => contract.wasmExists) &&
+        (!funding || funding.ready || dryRun),
+    };
+  }
+}

--- a/app/backend/src/soroban-tooling/dto/testnet-tooling.dto.ts
+++ b/app/backend/src/soroban-tooling/dto/testnet-tooling.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class FundingPreflightDto {
+  @ApiProperty({ example: 'GABCD1234EXAMPLE' })
+  @IsString()
+  @IsNotEmpty()
+  accountId: string;
+
+  @ApiPropertyOptional({ example: 5, default: 5 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  minBalanceXlm?: number;
+}
+
+export class DeployContractSpecDto {
+  @ApiProperty({ example: 'quickex' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ example: 'app/contract/target/wasm32-unknown-unknown/release/quickex.wasm' })
+  @IsString()
+  @IsNotEmpty()
+  wasmPath: string;
+
+  @ApiPropertyOptional({ example: 'initialize' })
+  @IsOptional()
+  @IsString()
+  initMethod?: string;
+
+  @ApiPropertyOptional({ example: ['GADMINEXAMPLE...'] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  initArgs?: string[];
+}
+
+export class DeploymentPlanDto {
+  @ApiProperty({ example: 'testnet' })
+  @IsString()
+  @Matches(/^(testnet|mainnet)$/)
+  network: 'testnet' | 'mainnet';
+
+  @ApiProperty({ example: 'test' })
+  @IsString()
+  @IsNotEmpty()
+  source: string;
+
+  @ApiPropertyOptional({ example: true, default: true })
+  @IsOptional()
+  @IsBoolean()
+  dryRun?: boolean;
+
+  @ApiPropertyOptional({ example: true, default: true })
+  @IsOptional()
+  @IsBoolean()
+  publishRegistry?: boolean;
+
+  @ApiPropertyOptional({ example: 'GADMINEXAMPLE...' })
+  @IsOptional()
+  @IsString()
+  adminPublicKey?: string;
+
+  @ApiProperty({ type: [DeployContractSpecDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => DeployContractSpecDto)
+  contracts: DeployContractSpecDto[];
+}

--- a/app/backend/src/soroban-tooling/funding-helper.service.ts
+++ b/app/backend/src/soroban-tooling/funding-helper.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+
+import { AppConfigService } from '../config';
+import { HorizonService } from '../stellar/horizon.service';
+import { FundingPreflightDto } from './dto/testnet-tooling.dto';
+
+@Injectable()
+export class FundingHelperService {
+  private readonly recommendedMinimum = 5;
+
+  constructor(
+    private readonly horizonService: HorizonService,
+    private readonly configService: AppConfigService,
+  ) {}
+
+  async checkFunding(dto: FundingPreflightDto) {
+    const minBalanceXlm = dto.minBalanceXlm ?? this.recommendedMinimum;
+    const account = await this.horizonService.getAccount(dto.accountId);
+
+    if (!account) {
+      return {
+        ready: false,
+        accountExists: false,
+        minimumBalanceXlm: minBalanceXlm,
+        currentBalanceXlm: '0',
+        network: this.configService.network,
+        faucetUrl: this.getFaucetUrl(),
+        remediation: [
+          'Create or fund the account with the Stellar testnet faucet before deploying.',
+          `Retry once the account holds at least ${minBalanceXlm} XLM.`,
+        ],
+      };
+    }
+
+    const nativeBalance = account.balances.find(
+      (balance) => balance.asset_type === 'native',
+    );
+    const currentBalance = Number(nativeBalance?.balance ?? '0');
+    const ready = currentBalance >= minBalanceXlm;
+
+    return {
+      ready,
+      accountExists: true,
+      minimumBalanceXlm: minBalanceXlm,
+      currentBalanceXlm: (nativeBalance?.balance ?? '0'),
+      network: this.configService.network,
+      faucetUrl: this.getFaucetUrl(),
+      remediation: ready
+        ? []
+        : [
+            `Fund the account until it reaches at least ${minBalanceXlm} XLM.`,
+            'Use the testnet faucet link below, then rerun deploy.',
+          ],
+    };
+  }
+
+  private getFaucetUrl(): string {
+    return this.configService.network === 'mainnet'
+      ? 'https://developers.stellar.org/docs/build/apps/example-application-tutorial/fund-account'
+      : 'https://laboratory.stellar.org/#account-creator?network=test';
+  }
+}

--- a/app/backend/src/soroban-tooling/soroban-tooling.controller.ts
+++ b/app/backend/src/soroban-tooling/soroban-tooling.controller.ts
@@ -1,0 +1,38 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { RequireScopes } from '../auth/decorators/require-scopes.decorator';
+import { ApiKeyGuard } from '../auth/guards/api-key.guard';
+import { DeploymentService } from './deployment.service';
+import { FundingPreflightDto, DeploymentPlanDto } from './dto/testnet-tooling.dto';
+import { FundingHelperService } from './funding-helper.service';
+
+@ApiTags('developer')
+@ApiHeader({
+  name: 'X-API-Key',
+  description: 'Optional API key. Deployment planning requires an admin-scoped key.',
+  required: false,
+})
+@UseGuards(ApiKeyGuard)
+@Controller('developer/testnet')
+export class SorobanToolingController {
+  constructor(
+    private readonly fundingHelperService: FundingHelperService,
+    private readonly deploymentService: DeploymentService,
+  ) {}
+
+  @Post('funding/preflight')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Check whether a Stellar account is funded enough for deploy flows' })
+  preflightFunding(@Body() body: FundingPreflightDto) {
+    return this.fundingHelperService.checkFunding(body);
+  }
+
+  @Post('deployments/plan')
+  @HttpCode(HttpStatus.OK)
+  @RequireScopes('admin')
+  @ApiOperation({ summary: 'Plan a deterministic Soroban deployment run without submitting transactions' })
+  planDeployment(@Body() body: DeploymentPlanDto) {
+    return this.deploymentService.planDeployment(body);
+  }
+}

--- a/app/backend/src/soroban-tooling/soroban-tooling.module.ts
+++ b/app/backend/src/soroban-tooling/soroban-tooling.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+
+import { ApiKeysModule } from '../api-keys/api-keys.module';
+import { ApiKeyGuard } from '../auth/guards/api-key.guard';
+import { ContractsModule } from '../contracts/contracts.module';
+import { StellarModule } from '../stellar/stellar.module';
+import { DeploymentService } from './deployment.service';
+import { FundingHelperService } from './funding-helper.service';
+import { SorobanToolingController } from './soroban-tooling.controller';
+
+@Module({
+  imports: [ApiKeysModule, StellarModule, ContractsModule],
+  controllers: [SorobanToolingController],
+  providers: [FundingHelperService, DeploymentService, ApiKeyGuard],
+  exports: [FundingHelperService, DeploymentService],
+})
+export class SorobanToolingModule {}

--- a/app/backend/src/soroban-tooling/soroban-tooling.unit.spec.ts
+++ b/app/backend/src/soroban-tooling/soroban-tooling.unit.spec.ts
@@ -1,0 +1,80 @@
+import { FundingHelperService } from './funding-helper.service';
+import { DeploymentService } from './deployment.service';
+import { HorizonService } from '../stellar/horizon.service';
+import { AppConfigService } from '../config';
+import { ContractRegistryService } from '../contracts/contract-registry.service';
+
+describe('Soroban tooling services', () => {
+  const mockConfig = { network: 'testnet' } as AppConfigService;
+
+  describe('FundingHelperService', () => {
+    it('returns faucet guidance when the account is missing', async () => {
+      const service = new FundingHelperService(
+        { getAccount: jest.fn().mockResolvedValue(null) } as unknown as HorizonService,
+        mockConfig,
+      );
+
+      const result = await service.checkFunding({ accountId: 'GTEST' });
+      expect(result.ready).toBe(false);
+      expect(result.accountExists).toBe(false);
+      expect(result.faucetUrl).toContain('laboratory.stellar.org');
+    });
+
+    it('marks the account ready when the minimum XLM balance is present', async () => {
+      const service = new FundingHelperService(
+        {
+          getAccount: jest.fn().mockResolvedValue({
+            balances: [{ asset_type: 'native', balance: '10.5000000' }],
+          }),
+        } as unknown as HorizonService,
+        mockConfig,
+      );
+
+      const result = await service.checkFunding({ accountId: 'GTEST', minBalanceXlm: 5 });
+      expect(result.ready).toBe(true);
+      expect(result.currentBalanceXlm).toBe('10.5000000');
+    });
+  });
+
+  describe('DeploymentService', () => {
+    it('produces a dry-run plan with idempotency hints from the registry', async () => {
+      const fundingHelperService = {
+        checkFunding: jest.fn().mockResolvedValue({ ready: true }),
+      } as unknown as FundingHelperService;
+      const contractRegistryService = {
+        getRegistry: jest.fn().mockResolvedValue({
+          data: {
+            quickex: {
+              id: 'C123',
+              wasmHash: 'not-the-same-hash',
+              version: 1,
+            },
+          },
+        }),
+      } as unknown as ContractRegistryService;
+
+      const service = new DeploymentService(
+        mockConfig,
+        fundingHelperService,
+        contractRegistryService,
+      );
+
+      const result = await service.planDeployment({
+        network: 'testnet',
+        source: 'test',
+        dryRun: true,
+        adminPublicKey: 'GADMIN',
+        contracts: [
+          {
+            name: 'quickex',
+            wasmPath: 'README.md',
+          },
+        ],
+      });
+
+      expect(result.ready).toBe(true);
+      expect(result.commands[0]).toContain('soroban contract install');
+      expect(result.contracts[0].wasmExists).toBe(true);
+    });
+  });
+});

--- a/app/backend/src/transactions/dto/compose-transaction-response.dto.ts
+++ b/app/backend/src/transactions/dto/compose-transaction-response.dto.ts
@@ -21,6 +21,21 @@ export interface ComposeTransactionResponse {
   feeEstimate: FeeEstimate;
   minResourceFee: string;
   simulationLatencyMs: number;
+  idempotencyKey: string;
+  simulationSummary: {
+    status: "success";
+    footprint: {
+      readOnly: number;
+      readWrite: number;
+    };
+    estimatedCost: {
+      cpuInstructions: number;
+      ledgerReads: number;
+      ledgerWrites: number;
+      eventBytes: number;
+      returnValueBytes: number;
+    };
+  };
 }
 
 export interface ComposeTransactionError {

--- a/app/backend/src/transactions/dto/compose-transaction.dto.ts
+++ b/app/backend/src/transactions/dto/compose-transaction.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsArray,
   ValidateNested,
+  MaxLength,
 } from "class-validator";
 import { Type } from "class-transformer";
 
@@ -18,10 +19,12 @@ export class ContractParamDto {
 export class ComposeTransactionDto {
   @IsString()
   @IsNotEmpty()
+  @MaxLength(128)
   contractId: string; // C... Strkey contract address
 
   @IsString()
   @IsNotEmpty()
+  @MaxLength(64)
   method: string; // Contract function name
 
   @IsArray()
@@ -36,4 +39,9 @@ export class ComposeTransactionDto {
   @IsString()
   @IsOptional()
   networkPassphrase?: string; // Defaults to testnet
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(128)
+  idempotencyKey?: string;
 }

--- a/app/backend/src/transactions/transaction.service.ts
+++ b/app/backend/src/transactions/transaction.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   InternalServerErrorException,
 } from "@nestjs/common";
+import { createHash } from "crypto";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
 import { ComposeTransactionDto } from "./dto/compose-transaction.dto";
@@ -24,12 +25,33 @@ const BASE_FEE = 100; // stroops
 @Injectable()
 export class TransactionsService {
   private readonly logger = new Logger(TransactionsService.name);
+  private readonly idempotencyResponses = new Map<
+    string,
+    ComposeTransactionResponse | ComposeTransactionError
+  >();
+  private readonly idempotencyFingerprints = new Map<string, string>();
 
   constructor(private readonly sorobanRpcService: SorobanRpcService) {}
 
   async composeTransaction(
     dto: ComposeTransactionDto,
   ): Promise<ComposeTransactionResponse | ComposeTransactionError> {
+    this.validatePayload(dto);
+
+    const payloadFingerprint = this.buildFingerprint(dto);
+    const idempotencyKey = dto.idempotencyKey ?? payloadFingerprint;
+    const fingerprintForKey = this.idempotencyFingerprints.get(idempotencyKey);
+    if (fingerprintForKey && fingerprintForKey !== payloadFingerprint) {
+      throw new BadRequestException(
+        "This idempotency key was already used with a different payload.",
+      );
+    }
+
+    const cached = this.idempotencyResponses.get(idempotencyKey);
+    if (cached) {
+      return cached;
+    }
+
     const startTime = Date.now();
 
     // 1. Resolve network passphrase
@@ -91,17 +113,19 @@ export class TransactionsService {
     if (SorobanRpc.Api.isSimulationError(simulationResult)) {
       const mapped = mapSorobanError(simulationResult.error);
       this.logger.warn(`Simulation failed [${mapped.code}]: ${simulationResult.error}`);
-      return {
+      const failedResponse: ComposeTransactionError = {
         success: false,
         error: mapped.code,
         userMessage: mapped.message,
         details: mapped.details,
       };
+      this.rememberResponse(idempotencyKey, payloadFingerprint, failedResponse);
+      return failedResponse;
     }
 
     // 8. Handle restoration needed
     if (SorobanRpc.Api.isSimulationRestore(simulationResult)) {
-      return {
+      const restoreResponse = {
         success: false,
         error: SorobanErrorCode.RESTORE_REQUIRED,
         userMessage:
@@ -110,6 +134,8 @@ export class TransactionsService {
           restorePreamble: simulationResult.restorePreamble,
         },
       } as ComposeTransactionError;
+      this.rememberResponse(idempotencyKey, payloadFingerprint, restoreResponse);
+      return restoreResponse;
     }
 
     // 9. Assemble transaction with simulation results (sets soroban data & resource fee)
@@ -154,13 +180,62 @@ export class TransactionsService {
         `${dto.contractId}::${dto.method}, fee: ${totalFeeStroops} stroops`,
     );
 
-    return {
+    const response: ComposeTransactionResponse = {
       success: true,
       unsignedXdr,
       resourceEstimate,
       feeEstimate,
       minResourceFee,
       simulationLatencyMs,
+      idempotencyKey,
+      simulationSummary: {
+        status: "success" as const,
+        footprint: {
+          readOnly: resources.footprint().readOnly().length,
+          readWrite: resources.footprint().readWrite().length,
+        },
+        estimatedCost: {
+          cpuInstructions: resourceEstimate.cpuInstructions,
+          ledgerReads: resourceEstimate.ledgerReads,
+          ledgerWrites: resourceEstimate.ledgerWrites,
+          eventBytes: resourceEstimate.eventBytes,
+          returnValueBytes: resourceEstimate.returnValueBytes,
+        },
+      },
     };
+    this.rememberResponse(idempotencyKey, payloadFingerprint, response);
+    return response;
+  }
+
+  private validatePayload(dto: ComposeTransactionDto): void {
+    const payloadSize = Buffer.byteLength(JSON.stringify(dto.params ?? []), "utf8");
+    if (payloadSize > 4096) {
+      throw new BadRequestException("Transaction parameters exceed the 4KB limit.");
+    }
+
+    if ((dto.params ?? []).length > 16) {
+      throw new BadRequestException("A maximum of 16 contract parameters is supported.");
+    }
+  }
+
+  private buildFingerprint(dto: ComposeTransactionDto): string {
+    const normalized = JSON.stringify({
+      contractId: dto.contractId,
+      method: dto.method,
+      params: dto.params,
+      sourceAccount: dto.sourceAccount,
+      networkPassphrase: dto.networkPassphrase ?? "__default__",
+    });
+
+    return createHash("sha256").update(normalized).digest("hex");
+  }
+
+  private rememberResponse(
+    idempotencyKey: string,
+    fingerprint: string,
+    response: ComposeTransactionResponse | ComposeTransactionError,
+  ): void {
+    this.idempotencyFingerprints.set(idempotencyKey, fingerprint);
+    this.idempotencyResponses.set(idempotencyKey, response);
   }
 }

--- a/app/backend/src/transactions/transaction.service.unit.spec.ts
+++ b/app/backend/src/transactions/transaction.service.unit.spec.ts
@@ -1,0 +1,168 @@
+jest.mock('@stellar/stellar-sdk', () => {
+  class MockAccount {
+    accountId: string;
+    sequence: string;
+
+    constructor(accountId: string, sequence: string) {
+      this.accountId = accountId;
+      this.sequence = sequence;
+    }
+  }
+
+  class MockContract {
+    contractId: string;
+
+    constructor(contractId: string) {
+      this.contractId = contractId;
+    }
+
+    call(method: string, ...params: unknown[]) {
+      return { contractId: this.contractId, method, params };
+    }
+  }
+
+  class MockTransactionBuilder {
+    account: MockAccount;
+    options: { fee: string; networkPassphrase: string };
+    operations: unknown[] = [];
+
+    constructor(account: MockAccount, options: { fee: string; networkPassphrase: string }) {
+      this.account = account;
+      this.options = options;
+    }
+
+    addOperation(operation: unknown) {
+      this.operations.push(operation);
+      return this;
+    }
+
+    setTimeout() {
+      return this;
+    }
+
+    build() {
+      const payload = JSON.stringify({
+        accountId: this.account.accountId,
+        sequence: this.account.sequence,
+        fee: this.options.fee,
+        networkPassphrase: this.options.networkPassphrase,
+        operations: this.operations,
+      });
+      return {
+        payload,
+        toEnvelope: () => ({ toXDR: () => Buffer.from(payload).toString('base64') }),
+      };
+    }
+  }
+
+  const assembleTransaction = jest.fn((tx: { payload: string }) => ({
+    build: () => ({
+      toEnvelope: () => ({ toXDR: () => Buffer.from(`${tx.payload}:assembled`).toString('base64') }),
+    }),
+  }));
+
+  return {
+    Account: MockAccount,
+    Contract: MockContract,
+    TransactionBuilder: MockTransactionBuilder,
+    TimeoutInfinite: 0,
+    rpc: {
+      assembleTransaction,
+      Api: {
+        isSimulationError: jest.fn(() => false),
+        isSimulationRestore: jest.fn(() => false),
+      },
+    },
+  };
+});
+
+import { BadRequestException } from '@nestjs/common';
+
+import { SorobanRpcService } from './soroban-rpc.service';
+import { TransactionsService } from './transaction.service';
+
+describe('TransactionsService', () => {
+  let service: TransactionsService;
+  let mockSorobanRpcService: jest.Mocked<Partial<SorobanRpcService>>;
+
+  beforeEach(() => {
+    mockSorobanRpcService = {
+      getNetworkPassphrase: jest.fn().mockResolvedValue('Test SDF Network ; September 2015'),
+      getAccount: jest.fn().mockResolvedValue({ accountId: 'G123', sequence: '1' }),
+      simulateTransaction: jest.fn().mockResolvedValue({
+        transactionData: {
+          build: () => ({
+            resources: () => ({
+              instructions: () => 123,
+              footprint: () => ({
+                readOnly: () => [1, 2],
+                readWrite: () => [3],
+              }),
+              writeBytes: () => 77,
+            }),
+          }),
+        },
+        minResourceFee: '250',
+        result: {
+          retval: {
+            toXDR: () => 'retval-xdr',
+          },
+        },
+      }),
+    };
+
+    service = new TransactionsService(mockSorobanRpcService as unknown as SorobanRpcService);
+  });
+
+  it('returns a simulation summary and idempotency key', async () => {
+    const result = await service.composeTransaction({
+      contractId: 'C123',
+      method: 'health_check',
+      params: [],
+      sourceAccount: 'G123',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.idempotencyKey).toBeDefined();
+      expect(result.simulationSummary.footprint.readOnly).toBe(2);
+      expect(result.feeEstimate.totalFee).toBe('350');
+    }
+  });
+
+  it('reuses the cached response for the same idempotency key', async () => {
+    const payload = {
+      contractId: 'C123',
+      method: 'health_check',
+      params: [],
+      sourceAccount: 'G123',
+      idempotencyKey: 'same-key',
+    };
+
+    const first = await service.composeTransaction(payload);
+    const second = await service.composeTransaction(payload);
+
+    expect(second).toEqual(first);
+    expect(mockSorobanRpcService.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects reusing an idempotency key with a different payload', async () => {
+    await service.composeTransaction({
+      contractId: 'C123',
+      method: 'health_check',
+      params: [],
+      sourceAccount: 'G123',
+      idempotencyKey: 'same-key',
+    });
+
+    await expect(
+      service.composeTransaction({
+        contractId: 'C123',
+        method: 'different_method',
+        params: [],
+        sourceAccount: 'G123',
+        idempotencyKey: 'same-key',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/app/backend/src/transactions/transactions.controller.ts
+++ b/app/backend/src/transactions/transactions.controller.ts
@@ -80,4 +80,14 @@ export class TransactionsController {
   async compose(@Body() dto: ComposeTransactionDto) {
     return this.transactionService.composeTransaction(dto);
   }
+
+  @Post("build")
+  @HttpCode(HttpStatus.OK)
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  @ApiOperation({
+    summary: "Build unsigned Soroban transaction XDR with simulation summary",
+  })
+  async buildUnsignedXdr(@Body() dto: ComposeTransactionDto) {
+    return this.transactionService.composeTransaction(dto);
+  }
 }

--- a/app/backend/supabase/migrations/20260530000000_create_contract_registry_entries.sql
+++ b/app/backend/supabase/migrations/20260530000000_create_contract_registry_entries.sql
@@ -1,0 +1,22 @@
+create table if not exists public.contract_registry_entries (
+  id uuid primary key default gen_random_uuid(),
+  contract_name text not null,
+  network text not null,
+  contract_id text not null,
+  wasm_hash text not null,
+  contract_version integer not null default 1,
+  deployment_id text,
+  metadata jsonb not null default '{}'::jsonb,
+  published_by text not null,
+  version bigint not null,
+  network_passphrase text not null,
+  is_active boolean not null default true,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists contract_registry_entries_network_idx
+  on public.contract_registry_entries (network, contract_name, is_active);
+
+create unique index if not exists contract_registry_entries_version_key
+  on public.contract_registry_entries (network, contract_name, version);


### PR DESCRIPTION
## Summary
- add a contract registry module with publish, read, and rollback flows backed by Supabase with in-memory fallback and audit logging
- add testnet funding preflight + deployment planning services plus a Soroban CLI deploy script that emits artifacts and can auto-publish to the registry
- extend transaction building with unsigned XDR v1 idempotency, payload limits, and simulation summaries
- add focused unit coverage for the new registry, tooling, and transaction paths

## Verification
- `npm run test:unit -- src/contracts/contract-registry.service.unit.spec.ts src/soroban-tooling/soroban-tooling.unit.spec.ts src/transactions/transaction.service.unit.spec.ts`
- `npm run test:unit` currently still fails in unrelated existing suites (for example bcrypt native loading on this machine, metrics expectations, and pre-existing ingestion/notification typing issues)
- `npm run type-check` currently still fails in unrelated existing analytics/ingestion/notification specs

Closes #502
Closes #503
Closes #504
Closes #505