### PR TITLE
[507] BE-48: Testnet Rate Limits + Abuse Controls for Public Endpoints

### DIFF
--- a/app/backend/.env.example
+++ b/app/backend/.env.example
@@ -107,3 +107,17 @@ STAGING_SEED_DATA_ENABLED=false
 # Explicit environment name for parity tracking
 # Options: development, staging, production, test
 ENVIRONMENT_NAME=development
+
+# -----------------------------------------------------------------------------
+# Rate Limiting & Abuse Controls (testnet-focused)
+# -----------------------------------------------------------------------------
+
+# Abuse-sensitive public routes: POST /stellar/quote, POST /links/metadata, POST /links/scan
+# Testnet defaults: 5 burst / 10s, 15 sustained / 60s (tighter than general public limits)
+# RATE_LIMIT_PUBLIC_ABUSE_BURST_LIMIT=5
+# RATE_LIMIT_PUBLIC_ABUSE_SUSTAINED_LIMIT=15
+
+# Trusted CI/contributor bypass (audited allowlist — keep keys scoped and rotated)
+RATE_LIMIT_ALLOWLIST_ENABLED=true
+# RATE_LIMIT_ALLOWLIST_IPS=127.0.0.1,::1
+# RATE_LIMIT_ALLOWLIST_KEYS=ci-smoke-test-key

--- a/app/backend/src/auth/guards/custom-throttler.guard.ts
+++ b/app/backend/src/auth/guards/custom-throttler.guard.ts
@@ -1,4 +1,9 @@
-import { ExecutionContext, Injectable, Inject } from "@nestjs/common";
+import {
+  ExecutionContext,
+  Injectable,
+  Inject,
+  Logger,
+} from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import {
   ThrottlerException,
@@ -10,8 +15,10 @@ import {
   RateLimitGroup,
   RateLimitKeyType,
   THROTTLER_BURST_NAME,
+  isAbuseSensitiveRoute,
   throttlerConfig,
 } from "../../config/rate-limit.config";
+import { allowlistConfig } from "../../config/rate-limit-allowlist.config";
 import { MetricsService } from "../../metrics/metrics.service";
 
 type RequestWithRateLimitContext = Record<string, unknown> & {
@@ -24,6 +31,7 @@ type RequestWithRateLimitContext = Record<string, unknown> & {
   path?: string;
   originalUrl?: string;
   method?: string;
+  correlationId?: string;
   rateLimitContext?: {
     group: RateLimitGroup;
     keyType: RateLimitKeyType;
@@ -32,10 +40,24 @@ type RequestWithRateLimitContext = Record<string, unknown> & {
 
 @Injectable()
 export class CustomThrottlerGuard extends ThrottlerGuard {
+  private readonly logger = new Logger(CustomThrottlerGuard.name);
+
   @Inject(MetricsService)
   private readonly metricsService: MetricsService;
 
   protected readonly reflector = new Reflector();
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context
+      .switchToHttp()
+      .getRequest<RequestWithRateLimitContext>();
+
+    if (this.isAllowlisted(req)) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
 
   protected async handleRequest(
     requestProps: ThrottlerRequest,
@@ -44,6 +66,10 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     const req = context
       .switchToHttp()
       .getRequest<RequestWithRateLimitContext>();
+
+    if (this.isAllowlisted(req)) {
+      return true;
+    }
 
     const group = this.resolveGroup(context, req);
     const window =
@@ -78,14 +104,29 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
         }
 
         const method = req.method ?? "unknown";
-        const routePath = req.route?.path ?? req.path ?? req.originalUrl ?? "unknown";
-        
+        const routePath =
+          req.route?.path ?? req.path ?? req.originalUrl ?? "unknown";
+
         this.metricsService.recordRateLimitedRequest(
           method,
           routePath,
           group,
           req.rateLimitContext.keyType,
         );
+
+        this.logger.warn({
+          event: "rate_limit_exceeded",
+          method,
+          route: routePath,
+          group,
+          keyType: req.rateLimitContext.keyType,
+          ip: this.getIp(req),
+          correlationId:
+            req.correlationId ??
+            (typeof req.headers?.["x-request-id"] === "string"
+              ? req.headers["x-request-id"]
+              : undefined),
+        });
       }
 
       throw error;
@@ -99,6 +140,24 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     return `${identity.keyType}:${identity.value}`;
   }
 
+  private isAllowlisted(req: RequestWithRateLimitContext): boolean {
+    if (!allowlistConfig.enabled) {
+      return false;
+    }
+
+    const ip = this.getIp(req);
+    if (allowlistConfig.ips.has(ip)) {
+      return true;
+    }
+
+    const apiKey = this.getApiKeyValue(req);
+    if (apiKey && allowlistConfig.apiKeys.has(apiKey)) {
+      return true;
+    }
+
+    return false;
+  }
+
   private resolveGroup(
     context: ExecutionContext,
     req: RequestWithRateLimitContext,
@@ -108,18 +167,30 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
       [context.getHandler(), context.getClass()],
     );
 
-    if (metadataGroup) {
-      return metadataGroup;
+    if (metadataGroup === "webhooks") {
+      return "webhooks";
     }
 
     const path =
       `${req.baseUrl ?? ""}${req.route?.path ?? req.path ?? req.originalUrl ?? ""}`.toLowerCase();
+
     if (path.startsWith("/webhooks") || path.includes("/webhooks/")) {
       return "webhooks";
     }
 
     if (this.getUserId(req) || this.getApiKeyValue(req)) {
       return "authenticated";
+    }
+
+    if (
+      metadataGroup === "public_abuse" ||
+      isAbuseSensitiveRoute(path)
+    ) {
+      return "public_abuse";
+    }
+
+    if (metadataGroup) {
+      return metadataGroup;
     }
 
     return "public";

--- a/app/backend/src/auth/guards/custom-throttler.guard.unit.spec.ts
+++ b/app/backend/src/auth/guards/custom-throttler.guard.unit.spec.ts
@@ -11,9 +11,21 @@ import {
   RATE_LIMIT_GROUP_METADATA_KEY,
   THROTTLER_BURST_NAME,
   THROTTLER_SUSTAINED_NAME,
-  throttlerConfig,
+  buildRateLimitConfig,
 } from "../../config/rate-limit.config";
 import { MetricsService } from "../../metrics/metrics.service";
+
+jest.mock("../../config/rate-limit-allowlist.config", () => ({
+  allowlistConfig: {
+    enabled: true,
+    ips: new Set<string>(),
+    apiKeys: new Set<string>(),
+  },
+}));
+
+import { allowlistConfig } from "../../config/rate-limit-allowlist.config";
+
+const throttlerConfig = buildRateLimitConfig({ STELLAR_NETWORK: "testnet" });
 
 type ReqShape = {
   headers?: Record<string, string>;
@@ -29,6 +41,7 @@ type ReqShape = {
 interface GuardSurface {
   handleRequest(requestProps: ThrottlerRequest): Promise<boolean>;
   getTracker(req: ReqShape): Promise<string>;
+  canActivate(context: ExecutionContext): Promise<boolean>;
 }
 
 function buildContext(
@@ -72,6 +85,10 @@ describe("CustomThrottlerGuard", () => {
   let metricsServiceRecordMock: jest.Mock;
 
   beforeEach(async () => {
+    allowlistConfig.enabled = true;
+    allowlistConfig.ips = new Set();
+    allowlistConfig.apiKeys = new Set();
+
     const module: TestingModule = await Test.createTestingModule({
       imports: [
         ThrottlerModule.forRoot([
@@ -113,8 +130,8 @@ describe("CustomThrottlerGuard", () => {
   it("uses public burst profile by default", async () => {
     const context = buildContext({
       ip: "127.0.0.1",
-      baseUrl: "/links",
-      route: { path: "/metadata" },
+      baseUrl: "/health",
+      route: { path: "/" },
     });
     const props = buildProps(context, THROTTLER_BURST_NAME);
 
@@ -145,6 +162,75 @@ describe("CustomThrottlerGuard", () => {
         ttl: throttlerConfig.groups.authenticated.sustained.ttlMs,
       }),
     );
+  });
+
+  it("uses public_abuse burst profile for metadata route", async () => {
+    const context = buildContext({
+      ip: "127.0.0.1",
+      baseUrl: "/links",
+      route: { path: "/metadata" },
+    });
+    const props = buildProps(context, THROTTLER_BURST_NAME);
+
+    await guard.handleRequest(props);
+
+    expect(superHandleRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: throttlerConfig.groups.public_abuse.burst.limit,
+        ttl: throttlerConfig.groups.public_abuse.burst.ttlMs,
+      }),
+    );
+  });
+
+  it("uses authenticated profile for abuse route when API key is present", async () => {
+    const context = buildContext({
+      headers: { "x-api-key": "trusted-client-key" },
+      ip: "127.0.0.1",
+      baseUrl: "/links",
+      route: { path: "/metadata" },
+    });
+    const props = buildProps(context, THROTTLER_BURST_NAME);
+
+    await guard.handleRequest(props);
+
+    expect(superHandleRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: throttlerConfig.groups.authenticated.burst.limit,
+        ttl: throttlerConfig.groups.authenticated.burst.ttlMs,
+      }),
+    );
+  });
+
+  it("bypasses throttling for allowlisted IPs", async () => {
+    allowlistConfig.ips = new Set(["10.0.0.1"]);
+
+    const context = buildContext({
+      ip: "10.0.0.1",
+      baseUrl: "/links",
+      route: { path: "/metadata" },
+    });
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(superHandleRequest).not.toHaveBeenCalled();
+  });
+
+  it("bypasses throttling for allowlisted API keys", async () => {
+    allowlistConfig.apiKeys = new Set(["ci-smoke-key"]);
+
+    const context = buildContext({
+      headers: { "x-api-key": "ci-smoke-key" },
+      ip: "10.0.0.2",
+      baseUrl: "/links",
+      route: { path: "/scan" },
+    });
+    const props = buildProps(context, THROTTLER_BURST_NAME);
+
+    const result = await guard.handleRequest(props);
+
+    expect(result).toBe(true);
+    expect(superHandleRequest).not.toHaveBeenCalled();
   });
 
   it("uses webhook profile when metadata tag is set", async () => {
@@ -209,7 +295,7 @@ describe("CustomThrottlerGuard", () => {
     expect(metricsServiceRecordMock).toHaveBeenCalledWith(
       "GET",
       "/metadata",
-      "public",
+      "public_abuse",
       "ip",
     );
   });

--- a/app/backend/src/common/filters/global-http-exception.filter.ts
+++ b/app/backend/src/common/filters/global-http-exception.filter.ts
@@ -9,7 +9,6 @@ import {
 import { ThrottlerException } from "@nestjs/throttler";
 import { Request, Response } from "express";
 import { AppConfigService } from "../../config";
-import { MetricsService } from "../../metrics/metrics.service";
 
 interface ErrorResponseBody {
   success: false;
@@ -45,10 +44,7 @@ type HttpExceptionResponse =
 export class GlobalHttpExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(GlobalHttpExceptionFilter.name);
 
-  constructor(
-    private readonly config: AppConfigService,
-    private readonly metricsService?: MetricsService,
-  ) {}
+  constructor(private readonly config: AppConfigService) {}
 
   catch(exception: unknown, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
@@ -80,20 +76,6 @@ export class GlobalHttpExceptionFilter implements ExceptionFilter {
         retryAfterSeconds,
       };
 
-      const reqRecord = request as Record<string, unknown>;
-      const rateLimitContext =
-        (reqRecord["rateLimitContext"] as
-          | { group?: string; keyType?: string }
-          | undefined) ?? {};
-
-      const route = this.resolveRoute(request);
-
-      this.metricsService?.recordRateLimitedRequest(
-        request.method,
-        route,
-        rateLimitContext.group ?? "public",
-        rateLimitContext.keyType ?? "ip",
-      );
     } else if (exception instanceof HttpException) {
       status = exception.getStatus();
       const res = exception.getResponse() as HttpExceptionResponse;

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -261,6 +261,49 @@ export const envSchema = Joi.object({
       "Preferred key order for rate-limit identity. Allowed values: user_id,api_key,ip",
     ),
 
+  RATE_LIMIT_PUBLIC_ABUSE_BURST_LIMIT: Joi.number()
+    .integer()
+    .min(1)
+    .description(
+      "Burst request limit for abuse-sensitive public routes (quotes, metadata, scan). Defaults to 5 on testnet, 8 on mainnet.",
+    ),
+  RATE_LIMIT_PUBLIC_ABUSE_BURST_TTL_MS: Joi.number()
+    .integer()
+    .min(1000)
+    .default(10000)
+    .description("Burst window for abuse-sensitive public routes in milliseconds"),
+  RATE_LIMIT_PUBLIC_ABUSE_SUSTAINED_LIMIT: Joi.number()
+    .integer()
+    .min(1)
+    .description(
+      "Sustained request limit for abuse-sensitive public routes. Defaults to 15 on testnet, 30 on mainnet.",
+    ),
+  RATE_LIMIT_PUBLIC_ABUSE_SUSTAINED_TTL_MS: Joi.number()
+    .integer()
+    .min(1000)
+    .default(60000)
+    .description(
+      "Sustained window for abuse-sensitive public routes in milliseconds",
+    ),
+
+  RATE_LIMIT_ALLOWLIST_ENABLED: Joi.boolean()
+    .default(true)
+    .description(
+      "When true, trusted IPs and API keys bypass rate limiting entirely",
+    ),
+  RATE_LIMIT_ALLOWLIST_IPS: Joi.string()
+    .empty("")
+    .optional()
+    .description(
+      "Comma-separated trusted IPs (CI runners, local dev) that bypass rate limits",
+    ),
+  RATE_LIMIT_ALLOWLIST_KEYS: Joi.string()
+    .empty("")
+    .optional()
+    .description(
+      "Comma-separated trusted API keys (CI smoke tests) that bypass rate limits",
+    ),
+
   // ---------------------------------------------------------------------------
   // Sentry Error Monitoring (optional; omit to disable)
   // ---------------------------------------------------------------------------
@@ -403,6 +446,13 @@ export interface EnvConfig {
   RATE_LIMIT_WEBHOOKS_SUSTAINED_LIMIT: number;
   RATE_LIMIT_WEBHOOKS_SUSTAINED_TTL_MS: number;
   RATE_LIMIT_KEY_ORDER: string;
+  RATE_LIMIT_PUBLIC_ABUSE_BURST_LIMIT?: number;
+  RATE_LIMIT_PUBLIC_ABUSE_BURST_TTL_MS: number;
+  RATE_LIMIT_PUBLIC_ABUSE_SUSTAINED_LIMIT?: number;
+  RATE_LIMIT_PUBLIC_ABUSE_SUSTAINED_TTL_MS: number;
+  RATE_LIMIT_ALLOWLIST_ENABLED: boolean;
+  RATE_LIMIT_ALLOWLIST_IPS?: string;
+  RATE_LIMIT_ALLOWLIST_KEYS?: string;
   SENTRY_DSN?: string;
   SENTRY_ENVIRONMENT?: string;
   SENTRY_RELEASE?: string;

--- a/app/backend/src/config/rate-limit-allowlist.config.ts
+++ b/app/backend/src/config/rate-limit-allowlist.config.ts
@@ -1,0 +1,42 @@
+/**
+ * Rate-limit allowlist configuration.
+ *
+ * Trusted IPs and API keys listed here bypass throttling entirely.
+ * This keeps CI pipelines and known contributor tooling friction-free
+ * while still protecting public endpoints from abuse.
+ *
+ * Environment variables:
+ *   RATE_LIMIT_ALLOWLIST_IPS  – comma-separated IPs (e.g. "127.0.0.1,::1")
+ *   RATE_LIMIT_ALLOWLIST_KEYS – comma-separated plain-text API keys
+ *   RATE_LIMIT_ALLOWLIST_ENABLED – "true" | "false" (default "true")
+ */
+
+export interface RateLimitAllowlistConfig {
+  enabled: boolean;
+  ips: Set<string>;
+  apiKeys: Set<string>;
+}
+
+function parseList(raw?: string): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean),
+  );
+}
+
+export function resolveAllowlistConfig(
+  env: Record<string, string | undefined> = process.env,
+): RateLimitAllowlistConfig {
+  const enabled = (env["RATE_LIMIT_ALLOWLIST_ENABLED"] ?? "true").toLowerCase() !== "false";
+
+  return {
+    enabled,
+    ips: parseList(env["RATE_LIMIT_ALLOWLIST_IPS"]),
+    apiKeys: parseList(env["RATE_LIMIT_ALLOWLIST_KEYS"]),
+  };
+}
+
+export const allowlistConfig = resolveAllowlistConfig();

--- a/app/backend/src/config/rate-limit-allowlist.config.unit.spec.ts
+++ b/app/backend/src/config/rate-limit-allowlist.config.unit.spec.ts
@@ -1,0 +1,27 @@
+import { resolveAllowlistConfig } from "./rate-limit-allowlist.config";
+
+describe("rate-limit-allowlist.config", () => {
+  it("parses trusted IPs and API keys", () => {
+    const config = resolveAllowlistConfig({
+      RATE_LIMIT_ALLOWLIST_ENABLED: "true",
+      RATE_LIMIT_ALLOWLIST_IPS: "127.0.0.1, ::1",
+      RATE_LIMIT_ALLOWLIST_KEYS: "ci-key, contributor-key",
+    });
+
+    expect(config.enabled).toBe(true);
+    expect(config.ips.has("127.0.0.1")).toBe(true);
+    expect(config.ips.has("::1")).toBe(true);
+    expect(config.apiKeys.has("ci-key")).toBe(true);
+    expect(config.apiKeys.has("contributor-key")).toBe(true);
+  });
+
+  it("can disable the allowlist entirely", () => {
+    const config = resolveAllowlistConfig({
+      RATE_LIMIT_ALLOWLIST_ENABLED: "false",
+      RATE_LIMIT_ALLOWLIST_IPS: "127.0.0.1",
+      RATE_LIMIT_ALLOWLIST_KEYS: "ci-key",
+    });
+
+    expect(config.enabled).toBe(false);
+  });
+});

--- a/app/backend/src/config/rate-limit.config.ts
+++ b/app/backend/src/config/rate-limit.config.ts
@@ -1,4 +1,8 @@
-export type RateLimitGroup = "public" | "authenticated" | "webhooks";
+export type RateLimitGroup =
+  | "public"
+  | "public_abuse"
+  | "authenticated"
+  | "webhooks";
 export type RateLimitWindow = "burst" | "sustained";
 export type RateLimitKeyType = "user_id" | "api_key" | "ip";
 
@@ -39,55 +43,115 @@ function parseKeyOrder(raw?: string): RateLimitKeyType[] {
   return ordered.length > 0 ? ordered : DEFAULT_KEY_ORDER;
 }
 
-export const throttlerConfig: RateLimitConfig = {
-  groups: {
-    public: {
-      burst: {
-        limit: Number(process.env["RATE_LIMIT_PUBLIC_BURST_LIMIT"] ?? 10),
-        ttlMs: Number(process.env["RATE_LIMIT_PUBLIC_BURST_TTL_MS"] ?? 10_000),
+export function isTestnetEnvironment(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const network = (
+    env["STELLAR_NETWORK"] ??
+    env["NETWORK"] ??
+    "testnet"
+  ).toLowerCase();
+
+  return network === "testnet";
+}
+
+/**
+ * Public endpoints that fan out to Horizon/RPC and are common abuse targets
+ * during contributor testing and public demos.
+ */
+export function isAbuseSensitiveRoute(path: string): boolean {
+  const normalized = path.toLowerCase();
+
+  return (
+    normalized.includes("/stellar/quote") ||
+    (normalized.includes("/links") && normalized.endsWith("/metadata")) ||
+    (normalized.includes("/links") && normalized.endsWith("/scan"))
+  );
+}
+
+function resolvePublicAbuseDefaults(
+  env: Record<string, string | undefined> = process.env,
+): GroupConfig {
+  const testnet = isTestnetEnvironment(env);
+
+  return {
+    burst: {
+      limit: Number(
+        env["RATE_LIMIT_PUBLIC_ABUSE_BURST_LIMIT"] ?? (testnet ? 5 : 8),
+      ),
+      ttlMs: Number(
+        env["RATE_LIMIT_PUBLIC_ABUSE_BURST_TTL_MS"] ?? 10_000,
+      ),
+    },
+    sustained: {
+      limit: Number(
+        env["RATE_LIMIT_PUBLIC_ABUSE_SUSTAINED_LIMIT"] ?? (testnet ? 15 : 30),
+      ),
+      ttlMs: Number(
+        env["RATE_LIMIT_PUBLIC_ABUSE_SUSTAINED_TTL_MS"] ?? 60_000,
+      ),
+    },
+  };
+}
+
+export function buildRateLimitConfig(
+  env: Record<string, string | undefined> = process.env,
+): RateLimitConfig {
+  return {
+    groups: {
+      public: {
+        burst: {
+          limit: Number(env["RATE_LIMIT_PUBLIC_BURST_LIMIT"] ?? 10),
+          ttlMs: Number(env["RATE_LIMIT_PUBLIC_BURST_TTL_MS"] ?? 10_000),
+        },
+        sustained: {
+          limit: Number(env["RATE_LIMIT_PUBLIC_SUSTAINED_LIMIT"] ?? 20),
+          ttlMs: Number(
+            env["RATE_LIMIT_PUBLIC_SUSTAINED_TTL_MS"] ?? 60_000,
+          ),
+        },
       },
-      sustained: {
-        limit: Number(process.env["RATE_LIMIT_PUBLIC_SUSTAINED_LIMIT"] ?? 20),
-        ttlMs: Number(
-          process.env["RATE_LIMIT_PUBLIC_SUSTAINED_TTL_MS"] ?? 60_000,
-        ),
+      public_abuse: resolvePublicAbuseDefaults(env),
+      authenticated: {
+        burst: {
+          limit: Number(
+            env["RATE_LIMIT_AUTHENTICATED_BURST_LIMIT"] ?? 40,
+          ),
+          ttlMs: Number(
+            env["RATE_LIMIT_AUTHENTICATED_BURST_TTL_MS"] ?? 10_000,
+          ),
+        },
+        sustained: {
+          limit: Number(
+            env["RATE_LIMIT_AUTHENTICATED_SUSTAINED_LIMIT"] ?? 120,
+          ),
+          ttlMs: Number(
+            env["RATE_LIMIT_AUTHENTICATED_SUSTAINED_TTL_MS"] ?? 60_000,
+          ),
+        },
+      },
+      webhooks: {
+        burst: {
+          limit: Number(env["RATE_LIMIT_WEBHOOKS_BURST_LIMIT"] ?? 20),
+          ttlMs: Number(
+            env["RATE_LIMIT_WEBHOOKS_BURST_TTL_MS"] ?? 10_000,
+          ),
+        },
+        sustained: {
+          limit: Number(
+            env["RATE_LIMIT_WEBHOOKS_SUSTAINED_LIMIT"] ?? 60,
+          ),
+          ttlMs: Number(
+            env["RATE_LIMIT_WEBHOOKS_SUSTAINED_TTL_MS"] ?? 60_000,
+          ),
+        },
       },
     },
-    authenticated: {
-      burst: {
-        limit: Number(
-          process.env["RATE_LIMIT_AUTHENTICATED_BURST_LIMIT"] ?? 40,
-        ),
-        ttlMs: Number(
-          process.env["RATE_LIMIT_AUTHENTICATED_BURST_TTL_MS"] ?? 10_000,
-        ),
-      },
-      sustained: {
-        limit: Number(
-          process.env["RATE_LIMIT_AUTHENTICATED_SUSTAINED_LIMIT"] ?? 120,
-        ),
-        ttlMs: Number(
-          process.env["RATE_LIMIT_AUTHENTICATED_SUSTAINED_TTL_MS"] ?? 60_000,
-        ),
-      },
-    },
-    webhooks: {
-      burst: {
-        limit: Number(process.env["RATE_LIMIT_WEBHOOKS_BURST_LIMIT"] ?? 20),
-        ttlMs: Number(
-          process.env["RATE_LIMIT_WEBHOOKS_BURST_TTL_MS"] ?? 10_000,
-        ),
-      },
-      sustained: {
-        limit: Number(process.env["RATE_LIMIT_WEBHOOKS_SUSTAINED_LIMIT"] ?? 60),
-        ttlMs: Number(
-          process.env["RATE_LIMIT_WEBHOOKS_SUSTAINED_TTL_MS"] ?? 60_000,
-        ),
-      },
-    },
-  },
-  keyOrder: parseKeyOrder(process.env["RATE_LIMIT_KEY_ORDER"]),
-};
+    keyOrder: parseKeyOrder(env["RATE_LIMIT_KEY_ORDER"]),
+  };
+}
+
+export const throttlerConfig: RateLimitConfig = buildRateLimitConfig();
 
 export const throttlerModuleProfiles = [
   {

--- a/app/backend/src/config/rate-limit.config.unit.spec.ts
+++ b/app/backend/src/config/rate-limit.config.unit.spec.ts
@@ -1,0 +1,62 @@
+import {
+  buildRateLimitConfig,
+  isAbuseSensitiveRoute,
+  isTestnetEnvironment,
+} from "./rate-limit.config";
+
+describe("rate-limit.config", () => {
+  describe("isTestnetEnvironment", () => {
+    it("returns true when STELLAR_NETWORK is testnet", () => {
+      expect(
+        isTestnetEnvironment({ STELLAR_NETWORK: "testnet", NETWORK: "mainnet" }),
+      ).toBe(true);
+    });
+
+    it("returns false when network is mainnet", () => {
+      expect(
+        isTestnetEnvironment({ STELLAR_NETWORK: "mainnet", NETWORK: "mainnet" }),
+      ).toBe(false);
+    });
+  });
+
+  describe("isAbuseSensitiveRoute", () => {
+    it("matches quote, metadata, and scan routes", () => {
+      expect(isAbuseSensitiveRoute("/stellar/quote")).toBe(true);
+      expect(isAbuseSensitiveRoute("/stellar/quote/abc-123")).toBe(true);
+      expect(isAbuseSensitiveRoute("/links/metadata")).toBe(true);
+      expect(isAbuseSensitiveRoute("/links/scan")).toBe(true);
+    });
+
+    it("does not match unrelated routes", () => {
+      expect(isAbuseSensitiveRoute("/health")).toBe(false);
+      expect(isAbuseSensitiveRoute("/stellar/verified-assets")).toBe(false);
+    });
+  });
+
+  describe("buildRateLimitConfig", () => {
+    it("applies tighter public_abuse defaults on testnet", () => {
+      const config = buildRateLimitConfig({ STELLAR_NETWORK: "testnet" });
+
+      expect(config.groups.public_abuse.burst.limit).toBe(5);
+      expect(config.groups.public_abuse.sustained.limit).toBe(15);
+    });
+
+    it("relaxes public_abuse defaults on mainnet", () => {
+      const config = buildRateLimitConfig({ STELLAR_NETWORK: "mainnet" });
+
+      expect(config.groups.public_abuse.burst.limit).toBe(8);
+      expect(config.groups.public_abuse.sustained.limit).toBe(30);
+    });
+
+    it("honors explicit public_abuse overrides", () => {
+      const config = buildRateLimitConfig({
+        STELLAR_NETWORK: "testnet",
+        RATE_LIMIT_PUBLIC_ABUSE_BURST_LIMIT: "12",
+        RATE_LIMIT_PUBLIC_ABUSE_SUSTAINED_LIMIT: "40",
+      });
+
+      expect(config.groups.public_abuse.burst.limit).toBe(12);
+      expect(config.groups.public_abuse.sustained.limit).toBe(40);
+    });
+  });
+});

--- a/app/backend/src/links/links.controller.ts
+++ b/app/backend/src/links/links.controller.ts
@@ -18,6 +18,7 @@ import { LinksService } from "./links.service";
 import { LinkMetadataRequestDto, LinkMetadataResponseDto } from "../dto";
 import { LinkValidationError } from "./errors";
 import { ApiKeyGuard } from "../auth/guards/api-key.guard";
+import { RateLimitGroupTag } from "../auth/decorators/rate-limit-group.decorator";
 
 @ApiTags("links")
 @ApiHeader({
@@ -32,6 +33,7 @@ export class LinksController {
   constructor(private readonly linksService: LinksService) {}
 
   @Post("metadata")
+  @RateLimitGroupTag("public_abuse")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Generate canonical link metadata",

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -21,7 +21,6 @@ import { resolveNetworkSnapshot } from "./config/network.config";
 import { GlobalHttpExceptionFilter } from "./common/filters/global-http-exception.filter";
 import { mapValidationErrors } from "./common/utils/validation-error.mapper";
 import { SentryExceptionFilter, SentryService } from "./sentry";
-import { MetricsService } from "./metrics/metrics.service";
 import { 
   sanitizeErrorMessage,
   createConfigSummary 
@@ -133,10 +132,9 @@ async function bootstrap() {
   // Register Sentry exception filter FIRST so it captures errors,
   // then the existing HTTP exception filter handles the response.
   const sentryService = app.get(SentryService);
-  const metricsService = app.get(MetricsService);
   app.useGlobalFilters(
     new SentryExceptionFilter(sentryService, configService),
-    new GlobalHttpExceptionFilter(configService, metricsService),
+    new GlobalHttpExceptionFilter(configService),
   );
 
   // Swagger setup

--- a/app/backend/src/scam-alerts/scam-alerts.controller.ts
+++ b/app/backend/src/scam-alerts/scam-alerts.controller.ts
@@ -1,15 +1,37 @@
-import { Controller, Post, Body, HttpCode, HttpStatus } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiResponse, ApiBody } from "@nestjs/swagger";
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiHeader,
+} from "@nestjs/swagger";
 import { ScamAlertsService } from "./scam-alerts.service";
 import { ScanLinkDto } from "../dto";
 import { ScanResultDto } from "./dto/scan-result.dto";
+import { ApiKeyGuard } from "../auth/guards/api-key.guard";
+import { RateLimitGroupTag } from "../auth/decorators/rate-limit-group.decorator";
 
 @ApiTags("scam-alerts")
+@ApiHeader({
+  name: "X-API-Key",
+  description: "Optional API key for higher rate limits",
+  required: false,
+})
+@UseGuards(ApiKeyGuard)
 @Controller("links")
 export class ScamAlertsController {
   constructor(private readonly scamAlertsService: ScamAlertsService) {}
 
   @Post("scan")
+  @RateLimitGroupTag("public_abuse")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Scan a payment link for scam indicators",
@@ -28,6 +50,10 @@ export class ScamAlertsController {
   @ApiResponse({
     status: 400,
     description: "Invalid input data",
+  })
+  @ApiResponse({
+    status: 429,
+    description: "Rate limit exceeded – retry after Retry-After seconds",
   })
   async scan(@Body() scanLinkDto: ScanLinkDto): Promise<ScanResultDto> {
     const result = await this.scamAlertsService.scanLink(scanLinkDto);

--- a/app/backend/src/stellar/stellar.controller.ts
+++ b/app/backend/src/stellar/stellar.controller.ts
@@ -14,6 +14,7 @@ import {
 import { ApiHeader, ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 
 import { ApiKeyGuard } from "../auth/guards/api-key.guard";
+import { RateLimitGroupTag } from "../auth/decorators/rate-limit-group.decorator";
 import { AssetMetadataService } from "../asset-metadata/asset-metadata.service";
 import { AssetListResponseDto } from "../asset-metadata/dto/asset-metadata.dto";
 import { AppConfigService } from "../config/app-config.service";
@@ -115,6 +116,7 @@ export class StellarController {
   }
 
   @Post("quote")
+  @RateLimitGroupTag("public_abuse")
   @HttpCode(HttpStatus.OK)
   @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
   @ApiOperation({
@@ -125,11 +127,13 @@ export class StellarController {
   })
   @ApiResponse({ status: 200, description: "Quote created", type: QuoteResponseDto })
   @ApiResponse({ status: 400, description: "No path found or invalid parameters" })
+  @ApiResponse({ status: 429, description: "Rate limit exceeded – retry after Retry-After seconds" })
   async createQuote(@Body() body: CreateQuoteDto): Promise<QuoteResponseDto> {
     return this.quoteService.createQuote(body);
   }
 
   @Get("quote/:quoteId")
+  @RateLimitGroupTag("public_abuse")
   @ApiOperation({
     summary: "Retrieve a quote by ID",
     description: "Returns the stored quote. Returns 410 Gone if the quote has expired.",
@@ -138,6 +142,7 @@ export class StellarController {
   @ApiResponse({ status: 200, description: "Quote details", type: QuoteResponseDto })
   @ApiResponse({ status: 404, description: "Quote not found" })
   @ApiResponse({ status: 410, description: "Quote expired" })
+  @ApiResponse({ status: 429, description: "Rate limit exceeded – retry after Retry-After seconds" })
   getQuote(@Param("quoteId") quoteId: string): QuoteResponseDto {
     return this.quoteService.getQuote(quoteId);
   }


### PR DESCRIPTION
## Summary

- Add a dedicated `public_abuse` rate-limit profile for abuse-sensitive public routes (`POST /stellar/quote`, `GET /stellar/quote/:id`, `POST /links/metadata`, `POST /links/scan`) with tighter testnet defaults (5 burst / 10s, 15 sustained / 60s).
- Wire per-IP and per-API-key throttling via the existing `CustomThrottlerGuard`, including an audited allowlist (`RATE_LIMIT_ALLOWLIST_IPS`, `RATE_LIMIT_ALLOWLIST_KEYS`) for CI and trusted contributors.
- Emit structured `rate_limit_exceeded` logs and `http_rate_limited_requests_total` Prometheus metrics when requests are blocked (single emission path; removed duplicate counter in the global exception filter).

Closes #507

## Test plan

- [x] `pnpm run type-check` in `app/backend`
- [x] `pnpm run build` in `app/backend`
- [x] `pnpm run lint` in `app/backend`
- [x] Unit tests for rate-limit config, allowlist config, and `CustomThrottlerGuard`