### PR TITLE
FE-37: Theme in app

### DIFF
--- a/app/frontend/src/app/[username]/page.tsx
+++ b/app/frontend/src/app/[username]/page.tsx
@@ -18,7 +18,7 @@ type Profile = {
 };
 
 const FOCUS_RING_CLASS =
-  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black";
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 export default function PublicProfile() {
   const params = useParams();
@@ -54,7 +54,7 @@ export default function PublicProfile() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center text-white">
+      <div className="min-h-screen flex items-center justify-center text-foreground">
         <p>Loading profile...</p>
       </div>
     );
@@ -62,10 +62,10 @@ export default function PublicProfile() {
 
   if (error || !profile) {
     return (
-      <div className="min-h-screen flex items-center justify-center text-white">
+      <div className="min-h-screen flex items-center justify-center text-foreground">
         <div className="text-center">
           <h1 className="text-4xl font-black mb-4">404</h1>
-          <p className="text-neutral-400">Username not found</p>
+          <p className="text-subtle">Username not found</p>
         </div>
       </div>
     );
@@ -74,7 +74,7 @@ export default function PublicProfile() {
   const primaryColor = profile.primaryColor || "#6366f1";
 
   return (
-    <div className="relative min-h-screen text-white">
+    <div className="relative min-h-screen text-foreground">
       <a
         href="#public-profile-main"
         className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-indigo-500 focus:px-3 focus:py-2 focus:text-sm focus:font-semibold focus:text-white"
@@ -123,7 +123,7 @@ export default function PublicProfile() {
 
           {/* Bio */}
           {profile.bio && (
-            <p className="text-neutral-300 text-lg mb-6 max-w-md mx-auto">
+            <p className="text-muted text-lg mb-6 max-w-md mx-auto">
               {profile.bio}
             </p>
           )}
@@ -137,7 +137,7 @@ export default function PublicProfile() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={`Open ${profile.twitterHandle} on X`}
-                  className={`w-12 h-12 rounded-full bg-white/5 hover:bg-white/10 flex items-center justify-center transition text-xl ${FOCUS_RING_CLASS}`}
+                  className={`w-12 h-12 rounded-full bg-surface hover:bg-surface-strong flex items-center justify-center transition text-xl ${FOCUS_RING_CLASS}`}
                   style={{ color: primaryColor }}
                 >
                   𝕏
@@ -145,7 +145,7 @@ export default function PublicProfile() {
               )}
               {profile.discordHandle && (
                 <div
-                  className="w-12 h-12 rounded-full bg-white/5 flex items-center justify-center text-xl"
+                  className="w-12 h-12 rounded-full bg-surface flex items-center justify-center text-xl"
                   style={{ color: primaryColor }}
                 >
                   💬
@@ -157,7 +157,7 @@ export default function PublicProfile() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={`Open ${profile.githubHandle} on GitHub`}
-                  className={`w-12 h-12 rounded-full bg-white/5 hover:bg-white/10 flex items-center justify-center transition text-xl ${FOCUS_RING_CLASS}`}
+                  className={`w-12 h-12 rounded-full bg-surface hover:bg-surface-strong flex items-center justify-center transition text-xl ${FOCUS_RING_CLASS}`}
                   style={{ color: primaryColor }}
                 >
                   🐙
@@ -168,12 +168,12 @@ export default function PublicProfile() {
         </div>
 
         {/* Payment Form */}
-        <div className="rounded-3xl bg-black/40 border border-white/5 backdrop-blur-2xl p-8 mb-8">
+        <div className="rounded-3xl bg-card border border-border backdrop-blur-2xl p-8 mb-8">
           <h2 className="text-2xl font-black mb-6">Send Payment</h2>
 
           <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
             <div>
-              <label htmlFor="payment-amount" className="block text-sm font-bold text-neutral-300 mb-2">
+              <label htmlFor="payment-amount" className="block text-sm font-bold text-muted mb-2">
                 Amount
               </label>
               <input
@@ -181,21 +181,21 @@ export default function PublicProfile() {
                 type="number"
                 value={paymentForm.amount}
                 onChange={(e) => setPaymentForm({ ...paymentForm, amount: e.target.value })}
-                className={`w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-lg ${FOCUS_RING_CLASS}`}
+                className={`w-full px-4 py-3 rounded-xl bg-surface border border-border-strong text-foreground text-lg ${FOCUS_RING_CLASS}`}
                 placeholder="0.00"
                 step="0.01"
               />
             </div>
 
             <div>
-              <label htmlFor="payment-asset" className="block text-sm font-bold text-neutral-300 mb-2">
+              <label htmlFor="payment-asset" className="block text-sm font-bold text-muted mb-2">
                 Asset
               </label>
               <select
                 id="payment-asset"
                 value={paymentForm.asset}
                 onChange={(e) => setPaymentForm({ ...paymentForm, asset: e.target.value })}
-                className={`w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white ${FOCUS_RING_CLASS}`}
+                className={`w-full px-4 py-3 rounded-xl bg-surface border border-border-strong text-foreground ${FOCUS_RING_CLASS}`}
               >
                 <option value="USDC">USDC</option>
                 <option value="XLM">XLM</option>
@@ -205,7 +205,7 @@ export default function PublicProfile() {
             </div>
 
             <div>
-              <label htmlFor="payment-memo" className="block text-sm font-bold text-neutral-300 mb-2">
+              <label htmlFor="payment-memo" className="block text-sm font-bold text-muted mb-2">
                 Memo (optional)
               </label>
               <input
@@ -213,7 +213,7 @@ export default function PublicProfile() {
                 type="text"
                 value={paymentForm.memo}
                 onChange={(e) => setPaymentForm({ ...paymentForm, memo: e.target.value })}
-                className={`w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white ${FOCUS_RING_CLASS}`}
+                className={`w-full px-4 py-3 rounded-xl bg-surface border border-border-strong text-foreground ${FOCUS_RING_CLASS}`}
                 placeholder="Payment for..."
                 maxLength={28}
               />
@@ -222,7 +222,7 @@ export default function PublicProfile() {
             <button
               type="submit"
               aria-label={`Generate payment link for ${profile.username}`}
-              className={`w-full py-4 rounded-xl font-bold text-white transition hover:opacity-90 mt-6 ${FOCUS_RING_CLASS}`}
+              className={`w-full py-4 rounded-xl font-bold text-foreground transition hover:opacity-90 mt-6 ${FOCUS_RING_CLASS}`}
               style={{ backgroundColor: primaryColor }}
             >
               Generate Payment Link
@@ -232,7 +232,7 @@ export default function PublicProfile() {
 
         {/* QR Code Preview */}
         {paymentForm.amount && (
-          <div className="rounded-3xl bg-black/40 border border-white/5 backdrop-blur-2xl p-8">
+          <div className="rounded-3xl bg-card border border-border backdrop-blur-2xl p-8">
             <h3 className="text-xl font-bold mb-4">Payment QR Code</h3>
             <QRPreview
               value={JSON.stringify({
@@ -246,7 +246,7 @@ export default function PublicProfile() {
         )}
 
         {/* Footer */}
-        <div className="text-center mt-12 text-neutral-400 text-sm">
+        <div className="text-center mt-12 text-subtle text-sm">
           <p>Powered by QuickEx • Stellar Network</p>
         </div>
       </main>

--- a/app/frontend/src/app/admin/layout.tsx
+++ b/app/frontend/src/app/admin/layout.tsx
@@ -14,10 +14,10 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
-      <header className="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
-        <h1 className="text-xl font-bold text-gray-800">Admin Console</h1>
-        <div className="text-sm bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium">Admin Active</div>
+    <div className="min-h-screen bg-background flex flex-col">
+      <header className="bg-card border-b border-border px-6 py-4 flex items-center justify-between">
+        <h1 className="text-xl font-bold text-foreground">Admin Console</h1>
+        <div className="text-sm bg-brand-soft text-brand px-3 py-1 rounded-full font-medium">Admin Active</div>
       </header>
       <main className="flex-1 p-6">
         {children}

--- a/app/frontend/src/app/dashboard/loading.tsx
+++ b/app/frontend/src/app/dashboard/loading.tsx
@@ -1,15 +1,15 @@
 export default function DashboardLoading() {
   return (
-    <div className="min-h-screen text-white selection:bg-indigo-500/30">
+    <div className="min-h-screen text-foreground selection:bg-indigo-500/30">
       <div className="space-y-10">
-        <div className="h-8 w-1/4 rounded-full bg-white/5 animate-pulse" />
+        <div className="h-8 w-1/4 rounded-full bg-surface animate-pulse" />
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {Array.from({ length: 3 }).map((_, idx) => (
-            <div key={idx} className="h-44 rounded-3xl bg-white/5 border border-white/5 animate-pulse" />
+            <div key={idx} className="h-44 rounded-3xl bg-surface border border-border animate-pulse" />
           ))}
         </div>
-        <div className="h-[420px] rounded-3xl bg-white/5 border border-white/5 animate-pulse" />
-        <div className="h-96 rounded-3xl bg-white/5 border border-white/5 animate-pulse" />
+        <div className="h-[420px] rounded-3xl bg-surface border border-border animate-pulse" />
+        <div className="h-96 rounded-3xl bg-surface border border-border animate-pulse" />
       </div>
     </div>
   );

--- a/app/frontend/src/app/dashboard/page.tsx
+++ b/app/frontend/src/app/dashboard/page.tsx
@@ -70,16 +70,16 @@ function toAnchorId(prefix: string, value: string) {
 function getStatusClasses(status: ActivityItem["status"]) {
   switch (status) {
     case "Pending":
-      return "text-amber-300";
+      return "text-warning";
     case "Settled":
-      return "text-emerald-300";
+      return "text-success";
     default:
-      return "text-indigo-200";
+      return "text-brand";
   }
 }
 
 const FOCUS_RING_CLASS =
-  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black";
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 function DashboardContent() {
   const searchParams = useSearchParams();
@@ -189,15 +189,15 @@ function DashboardContent() {
   };
 
   if (loading) {
-    return <p className="text-neutral-200">Loading dashboard...</p>;
+    return <p className="text-muted">Loading dashboard...</p>;
   }
 
   if (error) {
-    return <p className="text-red-300">{error}</p>;
+    return <p className="text-danger">{error}</p>;
   }
 
   return (
-    <div className="relative min-h-screen text-white">
+    <div className="relative min-h-screen text-foreground">
       <a
         href="#dashboard-main"
         className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-indigo-500 focus:px-3 focus:py-2 focus:text-sm focus:font-semibold focus:text-white"
@@ -209,30 +209,30 @@ function DashboardContent() {
       <div className="fixed left-[-30%] top-[-20%] h-[60%] w-[60%] rounded-full bg-indigo-500/10 blur-[120px]" />
       <div className="fixed bottom-[-20%] right-[-30%] h-[50%] w-[50%] rounded-full bg-purple-500/5 blur-[100px]" />
 
-      <aside className="fixed left-0 top-0 z-20 hidden h-screen w-72 flex-col border-r border-white/5 bg-black/20 backdrop-blur-3xl md:flex">
+      <aside className="fixed left-0 top-0 z-20 hidden h-screen w-72 flex-col border-r border-border bg-card backdrop-blur-3xl md:flex">
         <nav className="flex-1 space-y-2 px-4 py-20" aria-label="Dashboard navigation">
           <Link
             href="/dashboard"
             aria-current="page"
-            className={`flex items-center gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-3 font-semibold text-white ${FOCUS_RING_CLASS}`}
+            className={`flex items-center gap-3 rounded-2xl border border-border bg-surface px-4 py-3 font-semibold text-foreground ${FOCUS_RING_CLASS}`}
           >
             <span>Dashboard</span>
           </Link>
           <Link
             href="/generator"
-            className={`flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-neutral-200 transition hover:bg-white/5 hover:text-white ${FOCUS_RING_CLASS}`}
+            className={`flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-muted transition hover:bg-surface hover:text-foreground ${FOCUS_RING_CLASS}`}
           >
             <span>Link Generator</span>
           </Link>
           <Link
             href="/notifications"
-            className={`flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-neutral-200 transition hover:bg-white/5 hover:text-white ${FOCUS_RING_CLASS}`}
+            className={`flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-muted transition hover:bg-surface hover:text-foreground ${FOCUS_RING_CLASS}`}
           >
             <span>Notifications</span>
           </Link>
           <Link
             href="/settings"
-            className={`flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-neutral-200 transition hover:bg-white/5 hover:text-white ${FOCUS_RING_CLASS}`}
+            className={`flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-muted transition hover:bg-surface hover:text-foreground ${FOCUS_RING_CLASS}`}
           >
             <span>Profile Settings</span>
           </Link>
@@ -242,16 +242,16 @@ function DashboardContent() {
       <main id="dashboard-main" className="relative z-10 p-4 sm:p-6 md:ml-72 md:p-12">
         <header className="mb-10 flex flex-col gap-6 md:mb-16 md:flex-row md:items-start md:justify-between">
           <div>
-            <nav className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-neutral-400 md:mb-4">
+            <nav className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-subtle md:mb-4">
               <span>QuickEx</span>
               <span>/</span>
-              <span className="text-neutral-100">Dashboard</span>
+              <span className="text-foreground">Dashboard</span>
             </nav>
 
             <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
               Welcome back.
             </h1>
-            <p className="mt-2 text-sm font-medium text-neutral-200 sm:text-base md:text-lg">
+            <p className="mt-2 text-sm font-medium text-muted sm:text-base md:text-lg">
               Your payments, escrows, and action items all in one place.
             </p>
           </div>
@@ -259,7 +259,7 @@ function DashboardContent() {
           <div className="flex flex-wrap items-center gap-3">
             <Link
               href="/notifications"
-              className={`rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-neutral-100 transition hover:bg-white/10 ${FOCUS_RING_CLASS}`}
+              className={`rounded-xl border border-border-strong bg-surface px-4 py-3 text-sm font-semibold text-foreground transition hover:bg-surface-strong ${FOCUS_RING_CLASS}`}
               aria-label="Open notifications panel"
             >
               Open notifications
@@ -277,50 +277,50 @@ function DashboardContent() {
 
         <div className="mb-8 space-y-3">
           {spotlightMessage ? (
-            <p className="rounded-2xl border border-indigo-400/20 bg-indigo-500/10 px-4 py-3 text-sm text-indigo-50">
+            <p className="rounded-2xl border border-indigo-400/20 bg-indigo-500/10 px-4 py-3 text-sm text-brand">
               {spotlightMessage}
             </p>
           ) : null}
-          <p aria-live="polite" className="text-sm text-neutral-200">
+          <p aria-live="polite" className="text-sm text-muted">
             {statusMessage ??
               "Notifications can jump you directly into payments, active bids, and listing updates."}
           </p>
         </div>
 
         <section className="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2 md:mb-16 lg:grid-cols-3">
-          <div className="group relative overflow-hidden rounded-3xl border border-white/5 bg-neutral-900/40 p-6 transition hover:border-indigo-500/30">
+          <div className="group relative overflow-hidden rounded-3xl border border-border bg-card p-6 transition hover:border-indigo-500/30">
             <div className="absolute right-0 top-0 p-4 opacity-10 transition group-hover:opacity-20">
-              <span className="text-6xl font-semibold text-indigo-300">$</span>
+              <span className="text-6xl font-semibold text-brand">$</span>
             </div>
-            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-neutral-300">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-muted">
               Total Revenue
             </p>
             <div className="flex items-baseline gap-2">
-              <p className="text-4xl font-semibold text-white">$1,240.50</p>
-              <span className="rounded-full bg-emerald-400/10 px-2 py-1 text-xs font-semibold text-emerald-200">
+              <p className="text-4xl font-semibold text-foreground">$1,240.50</p>
+              <span className="rounded-full bg-emerald-400/10 px-2 py-1 text-xs font-semibold text-success">
                 +12.5%
               </span>
             </div>
           </div>
 
-          <div className="rounded-3xl border border-white/5 bg-neutral-900/40 p-6">
-            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-neutral-300">
+          <div className="rounded-3xl border border-border bg-card p-6">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-muted">
               Success Rate
             </p>
-            <p className="text-4xl font-semibold text-white">98.2%</p>
-            <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-neutral-800">
+            <p className="text-4xl font-semibold text-foreground">98.2%</p>
+            <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-surface-strong">
               <div className="h-full w-[98%] bg-indigo-400" />
             </div>
           </div>
 
-          <div className="rounded-3xl border border-indigo-300/50 bg-indigo-500 p-6 shadow-[0_20px_40px_-15px_rgba(99,102,241,0.3)]">
-            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-indigo-50/90">
+          <div className="rounded-3xl border border-indigo-300/50 bg-indigo-500 p-6 text-white shadow-[0_20px_40px_-15px_rgba(99,102,241,0.3)]">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-white/90">
               Available Payout
             </p>
             <p className="text-4xl font-semibold text-white">
               850.00 <span className="text-xl opacity-80">USDC</span>
             </p>
-            <p className="mt-3 text-xs text-indigo-50/90">
+            <p className="mt-3 text-xs text-white/90">
               Estimated settlement: 3 seconds
             </p>
           </div>
@@ -333,23 +333,23 @@ function DashboardContent() {
         <section
           id="dashboard-activity"
           tabIndex={-1}
-          className="overflow-hidden rounded-3xl border border-white/5 bg-black/40 shadow-2xl backdrop-blur-2xl"
+          className="overflow-hidden rounded-3xl border border-border bg-card shadow-2xl backdrop-blur-2xl"
         >
-          <div className="flex flex-col justify-between gap-4 border-b border-white/5 p-6 sm:flex-row sm:p-10">
+          <div className="flex flex-col justify-between gap-4 border-b border-border p-6 sm:flex-row sm:p-10">
             <div>
-              <h2 className="text-2xl font-semibold text-white">Activity Feed</h2>
-              <p className="mt-1 text-sm text-neutral-200">
+              <h2 className="text-2xl font-semibold text-foreground">Activity Feed</h2>
+              <p className="mt-1 text-sm text-muted">
                 Direct payment history, with actions and notification deep links.
               </p>
             </div>
 
-            <div className="rounded-xl border border-white/5 bg-white/5 p-2">
+            <div className="rounded-xl border border-border bg-surface p-2">
               <label htmlFor="dashboard-range" className="sr-only">
                 Filter activity period
               </label>
               <select
                 id="dashboard-range"
-                className={`bg-transparent text-sm font-semibold text-neutral-100 ${FOCUS_RING_CLASS}`}
+                className={`bg-transparent text-sm font-semibold text-foreground ${FOCUS_RING_CLASS}`}
                 defaultValue="Last 30 Days"
               >
                 <option>Last 30 Days</option>
@@ -365,7 +365,7 @@ function DashboardContent() {
                 completed records.
               </caption>
               <thead>
-                <tr className="border-b border-white/5 text-[10px] font-semibold uppercase tracking-[0.24em] text-neutral-300">
+                <tr className="border-b border-border text-[10px] font-semibold uppercase tracking-[0.24em] text-muted">
                   <th className="px-6 py-4 sm:px-10 sm:py-6">Transaction ID</th>
                   <th className="px-6 py-4 sm:px-10 sm:py-6">Asset</th>
                   <th className="px-6 py-4 sm:px-10 sm:py-6">Memo / Status</th>
@@ -376,7 +376,7 @@ function DashboardContent() {
                 </tr>
               </thead>
 
-              <tbody className="divide-y divide-white/5">
+              <tbody className="divide-y divide-border">
                 {(data?.items ?? []).map((item, index) => {
                   const isHighlighted = item.id === highlightedTransaction;
 
@@ -388,15 +388,15 @@ function DashboardContent() {
                       className={`transition ${
                         isHighlighted
                           ? "bg-indigo-500/10"
-                          : "hover:bg-white/[0.03]"
+                          : "hover:bg-surface"
                       }`}
                     >
                       <td className="px-6 py-6 sm:px-10">
                         <div className="flex items-center gap-3">
-                          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 font-mono text-[10px] opacity-70">
+                          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-surface font-mono text-[10px] opacity-70">
                             #{index + 1}
                           </span>
-                          <span className="font-mono text-sm text-neutral-100 sm:text-base">
+                          <span className="font-mono text-sm text-foreground sm:text-base">
                             {item.id}
                           </span>
                         </div>
@@ -406,7 +406,7 @@ function DashboardContent() {
                       </td>
                       <td className="px-6 py-6 sm:px-10">
                         <div className="flex flex-col">
-                          <span className="font-semibold text-neutral-100">
+                          <span className="font-semibold text-foreground">
                             {item.memo}
                           </span>
                           <div className="mt-1 flex items-center gap-2">
@@ -417,13 +417,13 @@ function DashboardContent() {
                             >
                               {item.status}
                             </span>
-                            <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-neutral-300">
+                            <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-muted">
                               Privacy {item.privacy}
                             </span>
                           </div>
                         </div>
                       </td>
-                      <td className="px-6 py-6 text-neutral-200 sm:px-10">
+                      <td className="px-6 py-6 text-muted sm:px-10">
                         {item.date}
                       </td>
                       <td className="px-6 py-6 text-right sm:px-10">
@@ -431,7 +431,7 @@ function DashboardContent() {
                           <button
                             type="button"
                             onClick={() => void handleExtend(item.id)}
-                            className={`rounded-full bg-indigo-500/10 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.24em] text-indigo-100 transition hover:bg-indigo-500 hover:text-white ${FOCUS_RING_CLASS}`}
+                            className={`rounded-full bg-indigo-500/10 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.24em] text-brand transition hover:bg-indigo-500 hover:text-white ${FOCUS_RING_CLASS}`}
                             aria-label={`Extend TTL for transaction ${item.id}`}
                           >
                             Extend TTL
@@ -440,7 +440,7 @@ function DashboardContent() {
                           <button
                             type="button"
                             onClick={() => void handleCleanup(item.id)}
-                            className={`rounded-full bg-red-500/10 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.24em] text-red-100 transition hover:bg-red-500 hover:text-white ${FOCUS_RING_CLASS}`}
+                            className={`rounded-full bg-red-500/10 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.24em] text-danger transition hover:bg-red-500 hover:text-white ${FOCUS_RING_CLASS}`}
                             aria-label={`Clean up transaction ${item.id}`}
                           >
                             Cleanup
@@ -454,42 +454,42 @@ function DashboardContent() {
             </table>
           </div>
 
-          <div className="bg-white/[0.01] p-6 text-center sm:p-8">
+          <div className="bg-surface p-6 text-center sm:p-8">
             <Link
               href="/notifications?category=payments"
-              className={`text-sm font-semibold text-neutral-200 transition hover:text-white ${FOCUS_RING_CLASS}`}
+              className={`text-sm font-semibold text-muted transition hover:text-foreground ${FOCUS_RING_CLASS}`}
             >
               View payment alerts
             </Link>
           </div>
         </section>
 
-        <section className="mt-10 overflow-hidden rounded-3xl border border-white/5 bg-black/40 shadow-2xl backdrop-blur-2xl md:mt-16">
-          <div className="flex flex-col items-start justify-between gap-4 border-b border-white/5 p-6 sm:flex-row sm:items-center sm:p-10">
+        <section className="mt-10 overflow-hidden rounded-3xl border border-border bg-card shadow-2xl backdrop-blur-2xl md:mt-16">
+          <div className="flex flex-col items-start justify-between gap-4 border-b border-border p-6 sm:flex-row sm:items-center sm:p-10">
             <div>
-              <h2 className="text-2xl font-semibold text-white">
+              <h2 className="text-2xl font-semibold text-foreground">
                 Escrow and Listing Activity
               </h2>
-              <p className="mt-1 text-sm text-neutral-200">
+              <p className="mt-1 text-sm text-muted">
                 Notifications here land on the exact bid or listing that needs
                 your attention.
               </p>
             </div>
             <Link
               href="/notifications?category=escrows"
-              className={`rounded-xl border border-indigo-300/40 bg-indigo-500/10 px-5 py-2.5 text-sm font-semibold text-indigo-100 transition hover:bg-indigo-500 hover:text-white ${FOCUS_RING_CLASS}`}
+              className={`rounded-xl border border-indigo-300/40 bg-indigo-500/10 px-5 py-2.5 text-sm font-semibold text-brand transition hover:bg-indigo-500 hover:text-white ${FOCUS_RING_CLASS}`}
             >
               Open escrow alerts
             </Link>
           </div>
 
-          <div className="grid divide-y divide-white/5 md:grid-cols-2 md:divide-x md:divide-y-0">
+          <div className="grid divide-y divide-border md:grid-cols-2 md:divide-x md:divide-y-0">
             <div id="dashboard-bids" tabIndex={-1} className="p-6 sm:p-8">
-              <h3 className="mb-5 text-sm font-semibold uppercase tracking-[0.24em] text-neutral-300">
+              <h3 className="mb-5 text-sm font-semibold uppercase tracking-[0.24em] text-muted">
                 My Active Bids
               </h3>
               {userBids.length === 0 ? (
-                <p className="text-sm text-neutral-200">No active bids yet.</p>
+                <p className="text-sm text-muted">No active bids yet.</p>
               ) : (
                 <div className="space-y-3">
                   {userBids.map((bid) => (
@@ -500,14 +500,14 @@ function DashboardContent() {
                       className={`flex items-center justify-between rounded-2xl border p-4 ${
                         bid.username === highlightedBid
                           ? "border-indigo-300/40 bg-indigo-500/10"
-                          : "border-white/5 bg-white/[0.03]"
+                          : "border-border bg-surface"
                       }`}
                     >
                       <div>
-                        <p className="text-base font-semibold text-white">
+                        <p className="text-base font-semibold text-foreground">
                           @{bid.username}
                         </p>
-                        <p className="text-[11px] text-neutral-200">
+                        <p className="text-[11px] text-muted">
                           My bid: {bid.myBid} USDC. Ends{" "}
                           {formatCountdown(bid.endsAt)}
                         </p>
@@ -515,8 +515,8 @@ function DashboardContent() {
                       <span
                         className={`rounded-full px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${
                           bid.isWinning
-                            ? "border border-emerald-300/40 bg-emerald-400/10 text-emerald-200"
-                            : "border border-red-300/40 bg-red-400/10 text-red-200"
+                            ? "border border-emerald-300/40 bg-emerald-400/10 text-success"
+                            : "border border-danger-soft/40 bg-red-400/10 text-danger"
                         }`}
                       >
                         {bid.isWinning ? "Winning" : "Outbid"}
@@ -528,11 +528,11 @@ function DashboardContent() {
             </div>
 
             <div id="dashboard-listings" tabIndex={-1} className="p-6 sm:p-8">
-              <h3 className="mb-5 text-sm font-semibold uppercase tracking-[0.24em] text-neutral-300">
+              <h3 className="mb-5 text-sm font-semibold uppercase tracking-[0.24em] text-muted">
                 My Listings
               </h3>
               {userListings.length === 0 ? (
-                <p className="text-sm text-neutral-200">
+                <p className="text-sm text-muted">
                   No usernames listed yet.
                 </p>
               ) : (
@@ -545,22 +545,22 @@ function DashboardContent() {
                       className={`rounded-2xl border p-4 ${
                         listing.username === highlightedListing
                           ? "border-indigo-300/40 bg-indigo-500/10"
-                          : "border-white/5 bg-white/[0.03]"
+                          : "border-border bg-surface"
                       }`}
                     >
                       <div className="mb-2 flex items-start justify-between">
-                        <p className="text-base font-semibold text-white">
+                        <p className="text-base font-semibold text-foreground">
                           @{listing.username}
                         </p>
-                        <span className="rounded-full border border-indigo-300/40 bg-indigo-400/10 px-2 py-1 text-[10px] font-semibold text-indigo-100">
+                        <span className="rounded-full border border-indigo-300/40 bg-indigo-400/10 px-2 py-1 text-[10px] font-semibold text-brand">
                           {listing.bidCount} bids
                         </span>
                       </div>
-                      <div className="flex justify-between text-[11px] text-neutral-200">
+                      <div className="flex justify-between text-[11px] text-muted">
                         <span>Current: {listing.currentBid} USDC</span>
                         <span>Ends: {formatCountdown(listing.endsAt)}</span>
                       </div>
-                      <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-white/5">
+                      <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-surface">
                         <div
                           className="h-full rounded-full bg-indigo-400"
                           style={{
@@ -586,7 +586,7 @@ function DashboardContent() {
 export default function Dashboard() {
   return (
     <Suspense
-      fallback={<p className="text-neutral-200">Loading dashboard...</p>}
+      fallback={<p className="text-muted">Loading dashboard...</p>}
     >
       <DashboardContent />
     </Suspense>

--- a/app/frontend/src/app/discovery/page.tsx
+++ b/app/frontend/src/app/discovery/page.tsx
@@ -22,22 +22,22 @@ export default function DiscoveryPage() {
 
   const UserCard = ({ user }: { user: User }) => (
     <Link href={`/profile/${user.username}`} className="block group">
-      <div className="p-6 rounded-3xl bg-neutral-900/40 border border-white/5 hover:border-indigo-500/30 hover:bg-neutral-900/80 transition-all h-full flex flex-col shadow-lg shadow-black/20 group-hover:shadow-indigo-500/10">
+      <div className="p-6 rounded-3xl bg-card border border-border hover:border-indigo-500/30 hover:bg-card/80 transition-all h-full flex flex-col shadow-lg shadow-black/20 group-hover:shadow-indigo-500/10">
         <div className="flex items-start justify-between mb-5">
           <div className={`w-14 h-14 rounded-2xl flex items-center justify-center font-bold text-2xl shadow-inner ${user.avatarColor}`}>
             {user.name.charAt(0)}
           </div>
           <div className="flex flex-col items-end">
-            <span className="text-xs font-semibold text-neutral-400 bg-black/50 px-3 py-1.5 rounded-full border border-white/5">
+            <span className="text-xs font-semibold text-subtle bg-background/50 px-3 py-1.5 rounded-full border border-border">
               {Number(user.followers).toLocaleString()} followers
             </span>
           </div>
         </div>
-        <h3 className="text-lg font-bold text-white group-hover:text-indigo-400 transition-colors">{user.name}</h3>
-        <p className="text-sm text-indigo-300/80 mb-4 tracking-tight">@{user.username}</p>
-        <p className="text-sm text-neutral-400 flex-1 leading-relaxed">{user.bio}</p>
+        <h3 className="text-lg font-bold text-foreground group-hover:text-indigo-400 transition-colors">{user.name}</h3>
+        <p className="text-sm text-brand/80 mb-4 tracking-tight">@{user.username}</p>
+        <p className="text-sm text-subtle flex-1 leading-relaxed">{user.bio}</p>
         
-        <div className="mt-6 pt-4 border-t border-white/5 flex items-center justify-between text-xs text-neutral-500 font-medium group-hover:text-indigo-400 transition-colors">
+        <div className="mt-6 pt-4 border-t border-border flex items-center justify-between text-xs text-subtle font-medium group-hover:text-indigo-400 transition-colors">
           <span>View Profile</span>
           <span>→</span>
         </div>
@@ -46,20 +46,20 @@ export default function DiscoveryPage() {
   );
 
   const SkeletonCard = () => (
-    <div className="p-6 rounded-3xl bg-neutral-900/20 border border-white/5 h-full flex flex-col animate-pulse">
+    <div className="p-6 rounded-3xl bg-card/20 border border-border h-full flex flex-col animate-pulse">
       <div className="flex items-start justify-between mb-5">
-        <div className="w-14 h-14 rounded-2xl bg-white/10"></div>
-        <div className="w-24 h-7 rounded-full bg-white/5"></div>
+        <div className="w-14 h-14 rounded-2xl bg-surface-strong"></div>
+        <div className="w-24 h-7 rounded-full bg-surface"></div>
       </div>
-      <div className="w-2/3 h-5 rounded bg-white/10 mb-2 mt-1"></div>
-      <div className="w-1/3 h-4 rounded bg-white/5 mb-5"></div>
-      <div className="w-full h-3 rounded bg-white/5 mb-2"></div>
-      <div className="w-4/5 h-3 rounded bg-white/5 mb-2"></div>
-      <div className="w-1/2 h-3 rounded bg-white/5"></div>
+      <div className="w-2/3 h-5 rounded bg-surface-strong mb-2 mt-1"></div>
+      <div className="w-1/3 h-4 rounded bg-surface mb-5"></div>
+      <div className="w-full h-3 rounded bg-surface mb-2"></div>
+      <div className="w-4/5 h-3 rounded bg-surface mb-2"></div>
+      <div className="w-1/2 h-3 rounded bg-surface"></div>
       
-      <div className="mt-auto pt-4 border-t border-white/5 flex items-center justify-between">
-        <div className="w-1/4 h-3 rounded bg-white/5"></div>
-        <div className="w-4 h-4 rounded bg-white/5"></div>
+      <div className="mt-auto pt-4 border-t border-border flex items-center justify-between">
+        <div className="w-1/4 h-3 rounded bg-surface"></div>
+        <div className="w-4 h-4 rounded bg-surface"></div>
       </div>
     </div>
   );
@@ -73,7 +73,7 @@ export default function DiscoveryPage() {
         <h1 className="text-5xl md:text-6xl font-black tracking-tighter">
           Discover <span className="text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-cyan-400">QuickEx</span>
         </h1>
-        <p className="text-xl text-neutral-400 leading-relaxed">
+        <p className="text-xl text-subtle leading-relaxed">
           Find public profiles, connect with trending creators, and effortlessly send payments to active members of the community.
         </p>
       </header>
@@ -110,17 +110,17 @@ export default function DiscoveryPage() {
 
       {/* Empty State / Join Community CTA */}
       {!isLoading && (
-        <section className="mt-32 p-12 rounded-3xl bg-gradient-to-br from-indigo-900/40 to-cyan-900/20 border border-white/10 text-center space-y-6 relative overflow-hidden shadow-2xl shadow-indigo-500/5 group hover:border-white/20 transition-all">
+        <section className="mt-32 p-12 rounded-3xl bg-gradient-to-br from-indigo-900/40 to-cyan-900/20 border border-border-strong text-center space-y-6 relative overflow-hidden shadow-2xl shadow-indigo-500/5 group hover:border-border-strong transition-all">
           <div className="absolute inset-0 bg-[url('https://grainy-gradients.vercel.app/noise.svg')] opacity-20 mix-blend-overlay pointer-events-none"></div>
           <div className="absolute top-0 right-0 w-64 h-64 bg-cyan-500/20 rounded-full blur-3xl -tralsate-y-1/2 translate-x-1/2"></div>
           <div className="absolute bottom-0 left-0 w-64 h-64 bg-indigo-500/20 rounded-full blur-3xl translate-y-1/2 -translate-x-1/2"></div>
           
           <h3 className="text-4xl font-bold relative z-10 tracking-tight">Want to get featured?</h3>
-          <p className="text-lg text-neutral-300 max-w-xl mx-auto relative z-10">
+          <p className="text-lg text-muted max-w-xl mx-auto relative z-10">
             Create your QuickEx profile, share your link, and start receiving payments to appear on the Discovery page.
           </p>
           <div className="relative z-10 pt-8">
-            <Link href="/generator" className="inline-block px-10 py-4 bg-white text-black font-bold rounded-2xl hover:bg-neutral-200 transition-all hover:scale-105 active:scale-95 shadow-xl shadow-white/10">
+            <Link href="/generator" className="inline-block px-10 py-4 bg-card text-foreground font-bold rounded-2xl hover:bg-surface-strong transition-all hover:scale-105 active:scale-95 shadow-xl shadow-white/10">
               Claim Your Username
             </Link>
           </div>

--- a/app/frontend/src/app/generator/page.tsx
+++ b/app/frontend/src/app/generator/page.tsx
@@ -59,7 +59,7 @@ type PathPreviewResponse = {
 const QUOTE_TTL_SECONDS = 25;
 const BASE_PATH_OPERATION_FEE_XLM = 0.00001;
 const FOCUS_RING_CLASS =
-  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black";
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 type LinkMetadataSuccess = {
   success: true;
@@ -849,7 +849,7 @@ export default function Generator() {
   };
 
   return (
-    <div className="relative min-h-screen text-white selection:bg-indigo-500/30 overflow-x-hidden">
+    <div className="relative min-h-screen text-foreground selection:bg-indigo-500/30 overflow-x-hidden">
       <a
         href="#generator-main"
         className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-indigo-500 focus:px-3 focus:py-2 focus:text-sm focus:font-semibold focus:text-white"
@@ -861,22 +861,22 @@ export default function Generator() {
       <div className="fixed top-[-20%] left-[-30%] w-[60%] h-[60%] bg-indigo-500/10 blur-[120px]" />
       <div className="fixed bottom-[-20%] right-[-30%] w-[50%] h-[50%] bg-purple-500/5 blur-[100px]" />
 
-      <aside className="hidden md:flex w-72 h-screen border-r border-white/5 bg-black/20 backdrop-blur-3xl flex-col fixed left-0 top-0 z-20">
+      <aside className="hidden md:flex w-72 h-screen border-r border-border bg-card backdrop-blur-3xl flex-col fixed left-0 top-0 z-20">
         <nav className="flex-1 px-4 py-20 space-y-2" aria-label="Generator navigation">
           <Link
             href="/dashboard"
-            className={`flex items-center gap-3 px-4 py-3 text-neutral-200 hover:text-white hover:bg-white/5 rounded-2xl font-semibold ${FOCUS_RING_CLASS}`}
+            className={`flex items-center gap-3 px-4 py-3 text-muted hover:text-foreground hover:bg-surface rounded-2xl font-semibold ${FOCUS_RING_CLASS}`}
           >
             <span aria-hidden="true">📊</span> {t('dashboard')}
           </Link>
           <Link
             href="/generator"
             aria-current="page"
-            className={`flex items-center gap-3 px-4 py-3 bg-white/5 text-white rounded-2xl font-bold border border-white/5 shadow-inner ${FOCUS_RING_CLASS}`}
+            className={`flex items-center gap-3 px-4 py-3 bg-surface text-foreground rounded-2xl font-bold border border-border shadow-inner ${FOCUS_RING_CLASS}`}
           >
             <span aria-hidden="true" className="text-indigo-400">⚡</span> {t('linkGenerator')}
           </Link>
-          <Link href="/settings" className={`flex items-center gap-3 px-4 py-3 text-neutral-200 hover:text-white hover:bg-white/5 rounded-2xl font-semibold ${FOCUS_RING_CLASS}`}>
+          <Link href="/settings" className={`flex items-center gap-3 px-4 py-3 text-muted hover:text-foreground hover:bg-surface rounded-2xl font-semibold ${FOCUS_RING_CLASS}`}>
             <span aria-hidden="true">⚙️</span> {t('profileSettings')}
           </Link>
         </nav>
@@ -886,11 +886,11 @@ export default function Generator() {
         <header className="mb-10 sm:mb-16 max-w-3xl">
           <nav
             aria-label="Breadcrumb"
-            className="flex items-center gap-2 text-xs font-black text-neutral-300 uppercase tracking-widest mb-4"
+            className="flex items-center gap-2 text-xs font-black text-muted uppercase tracking-widest mb-4"
           >
             <span>{t('services')}</span>
             <span aria-hidden="true">/</span>
-            <span className="text-neutral-100">{t('linkGenerator')}</span>
+            <span className="text-foreground">{t('linkGenerator')}</span>
           </nav>
 
           <h1 className="text-4xl sm:text-5xl md:text-6xl font-black tracking-tight mb-4">
@@ -900,7 +900,7 @@ export default function Generator() {
             </span>
           </h1>
 
-          <p className="text-neutral-300 text-lg max-w-xl">
+          <p className="text-muted text-lg max-w-xl">
             {t('advancedModeDescription')}
           </p>
         </header>
@@ -909,14 +909,14 @@ export default function Generator() {
           <div className="space-y-12">
             <section className="space-y-6">
               <div>
-                <label htmlFor="generator-amount" className="text-xs font-black uppercase tracking-widest text-neutral-300 ml-1">
+                <label htmlFor="generator-amount" className="text-xs font-black uppercase tracking-widest text-muted ml-1">
                   {t('amountLabel')}
                 </label>
 
                 <div className="relative group mt-2">
                   <div className="absolute -inset-0.5 bg-gradient-to-r from-indigo-500/20 to-purple-500/20 rounded-3xl blur opacity-0 group-focus-within:opacity-100 transition" />
 
-                  <div className="relative bg-neutral-900/50 border border-white/10 rounded-3xl p-1 shadow-2xl">
+                  <div className="relative bg-card/50 border border-border-strong rounded-3xl p-1 shadow-2xl">
                     <input
                       id="generator-amount"
                       type="number"
@@ -927,12 +927,12 @@ export default function Generator() {
                       }
                       aria-invalid={Boolean(errors.amount)}
                       aria-describedby={errors.amount ? "generator-amount-error" : undefined}
-                      className={`w-full bg-transparent p-6 sm:p-8 text-3xl sm:text-5xl font-black placeholder:text-neutral-500 ${FOCUS_RING_CLASS}`}
+                      className={`w-full bg-transparent p-6 sm:p-8 text-3xl sm:text-5xl font-black placeholder:text-subtle ${FOCUS_RING_CLASS}`}
                     />
 
-                    <div className="absolute right-4 top-1/2 -translate-y-1/2 flex bg-black/40 p-2 rounded-2xl border border-white/5 backdrop-blur-xl gap-1 max-w-[50%] flex-wrap justify-end">
+                    <div className="absolute right-4 top-1/2 -translate-y-1/2 flex bg-card p-2 rounded-2xl border border-border backdrop-blur-xl gap-1 max-w-[50%] flex-wrap justify-end">
                       {assetsLoading ? (
-                        <span className="px-3 py-2 text-xs text-neutral-500">
+                        <span className="px-3 py-2 text-xs text-subtle">
                           {t('loadingAssets')}
                         </span>
                       ) : (
@@ -947,8 +947,8 @@ export default function Generator() {
                             px-3 py-2 text-xs sm:text-sm rounded-xl transition ${FOCUS_RING_CLASS}
                             ${
                               recipientAssetCode === a.code
-                                ? "bg-white text-black font-black"
-                                : "text-neutral-300 hover:text-white"
+                                ? "bg-card text-foreground font-black"
+                                : "text-muted hover:text-foreground"
                             }
                           `}
                           >
@@ -969,7 +969,7 @@ export default function Generator() {
               </div>
 
               <div>
-                <label htmlFor="generator-destination" className="text-xs font-black uppercase tracking-widest text-neutral-300 ml-1">
+                <label htmlFor="generator-destination" className="text-xs font-black uppercase tracking-widest text-muted ml-1">
                   {t('destinationLabel')}
                 </label>
                 <input
@@ -982,7 +982,7 @@ export default function Generator() {
                   }
                   aria-invalid={Boolean(errors.destination)}
                   aria-describedby={errors.destination ? "generator-destination-error" : undefined}
-                  className={`w-full bg-neutral-900/30 border border-white/10 rounded-3xl p-5 font-bold mt-2 placeholder:text-neutral-400 ${FOCUS_RING_CLASS}`}
+                  className={`w-full bg-card/30 border border-border-strong rounded-3xl p-5 font-bold mt-2 placeholder:text-subtle ${FOCUS_RING_CLASS}`}
                 />
                 {errors.destination && (
                   <p id="generator-destination-error" role="alert" className="text-red-400 text-xs mt-2">
@@ -992,7 +992,7 @@ export default function Generator() {
               </div>
 
               <div>
-                <label htmlFor="generator-memo" className="text-xs font-black uppercase tracking-widest text-neutral-300 ml-1">
+                <label htmlFor="generator-memo" className="text-xs font-black uppercase tracking-widest text-muted ml-1">
                   {t('memoLabel')}
                 </label>
                 <input
@@ -1001,11 +1001,11 @@ export default function Generator() {
                   placeholder={t('memoPlaceholder')}
                   value={form.memo}
                   onChange={(e) => setForm({ ...form, memo: e.target.value })}
-                  className={`w-full bg-neutral-900/30 border border-white/10 rounded-3xl p-5 font-bold mt-2 placeholder:text-neutral-400 ${FOCUS_RING_CLASS}`}
+                  className={`w-full bg-card/30 border border-border-strong rounded-3xl p-5 font-bold mt-2 placeholder:text-subtle ${FOCUS_RING_CLASS}`}
                 />
               </div>
 
-              <div className="rounded-3xl border border-white/10 bg-black/30 p-6 space-y-4">
+              <div className="rounded-3xl border border-border-strong bg-background/30 p-6 space-y-4">
                 <button
                   type="button"
                   onClick={() => setAdvancedOpen((v) => !v)}
@@ -1013,21 +1013,21 @@ export default function Generator() {
                   aria-controls="generator-advanced-panel"
                   className={`flex w-full items-center justify-between text-left ${FOCUS_RING_CLASS}`}
                 >
-                  <span className="text-sm font-black uppercase tracking-widest text-indigo-300">
+                  <span className="text-sm font-black uppercase tracking-widest text-brand">
                     {t('advancedSettings')}
                   </span>
-                  <span className="text-neutral-300 text-sm">
+                  <span className="text-muted text-sm">
                     {advancedOpen ? t('hide') : t('show')} path payments
                   </span>
                 </button>
 
                 {advancedOpen && (
-                  <div id="generator-advanced-panel" className="space-y-6 pt-2 border-t border-white/5">
+                  <div id="generator-advanced-panel" className="space-y-6 pt-2 border-t border-border">
                     <div>
-                      <label htmlFor="generator-recipient-asset" className="text-xs font-bold uppercase tracking-wider text-neutral-300 mb-2 block">
+                      <label htmlFor="generator-recipient-asset" className="text-xs font-bold uppercase tracking-wider text-muted mb-2 block">
                         {t('recipientAsset')}
                       </label>
-                      <p className="text-sm text-neutral-300 mb-3">
+                      <p className="text-sm text-muted mb-3">
                         {t('recipientAssetDescription')}
                       </p>
                       <select
@@ -1036,7 +1036,7 @@ export default function Generator() {
                         onChange={(e) =>
                           setRecipientAssetCode(e.target.value)
                         }
-                        className={`w-full bg-neutral-900 border border-white/10 rounded-2xl p-4 font-bold ${FOCUS_RING_CLASS}`}
+                        className={`w-full bg-card border border-border-strong rounded-2xl p-4 font-bold ${FOCUS_RING_CLASS}`}
                       >
                         {verifiedAssets.map((a) => (
                           <option key={a.code} value={a.code}>
@@ -1055,10 +1055,10 @@ export default function Generator() {
                     </div>
 
                     <div>
-                      <p className="text-xs font-bold uppercase tracking-wider text-neutral-300 mb-2">
+                      <p className="text-xs font-bold uppercase tracking-wider text-muted mb-2">
                         {t('allowedSourceAssets')}
                       </p>
-                      <p className="text-sm text-neutral-300 mb-3">
+                      <p className="text-sm text-muted mb-3">
                         {t('allowedSourceAssetsDescription')}
                       </p>
                       <div className="flex flex-wrap gap-2">
@@ -1073,7 +1073,7 @@ export default function Generator() {
                               className={`px-4 py-2 rounded-xl text-sm font-bold border transition ${
                                 on
                                   ? "bg-indigo-500/30 border-indigo-400/50 text-white"
-                                  : `bg-neutral-900/50 border-white/10 text-neutral-300 hover:text-white ${FOCUS_RING_CLASS}`
+                                  : `bg-card/50 border-border-strong text-muted hover:text-foreground ${FOCUS_RING_CLASS}`
                               }`}
                             >
                               {a.code}
@@ -1083,16 +1083,16 @@ export default function Generator() {
                       </div>
                     </div>
 
-                    <div className="rounded-2xl border border-white/10 bg-neutral-950/60 p-4 space-y-3">
+                    <div className="rounded-2xl border border-border-strong bg-background/60 p-4 space-y-3">
                       <div className="flex items-center justify-between">
-                        <h3 className="text-xs font-black uppercase tracking-widest text-neutral-300">
+                        <h3 className="text-xs font-black uppercase tracking-widest text-muted">
                           {t('pathPreview')}
                         </h3>
                         <div className="flex items-center gap-3">
                           {quoteSecondsRemaining !== null && (
                             <span
                               className={`text-xs font-mono ${
-                                quoteExpired ? "text-amber-300" : "text-emerald-300"
+                                quoteExpired ? "text-warning" : "text-success"
                               }`}
                             >
                               {quoteExpired
@@ -1104,7 +1104,7 @@ export default function Generator() {
                             type="button"
                             onClick={() => void fetchPathPreview()}
                             disabled={pathLoading}
-                            className={`text-xs px-2 py-1 rounded-md border border-white/10 text-neutral-200 hover:text-white hover:bg-white/5 disabled:opacity-50 ${FOCUS_RING_CLASS}`}
+                            className={`text-xs px-2 py-1 rounded-md border border-border-strong text-muted hover:text-foreground hover:bg-surface disabled:opacity-50 ${FOCUS_RING_CLASS}`}
                           >
                             {pathLoading ? t('fetchingEstimates') : t('refreshQuote')}
                           </button>
@@ -1115,7 +1115,7 @@ export default function Generator() {
                           className={`text-xs ${
                             slippageWarningLevel === "block"
                               ? "text-red-400"
-                              : "text-amber-300"
+                              : "text-warning"
                           }`}
                         >
                           {slippageWarningText}
@@ -1134,12 +1134,12 @@ export default function Generator() {
                         !pathError &&
                         pathData &&
                         pathData.paths.length === 0 && (
-                          <p className="text-neutral-300 text-sm">
+                          <p className="text-muted text-sm">
                             {t('noPathsFound', { horizonUrl: pathData.horizonUrl })}
                           </p>
                         )}
                       {!pathLoading && !pathError && !pathData && (
-                        <p className="text-neutral-300 text-xs">
+                        <p className="text-muted text-xs">
                           {t('pathPreviewHint')}
                         </p>
                       )}
@@ -1148,9 +1148,9 @@ export default function Generator() {
                           {pathData.paths.map((p, i) => (
                             <li
                               key={`${p.sourceAsset}-${i}`}
-                              className="rounded-xl bg-black/40 border border-white/5 p-3 text-sm"
+                              className="rounded-xl bg-card border border-border p-3 text-sm"
                             >
-                              <div className="font-mono text-neutral-300">
+                              <div className="font-mono text-muted">
                                 {t('payReceive', {
                                   sourceAmount: p.sourceAmount,
                                   sourceAsset: p.sourceAsset,
@@ -1158,23 +1158,23 @@ export default function Generator() {
                                   destinationAsset: p.destinationAsset
                                 })}
                               </div>
-                              <div className="text-xs text-neutral-300 mt-1">
+                              <div className="text-xs text-muted mt-1">
                                 {t('hops', { hopCount: p.hopCount })}
                                 {p.pathHops.length > 0
                                   ? ` · ${p.pathHops.join(" → ")}`
                                   : ""}
                               </div>
-                              <div className="text-xs text-neutral-400 mt-1">
+                              <div className="text-xs text-subtle mt-1">
                                 {p.rateDescription}
                               </div>
-                              <div className="mt-2 rounded-lg border border-white/5 bg-white/[0.02] p-2 space-y-1">
-                                <p className="text-[11px] uppercase tracking-wide text-neutral-300 font-semibold">
+                              <div className="mt-2 rounded-lg border border-border bg-card/[0.02] p-2 space-y-1">
+                                <p className="text-[11px] uppercase tracking-wide text-muted font-semibold">
                                   {t('pathBreakdown')}
                                 </p>
                                 {getPathLegs(p).map((leg) => (
                                   <div
                                     key={`${leg.poolLabel}-${leg.fromAsset}-${leg.toAsset}`}
-                                    className="flex items-center justify-between text-xs text-neutral-300"
+                                    className="flex items-center justify-between text-xs text-muted"
                                   >
                                     <span>{leg.poolLabel}</span>
                                     <span className="font-mono">
@@ -1182,7 +1182,7 @@ export default function Generator() {
                                     </span>
                                   </div>
                                 ))}
-                                <p className="text-xs text-neutral-300">
+                                <p className="text-xs text-muted">
                                   {t('estimatedNetworkFee', {
                                     fee: ((p.hopCount + 1) * BASE_PATH_OPERATION_FEE_XLM).toFixed(5),
                                   })}
@@ -1194,16 +1194,16 @@ export default function Generator() {
                       )}
                     </div>
 
-                    <div className="rounded-2xl border border-white/10 bg-neutral-950/60 p-4 space-y-3">
+                    <div className="rounded-2xl border border-border-strong bg-background/60 p-4 space-y-3">
                       <div className="flex items-center justify-between">
-                        <h3 className="text-xs font-black uppercase tracking-widest text-neutral-300">
+                        <h3 className="text-xs font-black uppercase tracking-widest text-muted">
                           {t('slippageTolerance')}
                         </h3>
-                        <span className="text-sm font-mono text-neutral-200">
+                        <span className="text-sm font-mono text-muted">
                           {slippageValue.toFixed(2)}%
                         </span>
                       </div>
-                      <p className="text-xs text-neutral-300">
+                      <p className="text-xs text-muted">
                         {t('slippageDescription')}
                       </p>
                       <input
@@ -1224,8 +1224,8 @@ export default function Generator() {
                             onClick={() => setSlippagePct(preset)}
                             className={`px-3 py-1 text-xs rounded-lg border ${
                               slippagePct === preset
-                                ? "border-indigo-400/60 text-indigo-200 bg-indigo-500/10"
-                                : `border-white/10 text-neutral-200 ${FOCUS_RING_CLASS}`
+                                ? "border-indigo-400/60 text-brand bg-indigo-500/10"
+                                : `border-border-strong text-muted ${FOCUS_RING_CLASS}`
                             }`}
                           >
                             {preset}%
@@ -1234,11 +1234,11 @@ export default function Generator() {
                       </div>
                     </div>
 
-                    <div className="rounded-2xl border border-white/10 bg-neutral-950/60 p-4 space-y-3">
-                      <h3 className="text-xs font-black uppercase tracking-widest text-neutral-300">
+                    <div className="rounded-2xl border border-border-strong bg-background/60 p-4 space-y-3">
+                      <h3 className="text-xs font-black uppercase tracking-widest text-muted">
                         {t('sorobanPreflight')}
                       </h3>
-                      <p className="text-xs text-neutral-300">
+                      <p className="text-xs text-muted">
                         {t('sorobanPreflightDescription')}
                       </p>
                       <input
@@ -1246,13 +1246,13 @@ export default function Generator() {
                         placeholder={t('sourceAccountPlaceholder')}
                         value={preflightAccount}
                         onChange={(e) => setPreflightAccount(e.target.value)}
-                        className={`w-full bg-neutral-900/80 border border-white/10 rounded-xl p-3 font-mono text-sm ${FOCUS_RING_CLASS}`}
+                        className={`w-full bg-card/80 border border-border-strong rounded-xl p-3 font-mono text-sm ${FOCUS_RING_CLASS}`}
                       />
                       <button
                         type="button"
                         onClick={() => void runPreflight()}
                         disabled={preflightLoading}
-                        className={`w-full py-3 rounded-xl bg-white/10 hover:bg-white/15 border border-white/10 text-sm font-bold disabled:opacity-50 ${FOCUS_RING_CLASS}`}
+                        className={`w-full py-3 rounded-xl bg-surface-strong hover:bg-card/15 border border-border-strong text-sm font-bold disabled:opacity-50 ${FOCUS_RING_CLASS}`}
                       >
                         {preflightLoading
                           ? t('simulating')
@@ -1274,13 +1274,13 @@ export default function Generator() {
                         <div className="text-sm text-emerald-400 space-y-1">
                           <p>{t('simulationOk')}</p>
                           {preflightResult.feeEstimate?.totalFeeXLM && (
-                            <p className="font-mono text-neutral-300">
+                            <p className="font-mono text-muted">
                               {t('totalFee', { totalFee: preflightResult.feeEstimate.totalFeeXLM })}
                             </p>
                           )}
                           {typeof preflightResult.simulationLatencyMs ===
                             "number" && (
-                            <p className="text-xs text-neutral-500">
+                            <p className="text-xs text-subtle">
                               {t('latency', { latency: preflightResult.simulationLatencyMs })}
                             </p>
                           )}
@@ -1296,7 +1296,7 @@ export default function Generator() {
               type="button"
               onClick={handleSubmit}
               disabled={loading}
-              className={`w-full py-6 bg-white text-black text-3xl font-black rounded-3xl hover:bg-neutral-200 active:scale-95 transition disabled:opacity-60 ${FOCUS_RING_CLASS}`}
+              className={`w-full py-6 bg-card text-foreground text-3xl font-black rounded-3xl hover:bg-surface-strong active:scale-95 transition disabled:opacity-60 ${FOCUS_RING_CLASS}`}
             >
               {loading ? "Generating…" : "Generate Payment Link"}
             </button>
@@ -1310,14 +1310,14 @@ export default function Generator() {
               <QRPreview value={linkData} />
             </div>
 
-            <div className="space-y-4 p-8 rounded-3xl bg-black/40 border border-white/5 backdrop-blur-xl">
-              <label className="text-[10px] font-black uppercase tracking-widest text-neutral-300">
+            <div className="space-y-4 p-8 rounded-3xl bg-card border border-border backdrop-blur-xl">
+              <label className="text-[10px] font-black uppercase tracking-widest text-muted">
                 Canonical query (from API)
               </label>
 
-              <div className="bg-neutral-900 border border-white/5 p-4 rounded-xl font-mono text-neutral-200 text-xs break-all min-h-[3rem]">
+              <div className="bg-card border border-border p-4 rounded-xl font-mono text-muted text-xs break-all min-h-[3rem]">
                 {canonicalPreview ?? (
-                  <span className="text-neutral-400 italic">
+                  <span className="text-subtle italic">
                     Generate to fetch metadata from the backend.
                   </span>
                 )}
@@ -1332,7 +1332,7 @@ export default function Generator() {
                   }
                 }}
                 aria-label="Copy canonical query parameters"
-                className={`w-full py-3 bg-white/10 text-white rounded-xl border border-white/5 text-xs uppercase tracking-widest hover:bg-white/15 disabled:opacity-40 disabled:cursor-not-allowed ${FOCUS_RING_CLASS}`}
+                className={`w-full py-3 bg-surface-strong text-foreground rounded-xl border border-border text-xs uppercase tracking-widest hover:bg-card/15 disabled:opacity-40 disabled:cursor-not-allowed ${FOCUS_RING_CLASS}`}
               >
                 Copy canonical params
               </button>
@@ -1343,36 +1343,36 @@ export default function Generator() {
         <section className="mt-20 max-w-7xl space-y-8">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <p className="text-xs font-black uppercase tracking-widest text-indigo-300">
+              <p className="text-xs font-black uppercase tracking-widest text-brand">
                 Bulk Invoicing v2
               </p>
-              <h2 className="text-3xl font-black text-white mt-2">
+              <h2 className="text-3xl font-black text-foreground mt-2">
                 Templates, saved customers, and preview before generation
               </h2>
-              <p className="text-neutral-400 mt-3 max-w-3xl">
+              <p className="text-subtle mt-3 max-w-3xl">
                 Reuse one invoice template across your customer directory, then generate the final payment links from the same preview payload.
               </p>
             </div>
             <button
               type="button"
               onClick={() => setBulkResult(null)}
-              className={`rounded-xl border border-white/10 px-4 py-2 text-sm font-semibold text-neutral-200 hover:bg-white/5 ${FOCUS_RING_CLASS}`}
+              className={`rounded-xl border border-border-strong px-4 py-2 text-sm font-semibold text-muted hover:bg-surface ${FOCUS_RING_CLASS}`}
             >
               Clear generated results
             </button>
           </div>
 
-          <div className="rounded-3xl border border-white/10 bg-black/30 p-6 md:p-8">
+          <div className="rounded-3xl border border-border-strong bg-background/30 p-6 md:p-8">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
               <div>
-                <p className="text-xs font-black uppercase tracking-widest text-emerald-300">
+                <p className="text-xs font-black uppercase tracking-widest text-success">
                   CSV Batch Uploader
                 </p>
-                <h3 className="mt-2 text-2xl font-black text-white">
+                <h3 className="mt-2 text-2xl font-black text-foreground">
                   Drag in a customer invoice CSV, review each row, then generate links in one batch
                 </h3>
-                <p className="mt-3 max-w-3xl text-sm text-neutral-400">
-                  Accepted columns: <span className="font-mono text-neutral-300">amount, asset, memo, referenceId, username, destination, acceptedAssets, customerName, email</span>.
+                <p className="mt-3 max-w-3xl text-sm text-subtle">
+                  Accepted columns: <span className="font-mono text-muted">amount, asset, memo, referenceId, username, destination, acceptedAssets, customerName, email</span>.
                   Each row needs a positive amount and either a QuickEx username or a Stellar destination.
                 </p>
               </div>
@@ -1392,14 +1392,14 @@ export default function Generator() {
                 <button
                   type="button"
                   onClick={() => csvInputRef.current?.click()}
-                  className={`rounded-2xl border border-white/10 px-4 py-3 text-sm font-semibold text-neutral-100 hover:bg-white/5 ${FOCUS_RING_CLASS}`}
+                  className={`rounded-2xl border border-border-strong px-4 py-3 text-sm font-semibold text-foreground hover:bg-surface ${FOCUS_RING_CLASS}`}
                 >
                   Choose CSV
                 </button>
                 <button
                   type="button"
                   onClick={resetCsvReview}
-                  className={`rounded-2xl border border-white/10 px-4 py-3 text-sm font-semibold text-neutral-300 hover:bg-white/5 ${FOCUS_RING_CLASS}`}
+                  className={`rounded-2xl border border-border-strong px-4 py-3 text-sm font-semibold text-muted hover:bg-surface ${FOCUS_RING_CLASS}`}
                 >
                   Clear CSV
                 </button>
@@ -1440,23 +1440,23 @@ export default function Generator() {
               }}
               className={`mt-6 rounded-[28px] border border-dashed px-6 py-10 text-center transition ${
                 csvDragActive
-                  ? "border-emerald-400 bg-emerald-500/10"
-                  : "border-white/15 bg-neutral-950/40 hover:border-white/25 hover:bg-white/[0.03]"
+                  ? "border-emerald-400 bg-success-soft"
+                  : "border-white/15 bg-background/40 hover:border-white/25 hover:bg-surface"
               }`}
             >
-              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-white/5 text-2xl">
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-surface text-2xl">
                 📄
               </div>
-              <p className="mt-4 text-lg font-bold text-white">
+              <p className="mt-4 text-lg font-bold text-foreground">
                 {csvFileName ? `Loaded ${csvFileName}` : "Drop a CSV here or click to upload"}
               </p>
-              <p className="mt-2 text-sm text-neutral-400">
+              <p className="mt-2 text-sm text-subtle">
                 We parse the file in-browser first so you can fix invalid amounts, addresses, or routing before submission.
               </p>
             </div>
 
             {csvFileErrors.length > 0 && (
-              <div className="mt-4 rounded-2xl border border-amber-300/20 bg-amber-500/10 p-4 text-sm text-amber-100">
+              <div className="mt-4 rounded-2xl border border-amber-300/20 bg-warning-soft p-4 text-sm text-warning">
                 {csvFileErrors.map((message) => (
                   <p key={message}>{message}</p>
                 ))}
@@ -1467,8 +1467,8 @@ export default function Generator() {
               <div className="mt-8 space-y-5">
                 <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                   <div>
-                    <h4 className="text-xl font-bold text-white">Review table</h4>
-                    <p className="text-sm text-neutral-400">
+                    <h4 className="text-xl font-bold text-foreground">Review table</h4>
+                    <p className="text-sm text-subtle">
                       {validCsvRows.length} of {csvRows.length} rows are valid for generation.
                     </p>
                   </div>
@@ -1483,12 +1483,12 @@ export default function Generator() {
                 </div>
 
                 {bulkLoading && bulkSource === "csv" && (
-                  <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4">
-                    <div className="flex items-center justify-between text-sm font-semibold text-emerald-100">
+                  <div className="rounded-2xl border border-emerald-400/20 bg-success-soft p-4">
+                    <div className="flex items-center justify-between text-sm font-semibold text-success">
                       <span>Processing batch invoices</span>
                       <span>{bulkProgress}%</span>
                     </div>
-                    <div className="mt-3 h-2 overflow-hidden rounded-full bg-black/30">
+                    <div className="mt-3 h-2 overflow-hidden rounded-full bg-background/30">
                       <div
                         className="h-full rounded-full bg-emerald-300 transition-all duration-300"
                         style={{ width: `${bulkProgress}%` }}
@@ -1503,23 +1503,23 @@ export default function Generator() {
                       key={row.id}
                       className={`rounded-3xl border p-4 ${
                         row.errors.length === 0
-                          ? "border-white/10 bg-neutral-950/50"
-                          : "border-amber-400/40 bg-amber-500/10"
+                          ? "border-border-strong bg-background/50"
+                          : "border-amber-400/40 bg-warning-soft"
                       }`}
                     >
                       <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                         <div>
-                          <p className="text-sm font-semibold text-white">
+                          <p className="text-sm font-semibold text-foreground">
                             Row {index + 1} {row.customerName ? `• ${row.customerName}` : ""}
                           </p>
-                          <p className="text-xs text-neutral-500">
+                          <p className="text-xs text-subtle">
                             {row.email || "No email supplied"} {row.referenceId ? `• ${row.referenceId}` : ""}
                           </p>
                         </div>
                         <button
                           type="button"
                           onClick={() => removeCsvRow(row.id)}
-                          className={`rounded-xl border border-red-500/25 px-3 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/10 ${FOCUS_RING_CLASS}`}
+                          className={`rounded-xl border border-red-500/25 px-3 py-2 text-xs font-semibold text-danger hover:bg-red-500/10 ${FOCUS_RING_CLASS}`}
                         >
                           Delete row
                         </button>
@@ -1531,61 +1531,61 @@ export default function Generator() {
                           value={row.amount}
                           onChange={(event) => updateCsvRow(row.id, "amount", event.target.value)}
                           placeholder="Amount"
-                          className={`rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                          className={`rounded-2xl border border-border-strong bg-background/30 px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                         />
                         <input
                           type="text"
                           value={row.asset}
                           onChange={(event) => updateCsvRow(row.id, "asset", event.target.value)}
                           placeholder="Asset"
-                          className={`rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                          className={`rounded-2xl border border-border-strong bg-background/30 px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                         />
                         <input
                           type="text"
                           value={row.username}
                           onChange={(event) => updateCsvRow(row.id, "username", event.target.value)}
                           placeholder="QuickEx username"
-                          className={`rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                          className={`rounded-2xl border border-border-strong bg-background/30 px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                         />
                         <input
                           type="text"
                           value={row.destination}
                           onChange={(event) => updateCsvRow(row.id, "destination", event.target.value)}
                           placeholder="Stellar destination"
-                          className={`rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                          className={`rounded-2xl border border-border-strong bg-background/30 px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                         />
                         <input
                           type="text"
                           value={row.memo}
                           onChange={(event) => updateCsvRow(row.id, "memo", event.target.value)}
                           placeholder="Memo"
-                          className={`rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                          className={`rounded-2xl border border-border-strong bg-background/30 px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                         />
                         <input
                           type="text"
                           value={row.referenceId}
                           onChange={(event) => updateCsvRow(row.id, "referenceId", event.target.value)}
                           placeholder="Reference ID"
-                          className={`rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                          className={`rounded-2xl border border-border-strong bg-background/30 px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                         />
                         <input
                           type="text"
                           value={row.customerName}
                           onChange={(event) => updateCsvRow(row.id, "customerName", event.target.value)}
                           placeholder="Customer name"
-                          className={`rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                          className={`rounded-2xl border border-border-strong bg-background/30 px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                         />
                         <input
                           type="text"
                           value={row.acceptedAssets}
                           onChange={(event) => updateCsvRow(row.id, "acceptedAssets", event.target.value)}
                           placeholder="Accepted assets (XLM|USDC)"
-                          className={`rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                          className={`rounded-2xl border border-border-strong bg-background/30 px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                         />
                       </div>
 
                       {row.errors.length > 0 && (
-                        <div className="mt-3 rounded-2xl border border-amber-300/20 bg-black/20 p-3 text-xs text-amber-100">
+                        <div className="mt-3 rounded-2xl border border-amber-300/20 bg-card p-3 text-xs text-warning">
                           {row.errors.map((message) => (
                             <p key={`${row.id}-${message}`}>{message}</p>
                           ))}
@@ -1598,14 +1598,14 @@ export default function Generator() {
             )}
 
             {bulkResult && bulkSource === "csv" && (
-              <div className="mt-8 rounded-[32px] border border-emerald-300/25 bg-emerald-500/10 p-6">
-                <p className="text-xs font-black uppercase tracking-widest text-emerald-200">
+              <div className="mt-8 rounded-[32px] border border-emerald-300/25 bg-success-soft p-6">
+                <p className="text-xs font-black uppercase tracking-widest text-success">
                   Batch Success
                 </p>
-                <h4 className="mt-2 text-2xl font-black text-white">
+                <h4 className="mt-2 text-2xl font-black text-foreground">
                   {bulkResult.total} payment link{bulkResult.total === 1 ? "" : "s"} generated
                 </h4>
-                <p className="mt-2 max-w-2xl text-sm text-emerald-100/80">
+                <p className="mt-2 max-w-2xl text-sm text-success/80">
                   Review the exported CSV or copy individual links from the generated output panel below.
                 </p>
                 <div className="mt-5 flex flex-wrap gap-3">
@@ -1618,14 +1618,14 @@ export default function Generator() {
                         "text/csv;charset=utf-8",
                       )
                     }
-                    className={`rounded-2xl bg-white px-4 py-3 text-sm font-black text-black hover:bg-neutral-200 ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl bg-card px-4 py-3 text-sm font-black text-foreground hover:bg-surface-strong ${FOCUS_RING_CLASS}`}
                   >
                     Download links CSV
                   </button>
                   <button
                     type="button"
                     onClick={() => navigator.clipboard.writeText(bulkResult.links.map((link) => link.url).join("\n"))}
-                    className={`rounded-2xl border border-white/10 px-4 py-3 text-sm font-semibold text-white hover:bg-white/5 ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong px-4 py-3 text-sm font-semibold text-foreground hover:bg-surface ${FOCUS_RING_CLASS}`}
                   >
                     Copy all links
                   </button>
@@ -1636,16 +1636,16 @@ export default function Generator() {
 
           <div className="grid gap-8 xl:grid-cols-[1.05fr_0.95fr]">
             <div className="space-y-8">
-              <div className="rounded-3xl border border-white/10 bg-black/30 p-6">
+              <div className="rounded-3xl border border-border-strong bg-background/30 p-6">
                 <div className="flex items-center justify-between gap-4 mb-5">
                   <div>
-                    <h3 className="text-xl font-bold text-white">Invoice templates</h3>
-                    <p className="text-sm text-neutral-400">Line items, tax, notes, and destination asset.</p>
+                    <h3 className="text-xl font-bold text-foreground">Invoice templates</h3>
+                    <p className="text-sm text-subtle">Line items, tax, notes, and destination asset.</p>
                   </div>
                   <button
                     type="button"
                     onClick={resetTemplateForm}
-                    className={`rounded-xl border border-white/10 px-3 py-2 text-xs font-semibold text-neutral-200 hover:bg-white/5 ${FOCUS_RING_CLASS}`}
+                    className={`rounded-xl border border-border-strong px-3 py-2 text-xs font-semibold text-muted hover:bg-surface ${FOCUS_RING_CLASS}`}
                   >
                     New template
                   </button>
@@ -1659,7 +1659,7 @@ export default function Generator() {
                       setTemplateForm((current) => ({ ...current, name: event.target.value }))
                     }
                     placeholder="Template name"
-                    className={`rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                   />
                   <input
                     type="text"
@@ -1668,7 +1668,7 @@ export default function Generator() {
                       setTemplateForm((current) => ({ ...current, asset: event.target.value.toUpperCase() }))
                     }
                     placeholder="Asset code"
-                    className={`rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                   />
                   <input
                     type="number"
@@ -1677,7 +1677,7 @@ export default function Generator() {
                       setTemplateForm((current) => ({ ...current, taxRate: event.target.value }))
                     }
                     placeholder="Tax %"
-                    className={`rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                   />
                   <input
                     type="text"
@@ -1686,7 +1686,7 @@ export default function Generator() {
                       setTemplateForm((current) => ({ ...current, notes: event.target.value }))
                     }
                     placeholder="Notes"
-                    className={`rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                   />
                 </div>
 
@@ -1697,9 +1697,9 @@ export default function Generator() {
                   }
                   rows={5}
                   placeholder="Description|Qty|Unit Price"
-                  className={`w-full rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                  className={`w-full rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                 />
-                <p className="mt-2 text-xs text-neutral-500">
+                <p className="mt-2 text-xs text-subtle">
                   One line item per row using <span className="font-mono">Description|Qty|Unit Price</span>
                 </p>
 
@@ -1707,14 +1707,14 @@ export default function Generator() {
                   <button
                     type="button"
                     onClick={saveTemplate}
-                    className={`rounded-2xl bg-white px-4 py-3 text-sm font-bold text-black hover:bg-neutral-200 ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl bg-card px-4 py-3 text-sm font-bold text-foreground hover:bg-surface-strong ${FOCUS_RING_CLASS}`}
                   >
                     {editingTemplateId ? "Update template" : "Save template"}
                   </button>
                   <select
                     value={selectedTemplateId}
                     onChange={(event) => setSelectedTemplateId(event.target.value)}
-                    className={`rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                   >
                     {templates.map((template) => (
                       <option key={template.id} value={template.id}>
@@ -1731,13 +1731,13 @@ export default function Generator() {
                       className={`rounded-2xl border px-4 py-4 ${
                         selectedTemplateId === template.id
                           ? "border-indigo-400/60 bg-indigo-500/10"
-                          : "border-white/10 bg-white/[0.03]"
+                          : "border-border-strong bg-surface"
                       }`}
                     >
                       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                         <div>
-                          <p className="font-semibold text-white">{template.name}</p>
-                          <p className="text-sm text-neutral-400">
+                          <p className="font-semibold text-foreground">{template.name}</p>
+                          <p className="text-sm text-subtle">
                             {template.asset} • subtotal {formatCurrencyAmount(calculateTemplateSubtotal(template))} • tax {formatCurrencyAmount(calculateTemplateTax(template))} • total {formatCurrencyAmount(calculateTemplateTotal(template))}
                           </p>
                         </div>
@@ -1745,14 +1745,14 @@ export default function Generator() {
                           <button
                             type="button"
                             onClick={() => editTemplate(template)}
-                            className={`rounded-xl border border-white/10 px-3 py-2 text-xs font-semibold text-neutral-200 hover:bg-white/5 ${FOCUS_RING_CLASS}`}
+                            className={`rounded-xl border border-border-strong px-3 py-2 text-xs font-semibold text-muted hover:bg-surface ${FOCUS_RING_CLASS}`}
                           >
                             Edit
                           </button>
                           <button
                             type="button"
                             onClick={() => deleteTemplate(template.id)}
-                            className={`rounded-xl border border-red-500/20 px-3 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/10 ${FOCUS_RING_CLASS}`}
+                            className={`rounded-xl border border-red-500/20 px-3 py-2 text-xs font-semibold text-danger hover:bg-red-500/10 ${FOCUS_RING_CLASS}`}
                           >
                             Delete
                           </button>
@@ -1763,16 +1763,16 @@ export default function Generator() {
                 </div>
               </div>
 
-              <div className="rounded-3xl border border-white/10 bg-black/30 p-6">
+              <div className="rounded-3xl border border-border-strong bg-background/30 p-6">
                 <div className="flex items-center justify-between gap-4 mb-5">
                   <div>
-                    <h3 className="text-xl font-bold text-white">Saved customers</h3>
-                    <p className="text-sm text-neutral-400">Store contact info plus username or Stellar destination.</p>
+                    <h3 className="text-xl font-bold text-foreground">Saved customers</h3>
+                    <p className="text-sm text-subtle">Store contact info plus username or Stellar destination.</p>
                   </div>
                   <button
                     type="button"
                     onClick={resetCustomerForm}
-                    className={`rounded-xl border border-white/10 px-3 py-2 text-xs font-semibold text-neutral-200 hover:bg-white/5 ${FOCUS_RING_CLASS}`}
+                    className={`rounded-xl border border-border-strong px-3 py-2 text-xs font-semibold text-muted hover:bg-surface ${FOCUS_RING_CLASS}`}
                   >
                     New customer
                   </button>
@@ -1786,7 +1786,7 @@ export default function Generator() {
                       setCustomerForm((current) => ({ ...current, name: event.target.value }))
                     }
                     placeholder="Customer name"
-                    className={`rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                   />
                   <input
                     type="email"
@@ -1795,7 +1795,7 @@ export default function Generator() {
                       setCustomerForm((current) => ({ ...current, email: event.target.value }))
                     }
                     placeholder="Email"
-                    className={`rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                   />
                   <input
                     type="text"
@@ -1804,7 +1804,7 @@ export default function Generator() {
                       setCustomerForm((current) => ({ ...current, address: event.target.value }))
                     }
                     placeholder="Stellar address"
-                    className={`rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                   />
                   <input
                     type="text"
@@ -1813,21 +1813,21 @@ export default function Generator() {
                       setCustomerForm((current) => ({ ...current, username: event.target.value }))
                     }
                     placeholder="Username"
-                    className={`rounded-2xl border border-white/10 bg-neutral-900/60 px-4 py-3 text-sm text-white ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground ${FOCUS_RING_CLASS}`}
                   />
                 </div>
 
                 <button
                   type="button"
                   onClick={saveCustomer}
-                  className={`rounded-2xl bg-white px-4 py-3 text-sm font-bold text-black hover:bg-neutral-200 ${FOCUS_RING_CLASS}`}
+                  className={`rounded-2xl bg-card px-4 py-3 text-sm font-bold text-foreground hover:bg-surface-strong ${FOCUS_RING_CLASS}`}
                 >
                   {editingCustomerId ? "Update customer" : "Save customer"}
                 </button>
 
                 <div className="mt-6 space-y-3">
                   {customers.map((customer) => (
-                    <div key={customer.id} className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-4">
+                    <div key={customer.id} className="rounded-2xl border border-border-strong bg-surface px-4 py-4">
                       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                         <label className="flex items-start gap-3">
                           <input
@@ -1837,9 +1837,9 @@ export default function Generator() {
                             className="mt-1 h-4 w-4"
                           />
                           <div>
-                            <p className="font-semibold text-white">{customer.name}</p>
-                            <p className="text-sm text-neutral-400">{customer.email}</p>
-                            <p className="text-xs text-neutral-500">
+                            <p className="font-semibold text-foreground">{customer.name}</p>
+                            <p className="text-sm text-subtle">{customer.email}</p>
+                            <p className="text-xs text-subtle">
                               {customer.username || customer.address || "Missing payment route"}
                             </p>
                           </div>
@@ -1848,14 +1848,14 @@ export default function Generator() {
                           <button
                             type="button"
                             onClick={() => editCustomer(customer)}
-                            className={`rounded-xl border border-white/10 px-3 py-2 text-xs font-semibold text-neutral-200 hover:bg-white/5 ${FOCUS_RING_CLASS}`}
+                            className={`rounded-xl border border-border-strong px-3 py-2 text-xs font-semibold text-muted hover:bg-surface ${FOCUS_RING_CLASS}`}
                           >
                             Edit
                           </button>
                           <button
                             type="button"
                             onClick={() => deleteCustomer(customer.id)}
-                            className={`rounded-xl border border-red-500/20 px-3 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/10 ${FOCUS_RING_CLASS}`}
+                            className={`rounded-xl border border-red-500/20 px-3 py-2 text-xs font-semibold text-danger hover:bg-red-500/10 ${FOCUS_RING_CLASS}`}
                           >
                             Delete
                           </button>
@@ -1868,56 +1868,56 @@ export default function Generator() {
             </div>
 
             <div className="space-y-8">
-              <div className="rounded-3xl border border-white/10 bg-black/30 p-6">
+              <div className="rounded-3xl border border-border-strong bg-background/30 p-6">
                 <div className="flex items-center justify-between gap-3 mb-4">
                   <div>
-                    <h3 className="text-xl font-bold text-white">Preview</h3>
-                    <p className="text-sm text-neutral-400">These rows are transformed directly into the bulk API payload.</p>
+                    <h3 className="text-xl font-bold text-foreground">Preview</h3>
+                    <p className="text-sm text-subtle">These rows are transformed directly into the bulk API payload.</p>
                   </div>
                   <button
                     type="button"
                     onClick={() => void generateBulkInvoices()}
                     disabled={bulkLoading}
-                    className={`rounded-2xl bg-white px-4 py-3 text-sm font-bold text-black hover:bg-neutral-200 disabled:opacity-50 ${FOCUS_RING_CLASS}`}
+                    className={`rounded-2xl bg-card px-4 py-3 text-sm font-bold text-foreground hover:bg-surface-strong disabled:opacity-50 ${FOCUS_RING_CLASS}`}
                   >
                     {bulkLoading ? "Generating..." : "Generate invoices"}
                   </button>
                 </div>
 
                 {bulkError && (
-                  <p className="mb-4 rounded-md border border-amber-300/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">
+                  <p className="mb-4 rounded-md border border-amber-300/30 bg-warning-soft px-3 py-2 text-sm text-warning">
                     {bulkError}
                   </p>
                 )}
 
                 <div className="space-y-4">
                   {invoicePreviewRows.map((row) => (
-                    <div key={row.id} className="rounded-2xl border border-white/10 bg-neutral-950/50 p-4">
+                    <div key={row.id} className="rounded-2xl border border-border-strong bg-background/50 p-4">
                       <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                         <div>
-                          <p className="font-semibold text-white">{row.customerName}</p>
-                          <p className="text-sm text-neutral-400">{row.email}</p>
-                          <p className="text-xs text-neutral-500">
+                          <p className="font-semibold text-foreground">{row.customerName}</p>
+                          <p className="text-sm text-subtle">{row.email}</p>
+                          <p className="text-xs text-subtle">
                             {row.username ?? row.destination ?? "Missing payment route"}
                           </p>
                         </div>
                         <div className="text-right">
-                          <p className="text-lg font-black text-white">
+                          <p className="text-lg font-black text-foreground">
                             {formatCurrencyAmount(row.total)} {row.asset}
                           </p>
-                          <p className="text-xs text-neutral-500">{row.referenceId}</p>
+                          <p className="text-xs text-subtle">{row.referenceId}</p>
                         </div>
                       </div>
                       <div className="mt-4 space-y-2">
                         {row.lineItems.map((item) => (
-                          <div key={item.id} className="flex items-center justify-between text-sm text-neutral-300">
+                          <div key={item.id} className="flex items-center justify-between text-sm text-muted">
                             <span>{item.description}</span>
                             <span className="font-mono">
                               {item.quantity} × {formatCurrencyAmount(item.unitPrice)}
                             </span>
                           </div>
                         ))}
-                        <div className="border-t border-white/10 pt-2 text-sm text-neutral-300">
+                        <div className="border-t border-border-strong pt-2 text-sm text-muted">
                           <div className="flex items-center justify-between">
                             <span>Subtotal</span>
                             <span>{formatCurrencyAmount(row.subtotal)}</span>
@@ -1926,18 +1926,18 @@ export default function Generator() {
                             <span>Tax</span>
                             <span>{formatCurrencyAmount(row.taxAmount)}</span>
                           </div>
-                          <div className="flex items-center justify-between font-semibold text-white">
+                          <div className="flex items-center justify-between font-semibold text-foreground">
                             <span>Total</span>
                             <span>{formatCurrencyAmount(row.total)}</span>
                           </div>
                         </div>
-                        <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-neutral-300">
-                          <p className="font-semibold text-neutral-200">Generated memo</p>
+                        <div className="rounded-xl border border-border-strong bg-surface px-3 py-2 text-xs text-muted">
+                          <p className="font-semibold text-muted">Generated memo</p>
                           <p>{row.memo}</p>
                         </div>
                         {row.notes && (
-                          <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-neutral-300">
-                            <p className="font-semibold text-neutral-200">Notes</p>
+                          <div className="rounded-xl border border-border-strong bg-surface px-3 py-2 text-xs text-muted">
+                            <p className="font-semibold text-muted">Notes</p>
                             <p>{row.notes}</p>
                           </div>
                         )}
@@ -1945,16 +1945,16 @@ export default function Generator() {
                     </div>
                   ))}
                   {invoicePreviewRows.length === 0 && (
-                    <p className="rounded-2xl border border-dashed border-white/10 px-4 py-8 text-center text-sm text-neutral-400">
+                    <p className="rounded-2xl border border-dashed border-border-strong px-4 py-8 text-center text-sm text-subtle">
                       Select a template and at least one saved customer to build the preview.
                     </p>
                   )}
                 </div>
               </div>
 
-              <div className="rounded-3xl border border-white/10 bg-black/30 p-6">
-                <h3 className="text-xl font-bold text-white mb-4">Generated output</h3>
-                <div className="rounded-2xl border border-white/10 bg-neutral-950/60 p-4 text-xs text-neutral-300">
+              <div className="rounded-3xl border border-border-strong bg-background/30 p-6">
+                <h3 className="text-xl font-bold text-foreground mb-4">Generated output</h3>
+                <div className="rounded-2xl border border-border-strong bg-background/60 p-4 text-xs text-muted">
                   <pre className="overflow-x-auto whitespace-pre-wrap">
                     {JSON.stringify({ links: previewGenerationPayload }, null, 2)}
                   </pre>
@@ -1962,10 +1962,10 @@ export default function Generator() {
                 {bulkResult && (
                   <div className="mt-5 space-y-3">
                     {bulkResult.links.map((link) => (
-                      <div key={link.id} className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-4">
-                        <p className="font-semibold text-white">{link.referenceId ?? link.id}</p>
-                        <p className="mt-1 break-all text-xs text-neutral-400">{link.url}</p>
-                        <p className="mt-2 text-xs text-neutral-500">{link.canonical}</p>
+                      <div key={link.id} className="rounded-2xl border border-border-strong bg-surface px-4 py-4">
+                        <p className="font-semibold text-foreground">{link.referenceId ?? link.id}</p>
+                        <p className="mt-1 break-all text-xs text-subtle">{link.url}</p>
+                        <p className="mt-2 text-xs text-subtle">{link.canonical}</p>
                       </div>
                     ))}
                   </div>

--- a/app/frontend/src/app/globals.css
+++ b/app/frontend/src/app/globals.css
@@ -1,13 +1,103 @@
 @import "tailwindcss";
 
+/* Enable class-based dark mode so the theme toggle can switch themes at runtime. */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Semantic theme tokens
+   Every surface, border and text color in the app resolves to one of these
+   variables, so light/dark mode stays consistent across every route.
+   Light is the default (:root); `.dark` overrides flip the whole palette.
+   ────────────────────────────────────────────────────────────────────────── */
 :root {
-  --background: #0a0a0a;
-  --foreground: #ededed;
+  /* Base */
+  --background: #f6f7f9;
+  --foreground: #18181b;
+
+  /* Surfaces (cards, subtle fills) */
+  --card: #ffffff;
+  --surface: #f1f2f4;
+  --surface-strong: #e5e7eb;
+
+  /* Borders */
+  --border: #e4e4e7;
+  --border-strong: #d4d4d8;
+
+  /* Text emphasis ramp */
+  --muted: #3f3f46;
+  --subtle: #6b7280;
+  --faint: #9ca3af;
+
+  /* Brand + status (text + soft translucent background pairs) */
+  --brand: #4f46e5;
+  --brand-soft: rgba(99, 102, 241, 0.12);
+  --success: #047857;
+  --success-soft: rgba(16, 185, 129, 0.12);
+  --danger: #b91c1c;
+  --danger-soft: rgba(239, 68, 68, 0.1);
+  --warning: #b45309;
+  --warning-soft: rgba(245, 158, 11, 0.12);
+
+  /* Chart-specific tokens (consumed by recharts via var()) */
+  --chart-grid: rgba(0, 0, 0, 0.08);
+  --chart-axis: #71717a;
+  --chart-tooltip-bg: #ffffff;
+  --chart-tooltip-border: #e4e4e7;
+  --chart-tooltip-text: #18181b;
 }
 
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+
+  --card: rgba(18, 18, 26, 0.6);
+  --surface: rgba(255, 255, 255, 0.05);
+  --surface-strong: rgba(255, 255, 255, 0.1);
+
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.14);
+
+  --muted: #d4d4d4;
+  --subtle: #a3a3a3;
+  --faint: #6b7280;
+
+  --brand: #a5b4fc;
+  --brand-soft: rgba(99, 102, 241, 0.12);
+  --success: #6ee7b7;
+  --success-soft: rgba(16, 185, 129, 0.12);
+  --danger: #fca5a5;
+  --danger-soft: rgba(239, 68, 68, 0.12);
+  --warning: #fcd34d;
+  --warning-soft: rgba(245, 158, 11, 0.14);
+
+  --chart-grid: rgba(255, 255, 255, 0.06);
+  --chart-axis: #737373;
+  --chart-tooltip-bg: rgba(10, 10, 20, 0.92);
+  --chart-tooltip-border: rgba(255, 255, 255, 0.08);
+  --chart-tooltip-text: #ffffff;
+}
+
+/* Map tokens to Tailwind color utilities: bg-card, text-muted, border-border, … */
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-surface: var(--surface);
+  --color-surface-strong: var(--surface-strong);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-muted: var(--muted);
+  --color-subtle: var(--subtle);
+  --color-faint: var(--faint);
+  --color-brand: var(--brand);
+  --color-brand-soft: var(--brand-soft);
+  --color-success: var(--success);
+  --color-success-soft: var(--success-soft);
+  --color-danger: var(--danger);
+  --color-danger-soft: var(--danger-soft);
+  --color-warning: var(--warning);
+  --color-warning-soft: var(--warning-soft);
+
   --font-sans: "Avenir Next", "Segoe UI", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "SFMono-Regular", "IBM Plex Mono", ui-monospace, monospace;
 }
@@ -29,7 +119,7 @@ textarea {
 }
 
 :focus-visible {
-  outline: 2px solid #a5b4fc;
+  outline: 2px solid var(--brand);
   outline-offset: 2px;
   border-radius: 4px;
 }
@@ -41,7 +131,7 @@ a:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-  box-shadow: 0 0 0 3px rgba(165, 180, 252, 0.35);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/frontend/src/app/layout.tsx
+++ b/app/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Header } from "@/components/Header";
 import { NotificationCenterProvider } from "@/components/NotificationCenterProvider";
 import { ErrorReportingShell } from "@/components/ErrorReportingShell";
+import { ThemeProvider, themeInitScript } from "@/components/ThemeProvider";
 import "./globals.css";
 
 const siteUrl =
@@ -52,37 +53,42 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className="bg-neutral-950 text-white antialiased">
-        <NotificationCenterProvider>
-          <Header />
-          <ErrorReportingShell>
-            <main
-              id="main-content"
-              tabIndex={-1}
-              className="min-h-screen container mx-auto px-6 py-10 focus:outline-none"
-            >
-              {children}
-            </main>
-          </ErrorReportingShell>
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="bg-background text-foreground antialiased">
+        <ThemeProvider>
+          <NotificationCenterProvider>
+            <Header />
+            <ErrorReportingShell>
+              <main
+                id="main-content"
+                tabIndex={-1}
+                className="min-h-screen container mx-auto px-6 py-10 focus:outline-none"
+              >
+                {children}
+              </main>
+            </ErrorReportingShell>
 
-          <footer className="container mx-auto border-t border-white/5 px-6 py-12 text-sm text-neutral-400">
-            <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
-              <p>Copyright 2026 QuickEx Platform. Built by Pulsefy.</p>
-              <div className="flex gap-8 underline decoration-white/10 underline-offset-4 hover:decoration-white/20">
-                <a
-                  href="https://github.com/pulsefy/QuickEx"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  GitHub
-                </a>
-                <a href="#">Terms</a>
-                <a href="#">Privacy</a>
+            <footer className="container mx-auto border-t border-border px-6 py-12 text-sm text-subtle">
+              <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
+                <p>Copyright 2026 QuickEx Platform. Built by Pulsefy.</p>
+                <div className="flex gap-8 underline decoration-border underline-offset-4 hover:decoration-border-strong">
+                  <a
+                    href="https://github.com/pulsefy/QuickEx"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    GitHub
+                  </a>
+                  <a href="#">Terms</a>
+                  <a href="#">Privacy</a>
+                </div>
               </div>
-            </div>
-          </footer>
-        </NotificationCenterProvider>
+            </footer>
+          </NotificationCenterProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/frontend/src/app/marketplace/loading.tsx
+++ b/app/frontend/src/app/marketplace/loading.tsx
@@ -2,15 +2,15 @@ import * as React from "react";
 
 export default function MarketplaceLoading() {
   return (
-    <div className="min-h-screen text-white selection:bg-indigo-500/30">
+    <div className="min-h-screen text-foreground selection:bg-indigo-500/30">
       <div className="space-y-10">
-        <div className="h-8 w-1/3 rounded-full bg-white/5 animate-pulse" />
-        <div className="h-72 rounded-3xl bg-white/5 border border-white/5 animate-pulse" />
+        <div className="h-8 w-1/3 rounded-full bg-surface animate-pulse" />
+        <div className="h-72 rounded-3xl bg-surface border border-border animate-pulse" />
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {Array.from({ length: 6 }).map((_, idx) => (
             <div
               key={idx}
-              className="h-72 rounded-3xl bg-white/5 border border-white/5 animate-pulse"
+              className="h-72 rounded-3xl bg-surface border border-border animate-pulse"
             />
           ))}
         </div>

--- a/app/frontend/src/app/marketplace/page.tsx
+++ b/app/frontend/src/app/marketplace/page.tsx
@@ -18,8 +18,8 @@ const BidModal = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
-        <div className="h-72 w-[90%] max-w-3xl rounded-3xl bg-white/5 animate-pulse" />
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/70">
+        <div className="h-72 w-[90%] max-w-3xl rounded-3xl bg-surface animate-pulse" />
       </div>
     ),
   },
@@ -58,11 +58,11 @@ function StatsBar({ listings }: { listings: MarketplaceListing[] }) {
       ].map((s) => (
         <div
           key={s.label}
-          className="p-5 rounded-2xl bg-white/[0.03] border border-white/5 flex items-center gap-4"
+          className="p-5 rounded-2xl bg-surface border border-border flex items-center gap-4"
         >
           <span className="text-2xl opacity-70">{s.icon}</span>
           <div>
-            <p className="text-[10px] uppercase font-black tracking-widest text-neutral-500 mb-0.5">
+            <p className="text-[10px] uppercase font-black tracking-widest text-subtle mb-0.5">
               {s.label}
             </p>
             <p className="font-black text-lg">{s.value}</p>
@@ -179,40 +179,40 @@ function MarketplacePageContent() {
   }, [listings, search, activeCategory, sortKey, showWatchlistOnly, isInWatchlist]);
 
   return (
-    <div className="relative min-h-screen text-white selection:bg-indigo-500/30">
+    <div className="relative min-h-screen text-foreground selection:bg-indigo-500/30">
       {/* Background auras */}
       <div className="fixed top-[-20%] right-[-20%] w-[55%] h-[55%] bg-indigo-500/8 blur-[140px] rounded-full pointer-events-none" />
       <div className="fixed bottom-[-20%] left-[-20%] w-[45%] h-[45%] bg-purple-600/6 blur-[120px] rounded-full pointer-events-none" />
 
       {/* ── HERO HEADER ──────────────────────────────── */}
-      <div className="relative border-b border-white/5 bg-gradient-to-b from-indigo-500/5 to-transparent py-16 mb-10">
+      <div className="relative border-b border-border bg-gradient-to-b from-indigo-500/5 to-transparent py-16 mb-10">
         <div className="max-w-5xl mx-auto px-6">
           {/* Breadcrumb */}
-          <nav className="flex items-center gap-2 text-xs font-black text-neutral-600 uppercase tracking-widest mb-6">
-            <Link href="/" className="hover:text-white transition">QuickEx</Link>
+          <nav className="flex items-center gap-2 text-xs font-black text-faint uppercase tracking-widest mb-6">
+            <Link href="/" className="hover:text-foreground transition">QuickEx</Link>
             <span>/</span>
-            <span className="text-neutral-400">Marketplace</span>
+            <span className="text-subtle">Marketplace</span>
           </nav>
 
           <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
             <div>
               <div className="inline-flex items-center gap-2 px-3 py-1 bg-indigo-500/10 border border-indigo-500/20 rounded-full mb-4">
                 <span className="w-2 h-2 rounded-full bg-indigo-400 animate-pulse" />
-                <span className="text-xs font-black text-indigo-300 tracking-widest uppercase">
+                <span className="text-xs font-black text-brand tracking-widest uppercase">
                   Live Auctions
                 </span>
               </div>
               <h1 className="text-5xl md:text-6xl font-black tracking-tight bg-gradient-to-br from-white via-neutral-200 to-neutral-500 bg-clip-text text-transparent leading-none mb-4">
                 Username<br />Marketplace
               </h1>
-              <p className="text-neutral-400 max-w-lg leading-relaxed">
+              <p className="text-subtle max-w-lg leading-relaxed">
                 Bid on rare, short, and premium Stellar usernames. Own your identity on-chain — permanent, self-custodied, and transferable.
               </p>
             </div>
 
             <Link
               href="/dashboard?tab=listings"
-              className="shrink-0 px-6 py-4 bg-white/5 hover:bg-white/10 border border-white/10 rounded-2xl font-bold text-sm transition-all hover:border-white/20 whitespace-nowrap"
+              className="shrink-0 px-6 py-4 bg-surface hover:bg-surface-strong border border-border-strong rounded-2xl font-bold text-sm transition-all hover:border-border-strong whitespace-nowrap"
             >
               My Listings & Bids →
             </Link>
@@ -228,7 +228,7 @@ function MarketplacePageContent() {
         <div className="flex flex-col gap-4 mb-8">
           {/* Search */}
           <div className="relative">
-            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 text-lg pointer-events-none">
+            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-subtle text-lg pointer-events-none">
               ⌕
             </span>
             <input
@@ -237,12 +237,12 @@ function MarketplacePageContent() {
               placeholder="Search usernames…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full bg-white/5 border border-white/8 focus:border-indigo-500/50 rounded-2xl pl-11 pr-5 py-4 text-white placeholder-neutral-600 font-medium outline-none transition-all text-sm"
+              className="w-full bg-surface border border-white/8 focus:border-indigo-500/50 rounded-2xl pl-11 pr-5 py-4 text-foreground placeholder-neutral-600 font-medium outline-none transition-all text-sm"
             />
             {search && (
               <button
                 onClick={() => setSearch("")}
-                className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-white transition text-sm"
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-subtle hover:text-foreground transition text-sm"
               >
                 ✕
               </button>
@@ -258,7 +258,7 @@ function MarketplacePageContent() {
                 className={`flex items-center gap-1.5 px-3.5 py-2 rounded-xl font-bold text-xs transition-all ${
                   showWatchlistOnly
                     ? "bg-red-500 text-white shadow-[0_4px_20px_-8px_rgba(239,68,68,0.8)]"
-                    : "bg-white/5 border border-white/5 text-neutral-400 hover:text-white hover:bg-white/10"
+                    : "bg-surface border border-border text-subtle hover:text-foreground hover:bg-surface-strong"
                 }`}
               >
                 <span>❤️</span>
@@ -272,7 +272,7 @@ function MarketplacePageContent() {
                   className={`flex items-center gap-1.5 px-3.5 py-2 rounded-xl font-bold text-xs transition-all ${
                     activeCategory === cat.key
                       ? "bg-indigo-500 text-white shadow-[0_4px_20px_-8px_rgba(99,102,241,0.8)]"
-                      : "bg-white/5 border border-white/5 text-neutral-400 hover:text-white hover:bg-white/10"
+                      : "bg-surface border border-border text-subtle hover:text-foreground hover:bg-surface-strong"
                   }`}
                 >
                   <span>{cat.icon}</span>
@@ -286,7 +286,7 @@ function MarketplacePageContent() {
               id="marketplace-sort"
               value={sortKey}
               onChange={(e) => setSortKey(e.target.value)}
-              className="bg-white/5 border border-white/8 text-sm font-bold text-neutral-400 rounded-xl px-4 py-2 outline-none focus:border-indigo-500/40 transition"
+              className="bg-surface border border-white/8 text-sm font-bold text-subtle rounded-xl px-4 py-2 outline-none focus:border-indigo-500/40 transition"
             >
               {SORT_OPTIONS.map((o) => (
                 <option key={o.key} value={o.key}>
@@ -300,16 +300,16 @@ function MarketplacePageContent() {
           <div className="flex items-center justify-between text-xs">
             <div className="flex items-center gap-2">
               <span className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-400 animate-pulse' : 'bg-red-400'}`} />
-              <span className="text-neutral-500 font-bold">
+              <span className="text-subtle font-bold">
                 {isConnected ? 'Live Updates Active' : 'Connection Lost'}
               </span>
               {lastUpdate && (
-                <span className="text-neutral-600">
+                <span className="text-faint">
                   • Last update: {lastUpdate.toLocaleTimeString()}
                 </span>
               )}
             </div>
-            <span className="text-neutral-600">
+            <span className="text-faint">
               {watchlist.length} in watchlist
             </span>
           </div>
@@ -317,7 +317,7 @@ function MarketplacePageContent() {
 
         {/* ── RESULTS COUNT ─────────────────────────── */}
         {!loading && (
-          <p className="text-xs text-neutral-600 font-bold uppercase tracking-widest mb-6">
+          <p className="text-xs text-faint font-bold uppercase tracking-widest mb-6">
             {filtered.length} listing{filtered.length !== 1 ? "s" : ""} found
             {search && ` for "${search}"`}
           </p>
@@ -329,7 +329,7 @@ function MarketplacePageContent() {
             {Array.from({ length: 6 }).map((_, i) => (
               <div
                 key={i}
-                className="h-72 rounded-3xl bg-white/[0.03] border border-white/5 animate-pulse"
+                className="h-72 rounded-3xl bg-surface border border-border animate-pulse"
               />
             ))}
           </div>
@@ -347,7 +347,7 @@ function MarketplacePageContent() {
                   : 'No listings match your filters'
                 }
               </h3>
-              <p className="text-neutral-500 text-sm max-w-md mx-auto leading-relaxed">
+              <p className="text-subtle text-sm max-w-md mx-auto leading-relaxed">
                 {showWatchlistOnly
                   ? 'Add usernames to your watchlist by clicking the heart icon on any listing. You\'ll get notified of new bids and can easily revisit your favorites.'
                   : search
@@ -360,9 +360,9 @@ function MarketplacePageContent() {
             {/* Bidding rules explanation */}
             {!showWatchlistOnly && !search && (
               <div className="max-w-lg mx-auto">
-                <div className="bg-white/5 border border-white/10 rounded-2xl p-6 text-left">
+                <div className="bg-surface border border-border-strong rounded-2xl p-6 text-left">
                   <h4 className="font-black text-sm mb-3 text-indigo-400">💡 How Bidding Works</h4>
-                  <ul className="space-y-2 text-xs text-neutral-400 leading-relaxed">
+                  <ul className="space-y-2 text-xs text-subtle leading-relaxed">
                     <li>• <strong>Minimum bid:</strong> Must be at least 1 USDC higher than current bid</li>
                     <li>• <strong>Auction duration:</strong> 7 days from listing creation</li>
                     <li>• <strong>Buy Now:</strong> Instantly purchase at seller&apos;s set price (optional)</li>
@@ -377,7 +377,7 @@ function MarketplacePageContent() {
               {showWatchlistOnly && (
                 <button
                   onClick={() => setShowWatchlistOnly(false)}
-                  className="px-6 py-3 bg-indigo-500/10 hover:bg-indigo-500 border border-indigo-500/30 hover:border-indigo-500 text-indigo-300 hover:text-white font-bold rounded-xl transition"
+                  className="px-6 py-3 bg-indigo-500/10 hover:bg-indigo-500 border border-indigo-500/30 hover:border-indigo-500 text-brand hover:text-white font-bold rounded-xl transition"
                 >
                   Browse All Listings
                 </button>
@@ -385,7 +385,7 @@ function MarketplacePageContent() {
               {search && (
                 <button
                   onClick={() => { setSearch(""); setActiveCategory("all"); }}
-                  className="px-6 py-3 bg-white/5 border border-white/10 rounded-xl font-bold text-sm hover:bg-white/10 transition"
+                  className="px-6 py-3 bg-surface border border-border-strong rounded-xl font-bold text-sm hover:bg-surface-strong transition"
                 >
                   Clear Filters
                 </button>

--- a/app/frontend/src/app/notifications/page.tsx
+++ b/app/frontend/src/app/notifications/page.tsx
@@ -95,28 +95,28 @@ function NotificationsPageContent() {
   };
 
   return (
-    <div className="relative min-h-screen text-white">
+    <div className="relative min-h-screen text-foreground">
       <NetworkBadge />
 
       <div className="fixed left-[-20%] top-[-15%] h-[24rem] w-[24rem] rounded-full bg-indigo-500/15 blur-[120px]" />
-      <div className="fixed bottom-[-18%] right-[-12%] h-[22rem] w-[22rem] rounded-full bg-emerald-500/10 blur-[120px]" />
+      <div className="fixed bottom-[-18%] right-[-12%] h-[22rem] w-[22rem] rounded-full bg-success-soft blur-[120px]" />
 
       <div className="relative z-10 mx-auto max-w-6xl">
-        <header className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-8 shadow-[0_30px_80px_-30px_rgba(15,23,42,0.85)] backdrop-blur">
-          <nav className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-neutral-400">
-            <Link href="/" className="transition hover:text-white">
+        <header className="rounded-[2rem] border border-border-strong bg-card/[0.04] p-8 shadow-[0_30px_80px_-30px_rgba(15,23,42,0.85)] backdrop-blur">
+          <nav className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-subtle">
+            <Link href="/" className="transition hover:text-foreground">
               QuickEx
             </Link>
             <span>/</span>
-            <span className="text-neutral-100">Notifications</span>
+            <span className="text-foreground">Notifications</span>
           </nav>
 
           <div className="mt-6 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+              <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
                 Notification Center
               </h1>
-              <p className="mt-3 max-w-2xl text-base text-neutral-200">
+              <p className="mt-3 max-w-2xl text-base text-muted">
                 Review updates, jump directly into the right payment or escrow
                 context, and keep your inbox clean without losing anything on
                 refresh.
@@ -126,7 +126,7 @@ function NotificationsPageContent() {
             <div className="flex flex-wrap items-center gap-3">
               <Link
                 href="/dashboard"
-                className="rounded-full border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-semibold text-neutral-100 transition hover:bg-white/10"
+                className="rounded-full border border-border-strong bg-surface px-4 py-2.5 text-sm font-semibold text-foreground transition hover:bg-surface-strong"
               >
                 Back to dashboard
               </Link>
@@ -134,7 +134,7 @@ function NotificationsPageContent() {
                 type="button"
                 onClick={() => markAllAsRead()}
                 disabled={unreadCount === 0}
-                className="rounded-full bg-white px-4 py-2.5 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-200 disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded-full bg-card px-4 py-2.5 text-sm font-semibold text-foreground transition hover:bg-surface-strong disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Mark all as read
               </button>
@@ -142,38 +142,38 @@ function NotificationsPageContent() {
           </div>
 
           <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-            <div className="rounded-3xl border border-white/10 bg-neutral-950/60 p-5">
-              <p className="text-sm text-neutral-400">Unread</p>
-              <p className="mt-2 text-3xl font-semibold text-white">
+            <div className="rounded-3xl border border-border-strong bg-background/60 p-5">
+              <p className="text-sm text-subtle">Unread</p>
+              <p className="mt-2 text-3xl font-semibold text-foreground">
                 {unreadCount}
               </p>
             </div>
-            <div className="rounded-3xl border border-white/10 bg-neutral-950/60 p-5">
-              <p className="text-sm text-neutral-400">Payments</p>
-              <p className="mt-2 text-3xl font-semibold text-white">
+            <div className="rounded-3xl border border-border-strong bg-background/60 p-5">
+              <p className="text-sm text-subtle">Payments</p>
+              <p className="mt-2 text-3xl font-semibold text-foreground">
                 {counts.payments}
               </p>
             </div>
-            <div className="rounded-3xl border border-white/10 bg-neutral-950/60 p-5">
-              <p className="text-sm text-neutral-400">Escrows</p>
-              <p className="mt-2 text-3xl font-semibold text-white">
+            <div className="rounded-3xl border border-border-strong bg-background/60 p-5">
+              <p className="text-sm text-subtle">Escrows</p>
+              <p className="mt-2 text-3xl font-semibold text-foreground">
                 {counts.escrows}
               </p>
             </div>
-            <div className="rounded-3xl border border-white/10 bg-neutral-950/60 p-5">
-              <p className="text-sm text-neutral-400">System</p>
-              <p className="mt-2 text-3xl font-semibold text-white">
+            <div className="rounded-3xl border border-border-strong bg-background/60 p-5">
+              <p className="text-sm text-subtle">System</p>
+              <p className="mt-2 text-3xl font-semibold text-foreground">
                 {counts.system}
               </p>
             </div>
           </div>
         </header>
 
-        <section className="mt-8 rounded-[2rem] border border-white/10 bg-white/[0.03] p-8 backdrop-blur">
+        <section className="mt-8 rounded-[2rem] border border-border-strong bg-surface p-8 backdrop-blur">
           <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
             <div className="space-y-3">
               <div>
-                <p className="text-sm font-semibold text-neutral-300">
+                <p className="text-sm font-semibold text-muted">
                   Category
                 </p>
                 <div className="mt-3 flex flex-wrap gap-2">
@@ -184,8 +184,8 @@ function NotificationsPageContent() {
                       onClick={() => updateFilters({ category: option.value })}
                       className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
                         activeCategory === option.value
-                          ? "bg-white text-neutral-950"
-                          : "border border-white/10 bg-white/5 text-neutral-100 hover:bg-white/10"
+                          ? "bg-card text-foreground"
+                          : "border border-border-strong bg-surface text-foreground hover:bg-surface-strong"
                       }`}
                     >
                       {option.label}
@@ -195,7 +195,7 @@ function NotificationsPageContent() {
               </div>
 
               <div>
-                <p className="text-sm font-semibold text-neutral-300">
+                <p className="text-sm font-semibold text-muted">
                   Read state
                 </p>
                 <div className="mt-3 flex flex-wrap gap-2">
@@ -207,7 +207,7 @@ function NotificationsPageContent() {
                       className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
                         activeReadState === option.value
                           ? "bg-indigo-500 text-white"
-                          : "border border-white/10 bg-white/5 text-neutral-100 hover:bg-white/10"
+                          : "border border-border-strong bg-surface text-foreground hover:bg-surface-strong"
                       }`}
                     >
                       {option.label}
@@ -221,7 +221,7 @@ function NotificationsPageContent() {
               <button
                 type="button"
                 onClick={() => updateFilters({ category: "all", status: "all" })}
-                className="rounded-full border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-semibold text-neutral-100 transition hover:bg-white/10"
+                className="rounded-full border border-border-strong bg-surface px-4 py-2.5 text-sm font-semibold text-foreground transition hover:bg-surface-strong"
               >
                 Reset filters
               </button>
@@ -249,8 +249,8 @@ export default function NotificationsPage() {
   return (
     <Suspense
       fallback={
-        <div className="relative min-h-screen text-white">
-          <div className="mx-auto max-w-6xl rounded-[2rem] border border-white/10 bg-white/[0.04] p-8 text-neutral-200 backdrop-blur">
+        <div className="relative min-h-screen text-foreground">
+          <div className="mx-auto max-w-6xl rounded-[2rem] border border-border-strong bg-card/[0.04] p-8 text-muted backdrop-blur">
             Loading notifications...
           </div>
         </div>

--- a/app/frontend/src/app/offline/page.tsx
+++ b/app/frontend/src/app/offline/page.tsx
@@ -5,13 +5,13 @@ import React from "react";
 export default function OfflinePage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-6">
-      <div className="w-24 h-24 mb-8 bg-neutral-900 border border-white/10 rounded-3xl flex items-center justify-center shadow-2xl">
+      <div className="w-24 h-24 mb-8 bg-card border border-border-strong rounded-3xl flex items-center justify-center shadow-2xl">
         <svg
           fill="none"
           viewBox="0 0 24 24"
           strokeWidth={1.5}
           stroke="currentColor"
-          className="w-12 h-12 text-neutral-500"
+          className="w-12 h-12 text-subtle"
         >
           <path
             strokeLinecap="round"
@@ -23,19 +23,19 @@ export default function OfflinePage() {
       <h1 className="text-4xl font-bold text-white mb-4 bg-gradient-to-r from-purple-400 to-cyan-400 bg-clip-text text-transparent">
         You&apos;re Offline
       </h1>
-      <p className="text-neutral-400 max-w-md mx-auto mb-8 text-lg">
+      <p className="text-subtle max-w-md mx-auto mb-8 text-lg">
         It looks like you&apos;ve lost your connection. Don&apos;t worry,
         QuickEx is ready to resume once you&apos;re back online.
       </p>
       <button
         onClick={() => window.location.reload()}
-        className="px-8 py-3 bg-white text-black font-bold rounded-xl hover:bg-neutral-200 transition-all transform hover:scale-105 active:scale-95 shadow-lg"
+        className="px-8 py-3 bg-card text-foreground font-bold rounded-xl hover:bg-surface-strong transition-all transform hover:scale-105 active:scale-95 shadow-lg"
       >
         Retry Connection
       </button>
 
-      <div className="mt-12 p-4 rounded-2xl bg-white/5 border border-white/5 backdrop-blur-sm">
-        <p className="text-sm text-neutral-500">
+      <div className="mt-12 p-4 rounded-2xl bg-surface border border-border backdrop-blur-sm">
+        <p className="text-sm text-subtle">
           Tip: You can still use the app for some basic features if they were
           cached.
         </p>

--- a/app/frontend/src/app/page.tsx
+++ b/app/frontend/src/app/page.tsx
@@ -29,48 +29,48 @@ export default function Home() {
       <NetworkBadge />
       <section className="pt-20 md:pt-32 pb-32">
         <div className="max-w-3xl">
-          <h1 className="text-6xl md:text-7xl font-bold tracking-tighter mb-8 bg-gradient-to-br from-white to-neutral-500 bg-clip-text text-transparent leading-tight">
+          <h1 className="text-6xl md:text-7xl font-bold tracking-tighter mb-8 bg-gradient-to-br from-foreground to-subtle bg-clip-text text-transparent leading-tight">
             {t('heroTitle')}
           </h1>
-          <p className="text-xl text-neutral-400 mb-12 leading-relaxed max-w-xl">
+          <p className="text-xl text-subtle mb-12 leading-relaxed max-w-xl">
             {t('heroSubtitle')}
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
             <Link
               href="/generator"
-              className="px-8 py-4 bg-white text-black font-bold rounded-xl hover:bg-neutral-200 transition-all text-center shadow-xl shadow-white/5"
+              className="px-8 py-4 bg-card text-foreground font-bold rounded-xl hover:bg-surface-strong transition-all text-center shadow-xl shadow-white/5"
             >
               {t('generateLink')}
             </Link>
             <Link
               href="/dashboard"
-              className="px-8 py-4 bg-neutral-900 text-white font-bold rounded-xl hover:bg-neutral-800 transition-all border border-white/10 text-center"
+              className="px-8 py-4 bg-card text-foreground font-bold rounded-xl hover:bg-surface-strong transition-all border border-border-strong text-center"
             >
               {t('goToDashboard')}
             </Link>
           </div>
         </div>
         <div className="grid md:grid-cols-3 gap-8 mt-32 md:mt-48">
-          <div className="p-8 rounded-3xl bg-neutral-900/50 border border-white/5 hover:border-indigo-500/20 transition-colors group">
+          <div className="p-8 rounded-3xl bg-card/50 border border-border hover:border-indigo-500/20 transition-colors group">
             <div className="w-12 h-12 bg-indigo-500/10 rounded-2xl flex items-center justify-center mb-6 group-hover:bg-indigo-500/20 transition">
               <span className="text-2xl">👤</span>
             </div>
             <h3 className="text-xl font-bold mb-4">{t('shareableUsernames')}</h3>
-            <p className="text-neutral-400">{t('shareableUsernamesDesc')}</p>
+            <p className="text-subtle">{t('shareableUsernamesDesc')}</p>
           </div>
-          <div className="p-8 rounded-3xl bg-neutral-900/50 border border-white/5 hover:border-indigo-500/20 transition-colors group">
+          <div className="p-8 rounded-3xl bg-card/50 border border-border hover:border-indigo-500/20 transition-colors group">
             <div className="w-12 h-12 bg-indigo-500/10 rounded-2xl flex items-center justify-center mb-6 group-hover:bg-indigo-500/20 transition">
               <span className="text-2xl">🛡️</span>
             </div>
             <h3 className="text-xl font-bold mb-4">{t('shieldedTransactions')}</h3>
-            <p className="text-neutral-400">{t('shieldedTransactionsDesc')}</p>
+            <p className="text-subtle">{t('shieldedTransactionsDesc')}</p>
           </div>
-          <div className="p-8 rounded-3xl bg-neutral-900/50 border border-white/5 hover:border-indigo-500/20 transition-colors group">
+          <div className="p-8 rounded-3xl bg-card/50 border border-border hover:border-indigo-500/20 transition-colors group">
             <div className="w-12 h-12 bg-indigo-500/10 rounded-2xl flex items-center justify-center mb-6 group-hover:bg-indigo-500/20 transition">
               <span className="text-2xl">⚡</span>
             </div>
             <h3 className="text-xl font-bold mb-4">{t('instantPayments')}</h3>
-            <p className="text-neutral-400">{t('instantPaymentsDesc')}</p>
+            <p className="text-subtle">{t('instantPaymentsDesc')}</p>
           </div>
         </div>
       </section>

--- a/app/frontend/src/app/pay/PaymentPageClient.tsx
+++ b/app/frontend/src/app/pay/PaymentPageClient.tsx
@@ -163,7 +163,7 @@ function PaymentPageContent() {
 
   if (fetchState === "loading") {
     return (
-      <div className="min-h-screen bg-black text-white">
+      <div className="min-h-screen bg-background text-foreground">
         <NetworkBadge />
         <LoadingState />
       </div>
@@ -172,7 +172,7 @@ function PaymentPageContent() {
 
   if (fetchState === "error") {
     return (
-      <div className="min-h-screen bg-black text-white">
+      <div className="min-h-screen bg-background text-foreground">
         <NetworkBadge />
         <ErrorState
           message={error || "Failed to load payment link"}
@@ -185,7 +185,7 @@ function PaymentPageContent() {
 
   if (!status) {
     return (
-      <div className="min-h-screen bg-black text-white">
+      <div className="min-h-screen bg-background text-foreground">
         <NetworkBadge />
         <ErrorState
           message="Payment link data is unavailable"
@@ -224,7 +224,7 @@ function PaymentPageContent() {
   };
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       <NetworkBadge />
       <main className="container mx-auto px-4 py-12 max-w-2xl">
         {renderStateComponent()}
@@ -243,7 +243,7 @@ export default function PaymentPageClient() {
 
 function LoadingFallback() {
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       <NetworkBadge />
       <LoadingState />
     </div>

--- a/app/frontend/src/app/settings/developer/page.tsx
+++ b/app/frontend/src/app/settings/developer/page.tsx
@@ -178,7 +178,7 @@ export default function DeveloperSettings() {
   // ---------------------------------------------------------------------------
 
   return (
-    <div className="relative min-h-screen text-white selection:bg-indigo-500/30 overflow-x-hidden">
+    <div className="relative min-h-screen text-foreground selection:bg-indigo-500/30 overflow-x-hidden">
       {/* Background glows */}
       <div className="fixed top-[-20%] left-[-30%] w-[60%] h-[60%] bg-indigo-500/10 blur-[120px] pointer-events-none" />
       <div className="fixed bottom-[-20%] right-[-30%] w-[50%] h-[50%] bg-purple-500/5 blur-[100px] pointer-events-none" />
@@ -191,13 +191,13 @@ export default function DeveloperSettings() {
         <nav className="flex gap-3 mb-10">
           <Link
             href="/settings"
-            className="px-4 py-2 rounded-xl border border-white/10 text-sm font-semibold text-neutral-400 hover:text-white hover:bg-white/5 transition"
+            className="px-4 py-2 rounded-xl border border-border-strong text-sm font-semibold text-subtle hover:text-foreground hover:bg-surface transition"
           >
             General
           </Link>
           <Link
             href="/settings/developer"
-            className="px-4 py-2 rounded-xl border border-indigo-500/40 bg-indigo-500/10 text-indigo-300 text-sm font-semibold"
+            className="px-4 py-2 rounded-xl border border-indigo-500/40 bg-indigo-500/10 text-brand text-sm font-semibold"
           >
             Developer
           </Link>
@@ -207,7 +207,7 @@ export default function DeveloperSettings() {
         {error && (
           <div className="mb-6 px-4 py-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm flex items-center justify-between">
             <span>{error}</span>
-            <button onClick={() => setError(null)} className="ml-4 text-red-300 hover:text-white text-xs font-bold">
+            <button onClick={() => setError(null)} className="ml-4 text-danger hover:text-foreground text-xs font-bold">
               Dismiss
             </button>
           </div>
@@ -215,11 +215,11 @@ export default function DeveloperSettings() {
 
         <div className="space-y-6">
           {/* API Keys section */}
-          <section className="p-6 rounded-3xl bg-neutral-900/40 border border-white/5 space-y-6">
+          <section className="p-6 rounded-3xl bg-card border border-border space-y-6">
             <div className="flex items-center justify-between">
               <div>
                 <h2 className="text-xl font-bold">API Keys</h2>
-                <p className="text-sm text-neutral-500 mt-1">
+                <p className="text-sm text-subtle mt-1">
                   Manage keys used to authenticate requests to the QuickEx API.
                 </p>
               </div>
@@ -234,13 +234,13 @@ export default function DeveloperSettings() {
             {/* Key list */}
             <div className="space-y-3">
               {loadingKeys && (
-                <div className="text-center py-10 text-neutral-600 text-sm">
+                <div className="text-center py-10 text-faint text-sm">
                   Loading keys…
                 </div>
               )}
 
               {!loadingKeys && keys.length === 0 && (
-                <div className="text-center py-10 text-neutral-600 text-sm">
+                <div className="text-center py-10 text-faint text-sm">
                   No API keys yet. Create one to get started.
                 </div>
               )}
@@ -255,7 +255,7 @@ export default function DeveloperSettings() {
                 return (
                   <div
                     key={key.id}
-                    className="flex flex-col sm:flex-row sm:items-start gap-4 p-4 rounded-2xl bg-black/30 border border-white/5"
+                    className="flex flex-col sm:flex-row sm:items-start gap-4 p-4 rounded-2xl bg-background/30 border border-border"
                   >
                     {/* Key info */}
                     <div className="flex-1 min-w-0 space-y-2">
@@ -264,13 +264,13 @@ export default function DeveloperSettings() {
                         {key.scopes.map((scope) => (
                           <span
                             key={scope}
-                            className="text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border text-indigo-300 border-indigo-500/30 bg-indigo-500/10"
+                            className="text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border text-brand border-indigo-500/30 bg-indigo-500/10"
                           >
                             {scope}
                           </span>
                         ))}
                       </div>
-                      <div className="font-mono text-sm text-neutral-400 truncate">
+                      <div className="font-mono text-sm text-subtle truncate">
                         {displayKey}
                       </div>
                       {key.rawKey && (
@@ -278,7 +278,7 @@ export default function DeveloperSettings() {
                           Save this key now — it won&apos;t be shown again.
                         </p>
                       )}
-                      <div className="text-xs text-neutral-600">
+                      <div className="text-xs text-faint">
                         Created{" "}
                         {new Date(key.created_at).toLocaleDateString("en-US", {
                           month: "short",
@@ -295,7 +295,7 @@ export default function DeveloperSettings() {
                             })}
                           </span>
                         )}
-                        <span className="ml-2 text-neutral-700">
+                        <span className="ml-2 text-faint">
                           {key.request_count.toLocaleString()} requests
                         </span>
                       </div>
@@ -306,7 +306,7 @@ export default function DeveloperSettings() {
                       {!key.rawKey && (
                         <button
                           onClick={() => toggleReveal(key.id)}
-                          className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-300 hover:bg-white/10 hover:text-white transition"
+                          className="px-3 py-2 rounded-xl bg-surface border border-border-strong text-xs font-semibold text-muted hover:bg-surface-strong hover:text-foreground transition"
                         >
                           {key.revealed ? "Hide" : "Reveal"}
                         </button>
@@ -314,7 +314,7 @@ export default function DeveloperSettings() {
 
                       <button
                         onClick={() => copyKey(key.id, key.rawKey ?? key.key_prefix)}
-                        className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-300 hover:bg-white/10 hover:text-white transition"
+                        className="px-3 py-2 rounded-xl bg-surface border border-border-strong text-xs font-semibold text-muted hover:bg-surface-strong hover:text-foreground transition"
                       >
                         {key.copyLabel === "Copied!" ? "✓ Copied!" : "⧉ Copy"}
                       </button>
@@ -322,7 +322,7 @@ export default function DeveloperSettings() {
                       <button
                         onClick={() => rotateKey(key.id)}
                         disabled={rotatingId === key.id}
-                        className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-300 hover:bg-white/10 hover:text-white disabled:opacity-40 transition"
+                        className="px-3 py-2 rounded-xl bg-surface border border-border-strong text-xs font-semibold text-muted hover:bg-surface-strong hover:text-foreground disabled:opacity-40 transition"
                       >
                         {rotatingId === key.id ? "Rotating…" : "↻ Rotate"}
                       </button>
@@ -337,7 +337,7 @@ export default function DeveloperSettings() {
                           </button>
                           <button
                             onClick={() => setRevokeId(null)}
-                            className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-neutral-400 hover:text-white transition"
+                            className="px-3 py-2 rounded-xl bg-surface border border-border-strong text-xs font-semibold text-subtle hover:text-foreground transition"
                           >
                             Cancel
                           </button>
@@ -345,7 +345,7 @@ export default function DeveloperSettings() {
                       ) : (
                         <button
                           onClick={() => setRevokeId(key.id)}
-                          className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-semibold text-red-400 hover:bg-red-500/10 hover:border-red-500/20 transition"
+                          className="px-3 py-2 rounded-xl bg-surface border border-border-strong text-xs font-semibold text-red-400 hover:bg-red-500/10 hover:border-red-500/20 transition"
                         >
                           Revoke
                         </button>
@@ -358,10 +358,10 @@ export default function DeveloperSettings() {
           </section>
 
           {/* Usage quota section */}
-          <section className="p-6 rounded-3xl bg-neutral-900/40 border border-white/5 space-y-4">
+          <section className="p-6 rounded-3xl bg-card border border-border space-y-4">
             <div>
               <h2 className="text-xl font-bold">Monthly Usage</h2>
-              <p className="text-sm text-neutral-500 mt-1">
+              <p className="text-sm text-subtle mt-1">
                 API requests used this billing period across all keys.
               </p>
             </div>
@@ -370,24 +370,24 @@ export default function DeveloperSettings() {
               <div className="flex justify-between items-end">
                 <span className="text-3xl font-black">
                   {usedRequests.toLocaleString()}
-                  <span className="text-lg text-neutral-500 font-semibold ml-1">
+                  <span className="text-lg text-subtle font-semibold ml-1">
                     / {quota.toLocaleString()}
                   </span>
                 </span>
-                <span className="text-sm font-bold text-neutral-400">
+                <span className="text-sm font-bold text-subtle">
                   {usagePercent}% used
                 </span>
               </div>
 
               {/* Progress bar */}
-              <div className="h-2.5 w-full rounded-full bg-white/5 overflow-hidden">
+              <div className="h-2.5 w-full rounded-full bg-surface overflow-hidden">
                 <div
                   className={`h-full rounded-full transition-all duration-700 ${usageColor}`}
                   style={{ width: `${usagePercent}%` }}
                 />
               </div>
 
-              <p className="text-xs text-neutral-600">
+              <p className="text-xs text-faint">
                 {(quota - usedRequests).toLocaleString()} requests remaining.
                 Resets on {resetLabel}.
               </p>
@@ -395,7 +395,7 @@ export default function DeveloperSettings() {
           </section>
 
           {/* Scope reference */}
-          <section className="p-6 rounded-3xl bg-neutral-900/40 border border-white/5 space-y-4">
+          <section className="p-6 rounded-3xl bg-card border border-border space-y-4">
             <h2 className="text-xl font-bold">Scope Reference</h2>
             <div className="grid sm:grid-cols-2 gap-4">
               {[
@@ -408,10 +408,10 @@ export default function DeveloperSettings() {
                   key={scope}
                   className="p-4 rounded-2xl bg-indigo-500/5 border border-indigo-500/20 space-y-1"
                 >
-                  <span className="text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full text-indigo-300 border border-indigo-500/30 bg-indigo-500/10 font-mono">
+                  <span className="text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full text-brand border border-indigo-500/30 bg-indigo-500/10 font-mono">
                     {scope}
                   </span>
-                  <p className="text-sm text-neutral-400 mt-2">{desc}</p>
+                  <p className="text-sm text-subtle mt-2">{desc}</p>
                 </div>
               ))}
             </div>

--- a/app/frontend/src/app/settings/page.tsx
+++ b/app/frontend/src/app/settings/page.tsx
@@ -28,7 +28,7 @@ export default function Settings() {
   };
 
   return (
-    <div className="relative min-h-screen text-white selection:bg-indigo-500/30">
+    <div className="relative min-h-screen text-foreground selection:bg-indigo-500/30">
       <NetworkBadge />
 
       {/* Background glows */}
@@ -36,11 +36,11 @@ export default function Settings() {
       <div className="fixed bottom-[-20%] right-[-30%] w-[50%] h-[50%] bg-purple-500/5 blur-[100px] rounded-full" />
 
       {/* MOBILE HEADER */}
-      <div className="md:hidden relative z-10 p-4 border-b border-white/5 bg-black/20 backdrop-blur-3xl">
+      <div className="md:hidden relative z-10 p-4 border-b border-border bg-card backdrop-blur-3xl">
         <div className="flex items-center justify-between">
           <Link
             href="/dashboard"
-            className="text-neutral-400 hover:text-white transition"
+            className="text-subtle hover:text-foreground transition"
           >
             ← Back
           </Link>
@@ -50,29 +50,29 @@ export default function Settings() {
       </div>
 
       {/* DESKTOP SIDEBAR */}
-      <aside className="hidden md:flex w-72 h-screen fixed left-0 top-0 border-r border-white/5 bg-black/20 backdrop-blur-3xl flex-col z-20">
+      <aside className="hidden md:flex w-72 h-screen fixed left-0 top-0 border-r border-border bg-card backdrop-blur-3xl flex-col z-20">
         <nav className="flex-1 px-4 py-30 space-y-2">
           <Link
             href="/dashboard"
-            className="flex items-center gap-3 px-4 py-3 text-neutral-500 hover:text-white hover:bg-white/5 rounded-2xl font-semibold transition"
+            className="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition"
           >
             <span>📊</span> Dashboard
           </Link>
           <Link
             href="/generator"
-            className="flex items-center gap-3 px-4 py-3 text-neutral-500 hover:text-white hover:bg-white/5 rounded-2xl font-semibold transition"
+            className="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition"
           >
             <span>⚡</span> Link Generator
           </Link>
           <Link
             href="/settings"
-            className="flex items-center gap-3 px-4 py-3 bg-white/5 border border-white/5 rounded-2xl font-bold"
+            className="flex items-center gap-3 px-4 py-3 bg-surface border border-border rounded-2xl font-bold"
           >
             <span className="text-indigo-400">⚙️</span> Profile Settings
           </Link>
           <Link
             href="/settings/teams"
-            className="flex items-center gap-3 px-4 py-3 text-neutral-500 hover:text-white hover:bg-white/5 rounded-2xl font-semibold transition"
+            className="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition"
           >
             <span>👥</span> Team Management
           </Link>
@@ -86,14 +86,14 @@ export default function Settings() {
           <h1 className="text-3xl sm:text-4xl font-black tracking-tight mb-2">
             {t('profileCustomization')}
           </h1>
-          <p className="text-neutral-500 font-medium text-sm sm:text-base">
+          <p className="text-subtle font-medium text-sm sm:text-base">
             {t('profileCustomizationDescription', { username: form.username })}
           </p>
         </header>
 
         {/* Mobile subheader */}
         <div className="md:hidden mb-6">
-          <p className="text-neutral-400 text-sm">
+          <p className="text-subtle text-sm">
             {t('profileCustomizationDescription', { username: form.username })}
           </p>
         </div>
@@ -101,19 +101,19 @@ export default function Settings() {
         <nav className="flex gap-3 mb-8">
           <Link
             href="/settings"
-            className="px-4 py-2 rounded-xl border border-white/10 bg-white/10 text-sm font-semibold hover:bg-white/20"
+            className="px-4 py-2 rounded-xl border border-border-strong bg-surface-strong text-sm font-semibold hover:bg-surface-strong"
           >
             {t('generalTab')}
           </Link>
           <Link
             href="/settings/teams"
-            className="px-4 py-2 rounded-xl border border-white/10 text-sm font-semibold hover:bg-white/5"
+            className="px-4 py-2 rounded-xl border border-border-strong text-sm font-semibold hover:bg-surface"
           >
             Team
           </Link>
           <Link
             href="/settings/developer"
-            className="px-4 py-2 rounded-xl border border-white/10 text-sm font-semibold hover:bg-white/5"
+            className="px-4 py-2 rounded-xl border border-border-strong text-sm font-semibold hover:bg-surface"
           >
             {t('developerTab')}
           </Link>
@@ -123,14 +123,14 @@ export default function Settings() {
           {/* Settings Form */}
           <div className="space-y-4 sm:space-y-6">
             {/* Theme Settings Card */}
-            <div className="rounded-2xl sm:rounded-3xl bg-black/40 border border-white/5 p-5 sm:p-6 md:p-8">
+            <div className="rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8">
               <h2 className="text-lg sm:text-xl font-bold mb-4 sm:mb-6">
                 {t('themeSettings')}
               </h2>
 
               <div className="space-y-4">
                 <div>
-                  <label className="block text-xs sm:text-sm font-bold text-neutral-400 mb-2">
+                  <label className="block text-xs sm:text-sm font-bold text-subtle mb-2">
                     {t('primaryColor')}
                   </label>
                   <div className="flex gap-2 sm:gap-3">
@@ -140,7 +140,7 @@ export default function Settings() {
                       onChange={(e) =>
                         setForm({ ...form, primaryColor: e.target.value })
                       }
-                      className="w-14 sm:w-16 h-11 sm:h-12 rounded-xl border border-white/10 bg-transparent cursor-pointer"
+                      className="w-14 sm:w-16 h-11 sm:h-12 rounded-xl border border-border-strong bg-transparent cursor-pointer"
                     />
                     <input
                       type="text"
@@ -148,14 +148,14 @@ export default function Settings() {
                       onChange={(e) =>
                         setForm({ ...form, primaryColor: e.target.value })
                       }
-                      className="flex-1 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-white/5 border border-white/10 text-white font-mono text-sm sm:text-base"
+                      className="flex-1 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground font-mono text-sm sm:text-base"
                       placeholder="#6366f1"
                     />
                   </div>
                 </div>
 
                 <div>
-                  <label className="block text-xs sm:text-sm font-bold text-neutral-400 mb-2">
+                  <label className="block text-xs sm:text-sm font-bold text-subtle mb-2">
                     {t('avatarUrl')}
                   </label>
                   <input
@@ -164,13 +164,13 @@ export default function Settings() {
                     onChange={(e) =>
                       setForm({ ...form, avatarUrl: e.target.value })
                     }
-                    className="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm sm:text-base"
+                    className="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
                     placeholder="https://example.com/avatar.jpg"
                   />
                 </div>
 
                 <div>
-                  <label className="block text-xs sm:text-sm font-bold text-neutral-400 mb-2">
+                  <label className="block text-xs sm:text-sm font-bold text-subtle mb-2">
                     {t('bioLabel')}
                   </label>
                   <textarea
@@ -178,39 +178,39 @@ export default function Settings() {
                     onChange={(e) => setForm({ ...form, bio: e.target.value })}
                     maxLength={160}
                     rows={3}
-                    className="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-white/5 border border-white/10 text-white resize-none text-sm sm:text-base"
+                    className="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground resize-none text-sm sm:text-base"
                     placeholder="Building the future of payments on Stellar"
                   />
-                  <p className="text-xs text-neutral-600 mt-1">
+                  <p className="text-xs text-faint mt-1">
                     {form.bio.length}/160 characters
                   </p>
                 </div>
               </div>
             </div>
 
-            <div className="rounded-2xl sm:rounded-3xl bg-black/40 border border-white/5 p-5 sm:p-6 md:p-8">
+            <div className="rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8">
               <h2 className="text-lg sm:text-xl font-bold mb-4 sm:mb-6">
                 {t('languageLabel')}
               </h2>
-              <p className="text-sm text-neutral-400 mb-4">
+              <p className="text-sm text-subtle mb-4">
                 {t('changeLanguage')}
               </p>
               <LocaleSwitcher />
             </div>
 
             {/* Social Links Card */}
-            <div className="rounded-2xl sm:rounded-3xl bg-black/40 border border-white/5 p-5 sm:p-6 md:p-8">
+            <div className="rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8">
               <h2 className="text-lg sm:text-xl font-bold mb-4 sm:mb-6">
                 Social Links
               </h2>
 
               <div className="space-y-4">
                 <div>
-                  <label className="block text-xs sm:text-sm font-bold text-neutral-400 mb-2">
+                  <label className="block text-xs sm:text-sm font-bold text-subtle mb-2">
                     {t('twitterHandleLabel')}
                   </label>
                   <div className="flex items-center gap-2">
-                    <span className="text-neutral-500 text-sm sm:text-base">
+                    <span className="text-subtle text-sm sm:text-base">
                       @
                     </span>
                     <input
@@ -219,7 +219,7 @@ export default function Settings() {
                       onChange={(e) =>
                         setForm({ ...form, twitterHandle: e.target.value })
                       }
-                      className="flex-1 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm sm:text-base"
+                      className="flex-1 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
                       placeholder="stellarorg"
                       maxLength={15}
                     />
@@ -227,7 +227,7 @@ export default function Settings() {
                 </div>
 
                 <div>
-                  <label className="block text-xs sm:text-sm font-bold text-neutral-400 mb-2">
+                  <label className="block text-xs sm:text-sm font-bold text-subtle mb-2">
                     {t('discordUsernameLabel')}
                   </label>
                   <input
@@ -236,14 +236,14 @@ export default function Settings() {
                     onChange={(e) =>
                       setForm({ ...form, discordHandle: e.target.value })
                     }
-                    className="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm sm:text-base"
+                    className="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
                     placeholder="user#1234"
                     maxLength={32}
                   />
                 </div>
 
                 <div>
-                  <label className="block text-xs sm:text-sm font-bold text-neutral-400 mb-2">
+                  <label className="block text-xs sm:text-sm font-bold text-subtle mb-2">
                     {t('githubHandleLabel')}
                   </label>
                   <input
@@ -252,7 +252,7 @@ export default function Settings() {
                     onChange={(e) =>
                       setForm({ ...form, githubHandle: e.target.value })
                     }
-                    className="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm sm:text-base"
+                    className="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
                     placeholder="stellar"
                     maxLength={39}
                   />
@@ -270,7 +270,7 @@ export default function Settings() {
               </button>
               <button
                 onClick={() => setShowPreview(!showPreview)}
-                className="px-4 sm:px-6 py-3 sm:py-4 bg-white/5 border border-white/10 text-white font-bold rounded-xl hover:bg-white/10 transition text-sm sm:text-base whitespace-nowrap"
+                className="px-4 sm:px-6 py-3 sm:py-4 bg-surface border border-border-strong text-foreground font-bold rounded-xl hover:bg-surface-strong transition text-sm sm:text-base whitespace-nowrap"
               >
                 {showPreview ? t('hide') : t('show')} {t('preview')}
               </button>
@@ -280,9 +280,9 @@ export default function Settings() {
           {/* Live Preview - Desktop */}
           {showPreview && (
             <div className="hidden lg:block lg:sticky lg:top-12 h-fit">
-              <div className="rounded-3xl bg-black/40 border border-white/5 p-8">
+              <div className="rounded-3xl bg-card border border-border p-8">
                 <h2 className="text-xl font-bold mb-6">{t('livePreview')}</h2>
-                <div className="rounded-2xl border border-white/10 overflow-hidden bg-neutral-950">
+                <div className="rounded-2xl border border-border-strong overflow-hidden bg-background">
                   <ProfilePreview {...form} />
                 </div>
               </div>
@@ -291,11 +291,11 @@ export default function Settings() {
 
           {/* Live Preview - Mobile/Tablet (when toggled) */}
           {showPreview && (
-            <div className="lg:hidden rounded-2xl sm:rounded-3xl bg-black/40 border border-white/5 p-5 sm:p-6 md:p-8">
+            <div className="lg:hidden rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8">
               <h2 className="text-lg sm:text-xl font-bold mb-4 sm:mb-6">
                 {t('livePreview')}
               </h2>
-              <div className="rounded-2xl border border-white/10 overflow-hidden bg-neutral-950">
+              <div className="rounded-2xl border border-border-strong overflow-hidden bg-background">
                 <ProfilePreview {...form} />
               </div>
             </div>
@@ -304,7 +304,7 @@ export default function Settings() {
       </main>
 
       {/* MOBILE BOTTOM BAR */}
-      <div className="sm:hidden fixed bottom-0 left-0 right-0 z-30 p-4 bg-black/80 backdrop-blur-3xl border-t border-white/5">
+      <div className="sm:hidden fixed bottom-0 left-0 right-0 z-30 p-4 bg-card backdrop-blur-3xl border-t border-border">
         <div className="flex gap-3">
           <button
             onClick={handleSave}
@@ -314,7 +314,7 @@ export default function Settings() {
           </button>
           <button
             onClick={() => setShowPreview(!showPreview)}
-            className="px-4 py-3 bg-white/5 border border-white/10 text-white font-bold rounded-xl active:scale-95 transition"
+            className="px-4 py-3 bg-surface border border-border-strong text-foreground font-bold rounded-xl active:scale-95 transition"
           >
             {showPreview ? t('hide') : t('show')} {t('preview')}
           </button>
@@ -369,7 +369,7 @@ function ProfilePreview({
 
       {/* Bio */}
       {bio && (
-        <p className="text-neutral-400 text-xs sm:text-sm mb-4 sm:mb-6 px-2">
+        <p className="text-subtle text-xs sm:text-sm mb-4 sm:mb-6 px-2">
           {bio}
         </p>
       )}
@@ -382,7 +382,7 @@ function ProfilePreview({
               href={`https://twitter.com/${twitterHandle}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-white/5 hover:bg-white/10 flex items-center justify-center transition text-sm sm:text-base"
+              className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-surface hover:bg-surface-strong flex items-center justify-center transition text-sm sm:text-base"
               style={{ color: primaryColor }}
             >
               𝕏
@@ -390,7 +390,7 @@ function ProfilePreview({
           )}
           {discordHandle && (
             <div
-              className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-white/5 flex items-center justify-center text-sm sm:text-base"
+              className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-surface flex items-center justify-center text-sm sm:text-base"
               style={{ color: primaryColor }}
             >
               💬
@@ -401,7 +401,7 @@ function ProfilePreview({
               href={`https://github.com/${githubHandle}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-white/5 hover:bg-white/10 flex items-center justify-center transition text-sm sm:text-base"
+              className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-surface hover:bg-surface-strong flex items-center justify-center transition text-sm sm:text-base"
               style={{ color: primaryColor }}
             >
               🐙
@@ -412,7 +412,7 @@ function ProfilePreview({
 
       {/* Payment Button */}
       <button
-        className="w-full py-3 sm:py-4 rounded-xl font-bold text-white transition hover:opacity-90 text-sm sm:text-base"
+        className="w-full py-3 sm:py-4 rounded-xl font-bold text-foreground transition hover:opacity-90 text-sm sm:text-base"
         style={{ backgroundColor: primaryColor }}
       >
         Send Payment

--- a/app/frontend/src/app/settings/teams/page.tsx
+++ b/app/frontend/src/app/settings/teams/page.tsx
@@ -32,20 +32,20 @@ export default function TeamSettings() {
   };
 
   return (
-    <div className="relative min-h-screen text-white">
+    <div className="relative min-h-screen text-foreground">
       {/* Background glows */}
       <div className="fixed top-[-20%] left-[-30%] w-[60%] h-[60%] bg-indigo-500/10 blur-[120px] rounded-full" />
 
       {/* DESKTOP SIDEBAR (Reused from settings) */}
-      <aside className="hidden md:flex w-72 h-screen fixed left-0 top-0 border-r border-white/5 bg-black/20 backdrop-blur-3xl flex-col z-20">
+      <aside className="hidden md:flex w-72 h-screen fixed left-0 top-0 border-r border-border bg-card backdrop-blur-3xl flex-col z-20">
         <nav className="flex-1 px-4 py-30 space-y-2">
-          <Link href="/dashboard" className="flex items-center gap-3 px-4 py-3 text-neutral-500 hover:text-white hover:bg-white/5 rounded-2xl font-semibold transition">
+          <Link href="/dashboard" className="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition">
             <span>📊</span> Dashboard
           </Link>
-          <Link href="/settings" className="flex items-center gap-3 px-4 py-3 text-neutral-500 hover:text-white hover:bg-white/5 rounded-2xl font-semibold transition">
+          <Link href="/settings" className="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition">
             <span>⚙️</span> Profile Settings
           </Link>
-          <Link href="/settings/teams" className="flex items-center gap-3 px-4 py-3 bg-white/5 border border-white/5 rounded-2xl font-bold">
+          <Link href="/settings/teams" className="flex items-center gap-3 px-4 py-3 bg-surface border border-border rounded-2xl font-bold">
             <span className="text-indigo-400">👥</span> Team Management
           </Link>
         </nav>
@@ -54,23 +54,23 @@ export default function TeamSettings() {
       <main className="relative z-10 p-4 sm:p-6 md:p-12 md:ml-72">
         <header className="mb-10">
           <h1 className="text-3xl font-black tracking-tight mb-2">Team Management</h1>
-          <p className="text-neutral-500 font-medium">Manage members, roles, and workspace permissions.</p>
+          <p className="text-subtle font-medium">Manage members, roles, and workspace permissions.</p>
         </header>
 
         <nav className="flex gap-3 mb-8">
-          <Link href="/settings" className="px-4 py-2 rounded-xl border border-white/10 text-sm font-semibold hover:bg-white/5 transition">
+          <Link href="/settings" className="px-4 py-2 rounded-xl border border-border-strong text-sm font-semibold hover:bg-surface transition">
             General
           </Link>
-          <Link href="/settings/teams" className="px-4 py-2 rounded-xl border border-white/10 bg-white/10 text-sm font-semibold">
+          <Link href="/settings/teams" className="px-4 py-2 rounded-xl border border-border-strong bg-surface-strong text-sm font-semibold">
             Team
           </Link>
-          <Link href="/settings/developer" className="px-4 py-2 rounded-xl border border-white/10 text-sm font-semibold hover:bg-white/5 transition">
+          <Link href="/settings/developer" className="px-4 py-2 rounded-xl border border-border-strong text-sm font-semibold hover:bg-surface transition">
             Developer
           </Link>
         </nav>
 
-        <div className="rounded-3xl bg-black/40 border border-white/5 overflow-hidden">
-          <div className="p-6 border-b border-white/5 flex justify-between items-center">
+        <div className="rounded-3xl bg-card border border-border overflow-hidden">
+          <div className="p-6 border-b border-border flex justify-between items-center">
             <h2 className="text-xl font-bold">Workspace Members</h2>
             <button 
               disabled={userRole !== "admin"}
@@ -78,7 +78,7 @@ export default function TeamSettings() {
             >
               + Invite Member
               {userRole !== "admin" && (
-                <span className="block text-[10px] text-indigo-200 font-medium">Admin only</span>
+                <span className="block text-[10px] text-brand font-medium">Admin only</span>
               )}
             </button>
           </div>
@@ -86,24 +86,24 @@ export default function TeamSettings() {
           <div className="overflow-x-auto">
             <table className="w-full text-left">
               <thead>
-                <tr className="text-neutral-500 text-xs font-bold uppercase tracking-wider">
+                <tr className="text-subtle text-xs font-bold uppercase tracking-wider">
                   <th className="px-6 py-4">Member</th>
                   <th className="px-6 py-4">Role</th>
                   <th className="px-6 py-4">Status</th>
                   <th className="px-6 py-4 text-right">Actions</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-white/5">
+              <tbody className="divide-y divide-border">
                 {members.map((member) => (
-                  <tr key={member.id} className="group hover:bg-white/[0.02] transition">
+                  <tr key={member.id} className="group hover:bg-card/[0.02] transition">
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 bg-neutral-800 rounded-full flex items-center justify-center font-bold text-indigo-400">
+                        <div className="w-10 h-10 bg-surface-strong rounded-full flex items-center justify-center font-bold text-indigo-400">
                           {member.name[0]}
                         </div>
                         <div>
                           <p className="font-bold">{member.name}</p>
-                          <p className="text-xs text-neutral-500">{member.email}</p>
+                          <p className="text-xs text-subtle">{member.email}</p>
                         </div>
                       </div>
                     </td>
@@ -112,7 +112,7 @@ export default function TeamSettings() {
                         value={member.role}
                         disabled={userRole !== "admin" || member.id === "1"} // Can't change own role or if not admin
                         onChange={(e) => handleRoleChange(member.id, e.target.value as "admin" | "operator" | "viewer")}
-                        className="bg-neutral-900 border border-white/10 rounded-lg px-2 py-1 text-sm outline-none focus:border-indigo-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="bg-card border border-border-strong rounded-lg px-2 py-1 text-sm outline-none focus:border-indigo-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <option value="admin">Admin</option>
                         <option value="operator">Operator</option>
@@ -121,7 +121,7 @@ export default function TeamSettings() {
                     </td>
                     <td className="px-6 py-4">
                       <span className={`px-2 py-1 rounded-md text-[10px] font-black uppercase tracking-widest ${
-                        member.status === "active" ? "bg-emerald-500/10 text-emerald-500" : "bg-amber-500/10 text-amber-500"
+                        member.status === "active" ? "bg-success-soft text-emerald-500" : "bg-warning-soft text-amber-500"
                       }`}>
                         {member.status}
                       </span>
@@ -130,7 +130,7 @@ export default function TeamSettings() {
                       <button 
                         onClick={() => removeMember(member.id)}
                         disabled={userRole !== "admin" || member.id === "1"}
-                        className="p-2 text-neutral-500 hover:text-red-500 transition disabled:opacity-0"
+                        className="p-2 text-subtle hover:text-red-500 transition disabled:opacity-0"
                       >
                         🗑️
                       </button>
@@ -144,17 +144,17 @@ export default function TeamSettings() {
 
         {/* Role Descriptions */}
         <div className="mt-12 grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="p-6 rounded-2xl bg-white/5 border border-white/5">
+          <div className="p-6 rounded-2xl bg-surface border border-border">
             <p className="text-indigo-400 font-black text-xs uppercase mb-2">Admin</p>
-            <p className="text-sm text-neutral-400">Full access to all settings, team management, and financial operations.</p>
+            <p className="text-sm text-subtle">Full access to all settings, team management, and financial operations.</p>
           </div>
-          <div className="p-6 rounded-2xl bg-white/5 border border-white/5">
+          <div className="p-6 rounded-2xl bg-surface border border-border">
             <p className="text-purple-400 font-black text-xs uppercase mb-2">Operator</p>
-            <p className="text-sm text-neutral-400">Can manage links and view analytics, but cannot manage team or workspace settings.</p>
+            <p className="text-sm text-subtle">Can manage links and view analytics, but cannot manage team or workspace settings.</p>
           </div>
-          <div className="p-6 rounded-2xl bg-white/5 border border-white/5">
-            <p className="text-neutral-400 font-black text-xs uppercase mb-2">Viewer</p>
-            <p className="text-sm text-neutral-400">Read-only access to dashboard and analytics. Cannot perform any actions.</p>
+          <div className="p-6 rounded-2xl bg-surface border border-border">
+            <p className="text-subtle font-black text-xs uppercase mb-2">Viewer</p>
+            <p className="text-sm text-subtle">Read-only access to dashboard and analytics. Cannot perform any actions.</p>
           </div>
         </div>
       </main>

--- a/app/frontend/src/app/webhooks/page.tsx
+++ b/app/frontend/src/app/webhooks/page.tsx
@@ -92,30 +92,30 @@ export default function WebhooksPage() {
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* List View */}
-        <div className="md:col-span-1 bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden">
-          <div className="p-4 border-b border-gray-200 bg-gray-50">
-            <h2 className="font-semibold text-gray-700">Endpoints</h2>
+        <div className="md:col-span-1 bg-card border border-border rounded-lg shadow-sm overflow-hidden">
+          <div className="p-4 border-b border-border bg-background">
+            <h2 className="font-semibold text-muted">Endpoints</h2>
           </div>
-          <ul className="divide-y divide-gray-200">
+          <ul className="divide-y divide-border">
             {webhooks.length === 0 && (
-              <li className="p-4 text-sm text-gray-500 text-center">No webhooks found.</li>
+              <li className="p-4 text-sm text-subtle text-center">No webhooks found.</li>
             )}
             {webhooks.map(wh => (
               <li
                 key={wh.id}
                 onClick={() => setSelectedWebhook(wh)}
-                className={`p-4 cursor-pointer hover:bg-gray-50 transition-colors ${selectedWebhook?.id === wh.id ? 'bg-blue-50 border-l-4 border-blue-500' : ''}`}
+                className={`p-4 cursor-pointer hover:bg-background transition-colors ${selectedWebhook?.id === wh.id ? 'bg-brand-soft border-l-4 border-blue-500' : ''}`}
               >
                 <div className="flex justify-between items-start mb-1">
                   <span className="font-medium text-sm truncate pr-2" title={wh.url}>{wh.url}</span>
-                  <span className={`text-xs px-2 py-1 rounded-full ${wh.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>
+                  <span className={`text-xs px-2 py-1 rounded-full ${wh.status === 'active' ? 'bg-success-soft text-success' : 'bg-surface text-foreground'}`}>
                     {wh.status}
                   </span>
                 </div>
-                <div className="text-xs text-gray-500 flex items-center space-x-2">
+                <div className="text-xs text-subtle flex items-center space-x-2">
                   <span>{wh.events.length} events</span>
                   {wh.lastDeliveryStatus && (
-                    <span className={`flex items-center ${wh.lastDeliveryStatus === 'success' ? 'text-green-600' : 'text-red-600'}`}>
+                    <span className={`flex items-center ${wh.lastDeliveryStatus === 'success' ? 'text-success' : 'text-danger'}`}>
                       <span className="mr-1">•</span>
                       Last test: {wh.lastDeliveryStatus}
                     </span>
@@ -129,15 +129,15 @@ export default function WebhooksPage() {
         {/* Detail View */}
         <div className="md:col-span-2">
           {selectedWebhook ? (
-            <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-6">
+            <div className="bg-card border border-border rounded-lg shadow-sm p-6">
               <div className="flex justify-between items-start mb-6">
                 <div>
                   <h2 className="text-xl font-bold mb-2 break-all">{selectedWebhook.url}</h2>
                   <div className="flex space-x-2">
-                    <span className={`text-xs px-2 py-1 rounded-full ${selectedWebhook.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>
+                    <span className={`text-xs px-2 py-1 rounded-full ${selectedWebhook.status === 'active' ? 'bg-success-soft text-success' : 'bg-surface text-foreground'}`}>
                       {selectedWebhook.status.toUpperCase()}
                     </span>
-                    <span className="text-xs px-2 py-1 rounded-full bg-gray-100 text-gray-600">
+                    <span className="text-xs px-2 py-1 rounded-full bg-surface text-muted">
                       ID: {selectedWebhook.id}
                     </span>
                   </div>
@@ -145,14 +145,14 @@ export default function WebhooksPage() {
                 <div className="flex space-x-2">
                   <button
                     onClick={() => handleTestWebhook(selectedWebhook.id)}
-                    className="border border-gray-300 text-gray-700 px-3 py-1.5 rounded-md hover:bg-gray-50 text-sm transition-colors"
+                    className="border border-border-strong text-muted px-3 py-1.5 rounded-md hover:bg-background text-sm transition-colors"
                   >
                     Test Webhook
                   </button>
                   {selectedWebhook.status === 'active' && (
                     <button
                       onClick={() => handleDisableWebhook(selectedWebhook.id)}
-                      className="border border-red-300 text-red-600 px-3 py-1.5 rounded-md hover:bg-red-50 text-sm transition-colors"
+                      className="border border-danger-soft text-danger px-3 py-1.5 rounded-md hover:bg-danger-soft text-sm transition-colors"
                     >
                       Disable
                     </button>
@@ -162,10 +162,10 @@ export default function WebhooksPage() {
 
               <div className="space-y-6">
                 <div>
-                  <h3 className="text-sm font-semibold text-gray-700 mb-2">Subscribed Events</h3>
+                  <h3 className="text-sm font-semibold text-muted mb-2">Subscribed Events</h3>
                   <div className="flex flex-wrap gap-2">
                     {selectedWebhook.events.map(ev => (
-                      <span key={ev} className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-md">
+                      <span key={ev} className="text-xs bg-brand-soft text-brand px-2 py-1 rounded-md">
                         {ev}
                       </span>
                     ))}
@@ -173,15 +173,15 @@ export default function WebhooksPage() {
                 </div>
 
                 <div>
-                  <h3 className="text-sm font-semibold text-gray-700 mb-2">Signing Secret</h3>
-                  <p className="text-xs text-gray-500 mb-2">Use this secret to verify that webhooks were sent by QuickEx.</p>
+                  <h3 className="text-sm font-semibold text-muted mb-2">Signing Secret</h3>
+                  <p className="text-xs text-subtle mb-2">Use this secret to verify that webhooks were sent by QuickEx.</p>
                   <div className="flex items-center">
-                    <code className="bg-gray-100 px-3 py-2 rounded-l-md text-sm font-mono border border-gray-200 border-r-0 flex-grow">
+                    <code className="bg-surface px-3 py-2 rounded-l-md text-sm font-mono border border-border border-r-0 flex-grow">
                       {revealedSecrets[selectedWebhook.id] ? selectedWebhook.signingSecret : '••••••••••••••••••••••••••••••••'}
                     </code>
                     <button
                       onClick={() => toggleSecret(selectedWebhook.id)}
-                      className="bg-gray-200 hover:bg-gray-300 text-gray-700 px-4 py-2 rounded-r-md text-sm border border-gray-200 border-l-0 transition-colors"
+                      className="bg-surface-strong hover:bg-surface-strong text-muted px-4 py-2 rounded-r-md text-sm border border-border border-l-0 transition-colors"
                     >
                       {revealedSecrets[selectedWebhook.id] ? 'Hide' : 'Reveal'}
                     </button>
@@ -190,8 +190,8 @@ export default function WebhooksPage() {
                 
                 {selectedWebhook.lastDeliveryStatus && (
                   <div>
-                    <h3 className="text-sm font-semibold text-gray-700 mb-2">Recent Test Delivery</h3>
-                    <div className={`p-3 rounded-md border text-sm ${selectedWebhook.lastDeliveryStatus === 'success' ? 'bg-green-50 border-green-200 text-green-800' : 'bg-red-50 border-red-200 text-red-800'}`}>
+                    <h3 className="text-sm font-semibold text-muted mb-2">Recent Test Delivery</h3>
+                    <div className={`p-3 rounded-md border text-sm ${selectedWebhook.lastDeliveryStatus === 'success' ? 'bg-success-soft border-success-soft text-success' : 'bg-danger-soft border-danger-soft text-danger'}`}>
                       {selectedWebhook.lastDeliveryStatus === 'success' 
                         ? 'Test payload delivered successfully with HTTP 200 OK.' 
                         : 'Delivery failed. Endpoint returned a non-200 status code or timed out.'}
@@ -201,7 +201,7 @@ export default function WebhooksPage() {
               </div>
             </div>
           ) : (
-            <div className="bg-gray-50 border border-gray-200 rounded-lg flex items-center justify-center h-64 text-gray-500">
+            <div className="bg-background border border-border rounded-lg flex items-center justify-center h-64 text-subtle">
               Select a webhook to view details
             </div>
           )}
@@ -210,49 +210,49 @@ export default function WebhooksPage() {
 
       {/* Create Modal */}
       {isCreateModalOpen && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-md overflow-hidden">
-            <div className="p-4 border-b border-gray-200 flex justify-between items-center">
+        <div className="fixed inset-0 bg-background/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-card rounded-lg shadow-xl w-full max-w-md overflow-hidden">
+            <div className="p-4 border-b border-border flex justify-between items-center">
               <h2 className="text-lg font-bold">Create Webhook Endpoint</h2>
-              <button onClick={() => setIsCreateModalOpen(false)} className="text-gray-400 hover:text-gray-600">
+              <button onClick={() => setIsCreateModalOpen(false)} className="text-subtle hover:text-muted">
                 ✕
               </button>
             </div>
             <form onSubmit={handleCreateWebhook}>
               <div className="p-4 space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Endpoint URL</label>
+                  <label className="block text-sm font-medium text-muted mb-1">Endpoint URL</label>
                   <input
                     type="url"
                     required
                     value={newWebhookUrl}
                     onChange={(e) => setNewWebhookUrl(e.target.value)}
                     placeholder="https://api.yourdomain.com/webhook"
-                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="w-full border border-border-strong rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">Events to send</label>
-                  <div className="space-y-2 border border-gray-200 rounded-md p-3 max-h-48 overflow-y-auto">
+                  <label className="block text-sm font-medium text-muted mb-2">Events to send</label>
+                  <div className="space-y-2 border border-border rounded-md p-3 max-h-48 overflow-y-auto">
                     {EVENT_TYPES.map(ev => (
                       <label key={ev} className="flex items-center space-x-2">
                         <input
                           type="checkbox"
                           checked={newWebhookEvents.includes(ev)}
                           onChange={() => handleToggleEvent(ev)}
-                          className="rounded text-blue-600 focus:ring-blue-500"
+                          className="rounded text-brand focus:ring-brand"
                         />
-                        <span className="text-sm text-gray-700">{ev}</span>
+                        <span className="text-sm text-muted">{ev}</span>
                       </label>
                     ))}
                   </div>
                 </div>
               </div>
-              <div className="p-4 border-t border-gray-200 bg-gray-50 flex justify-end space-x-2">
+              <div className="p-4 border-t border-border bg-background flex justify-end space-x-2">
                 <button
                   type="button"
                   onClick={() => setIsCreateModalOpen(false)}
-                  className="px-4 py-2 border border-gray-300 text-gray-700 rounded-md text-sm hover:bg-gray-100 transition-colors"
+                  className="px-4 py-2 border border-border-strong text-muted rounded-md text-sm hover:bg-surface transition-colors"
                 >
                   Cancel
                 </button>

--- a/app/frontend/src/components/AnalyticsDashboard.tsx
+++ b/app/frontend/src/components/AnalyticsDashboard.tsx
@@ -52,7 +52,7 @@ function DateRangeFilter({
   onChange: (r: DateRange) => void;
 }) {
   return (
-    <div className="inline-flex gap-1 p-1 rounded-xl bg-white/5 border border-white/5">
+    <div className="inline-flex gap-1 p-1 rounded-xl bg-surface border border-border">
       {RANGES.map((r) => (
         <button
           key={r.value}
@@ -61,7 +61,7 @@ function DateRangeFilter({
           className={`px-3 py-1.5 text-xs font-black rounded-lg transition-all ${
             active === r.value
               ? "bg-indigo-500 text-white shadow-lg shadow-indigo-500/20"
-              : "text-neutral-500 hover:text-white hover:bg-white/5"
+              : "text-subtle hover:text-foreground hover:bg-surface"
           }`}
         >
           {r.label}
@@ -75,14 +75,14 @@ function DateRangeFilter({
 
 const tooltipStyle = {
   contentStyle: {
-    background: "rgba(10,10,20,0.9)",
-    border: "1px solid rgba(255,255,255,0.06)",
+    background: "var(--chart-tooltip-bg)",
+    border: "1px solid var(--chart-tooltip-border)",
     borderRadius: "12px",
-    color: "#fff",
+    color: "var(--chart-tooltip-text)",
     fontSize: "12px",
-    boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+    boxShadow: "0 8px 32px rgba(0,0,0,0.25)",
   },
-  labelStyle: { color: "#6366f1", fontWeight: 800 },
+  labelStyle: { color: "var(--brand)", fontWeight: 800 },
   cursor: { stroke: "rgba(99,102,241,0.3)", strokeWidth: 2 },
 };
 
@@ -91,8 +91,8 @@ const tooltipStyle = {
 function ChartSkeleton() {
   return (
     <div className="animate-pulse flex flex-col gap-3 h-full">
-      <div className="h-4 bg-white/5 rounded w-1/3" />
-      <div className="flex-1 bg-white/[0.03] rounded-2xl" />
+      <div className="h-4 bg-surface rounded w-1/3" />
+      <div className="flex-1 bg-surface rounded-2xl" />
     </div>
   );
 }
@@ -110,8 +110,8 @@ function StatCard({
 }) {
   const positive = (change ?? 0) >= 0;
   return (
-    <div className="p-5 rounded-2xl bg-white/[0.03] border border-white/5 flex flex-col gap-1">
-      <p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
+    <div className="p-5 rounded-2xl bg-surface border border-border flex flex-col gap-1">
+      <p className="text-[10px] font-black uppercase tracking-widest text-subtle">
         {label}
       </p>
       <p className="text-2xl font-black">{value}</p>
@@ -148,7 +148,7 @@ function DonutLabel({
         x={cx}
         y={cy - 8}
         textAnchor="middle"
-        fill="#6366f1"
+        fill="var(--brand)"
         style={{ fontSize: 11, fontWeight: 900, letterSpacing: 2 }}
       >
         TOTAL
@@ -157,7 +157,7 @@ function DonutLabel({
         x={cx}
         y={cy + 12}
         textAnchor="middle"
-        fill="#fff"
+        fill="var(--chart-tooltip-text)"
         style={{ fontSize: 18, fontWeight: 900 }}
       >
         {total}%
@@ -221,15 +221,15 @@ export default function AnalyticsDashboard() {
   return (
     <section
       id="analytics-dashboard"
-      className="rounded-3xl bg-black/40 border border-white/5 backdrop-blur-2xl shadow-2xl overflow-hidden"
+      className="rounded-3xl bg-card border border-border backdrop-blur-2xl shadow-2xl overflow-hidden"
     >
       {/* ── Header ── */}
-      <div className="p-6 sm:p-10 border-b border-white/5 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+      <div className="p-6 sm:p-10 border-b border-border flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h2 className="text-xl sm:text-2xl font-black mb-1">
             Analytics Overview
           </h2>
-          <p className="text-xs sm:text-sm text-neutral-500">
+          <p className="text-xs sm:text-sm text-subtle">
             Payment volume, transaction counts &amp; asset distribution
           </p>
         </div>
@@ -241,7 +241,7 @@ export default function AnalyticsDashboard() {
               onChange={(event) =>
                 setReportType(event.target.value as "accounting" | "tax")
               }
-              className="rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-xs font-black text-neutral-200"
+              className="rounded-lg border border-border-strong bg-surface px-2 py-1.5 text-xs font-black text-muted"
               aria-label="Select report type"
             >
               <option value="accounting">Accounting</option>
@@ -251,7 +251,7 @@ export default function AnalyticsDashboard() {
               type="button"
               onClick={() => void handleExport("csv")}
               disabled={exporting !== null}
-              className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-black text-neutral-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-lg border border-border-strong bg-surface px-3 py-1.5 text-xs font-black text-muted transition hover:bg-surface-strong disabled:cursor-not-allowed disabled:opacity-60"
             >
               {exporting === "csv" ? "Exporting..." : "Export CSV"}
             </button>
@@ -259,13 +259,13 @@ export default function AnalyticsDashboard() {
               type="button"
               onClick={() => void handleExport("pdf")}
               disabled={exporting !== null}
-              className="rounded-lg border border-indigo-400/30 bg-indigo-500/10 px-3 py-1.5 text-xs font-black text-indigo-100 transition hover:bg-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-lg border border-indigo-400/30 bg-indigo-500/10 px-3 py-1.5 text-xs font-black text-brand transition hover:bg-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {exporting === "pdf" ? "Exporting..." : "Export PDF"}
             </button>
           </div>
           {exportMessage ? (
-            <p className="text-[11px] font-bold text-neutral-300">{exportMessage}</p>
+            <p className="text-[11px] font-bold text-muted">{exportMessage}</p>
           ) : null}
         </div>
       </div>
@@ -277,7 +277,7 @@ export default function AnalyticsDashboard() {
             Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
-                className="animate-pulse h-24 rounded-2xl bg-white/[0.03]"
+                className="animate-pulse h-24 rounded-2xl bg-surface"
               />
             ))
           ) : (
@@ -309,7 +309,7 @@ export default function AnalyticsDashboard() {
 
         {/* ── Area Chart: Payment Volume ── */}
         <div>
-          <h3 className="text-sm font-black uppercase tracking-widest text-neutral-500 mb-5">
+          <h3 className="text-sm font-black uppercase tracking-widest text-subtle mb-5">
             Payment Volume
           </h3>
           <div className="h-64">
@@ -333,18 +333,18 @@ export default function AnalyticsDashboard() {
                   </defs>
                   <CartesianGrid
                     strokeDasharray="3 3"
-                    stroke="rgba(255,255,255,0.04)"
+                    stroke="var(--chart-grid)"
                     vertical={false}
                   />
                   <XAxis
                     dataKey="date"
-                    tick={{ fill: "#525252", fontSize: 10, fontWeight: 700 }}
+                    tick={{ fill: "var(--chart-axis)", fontSize: 10, fontWeight: 700 }}
                     axisLine={false}
                     tickLine={false}
                     interval="preserveStartEnd"
                   />
                   <YAxis
-                    tick={{ fill: "#525252", fontSize: 10, fontWeight: 700 }}
+                    tick={{ fill: "var(--chart-axis)", fontSize: 10, fontWeight: 700 }}
                     axisLine={false}
                     tickLine={false}
                     tickFormatter={(v: number) => `$${v}`}
@@ -394,7 +394,7 @@ export default function AnalyticsDashboard() {
         <div className="grid md:grid-cols-2 gap-10">
           {/* Line Chart: Transaction Count */}
           <div>
-            <h3 className="text-sm font-black uppercase tracking-widest text-neutral-500 mb-5">
+            <h3 className="text-sm font-black uppercase tracking-widest text-subtle mb-5">
               Transaction Count
             </h3>
             <div className="h-56">
@@ -408,18 +408,18 @@ export default function AnalyticsDashboard() {
                   >
                     <CartesianGrid
                       strokeDasharray="3 3"
-                      stroke="rgba(255,255,255,0.04)"
+                      stroke="var(--chart-grid)"
                       vertical={false}
                     />
                     <XAxis
                       dataKey="date"
-                      tick={{ fill: "#525252", fontSize: 10, fontWeight: 700 }}
+                      tick={{ fill: "var(--chart-axis)", fontSize: 10, fontWeight: 700 }}
                       axisLine={false}
                       tickLine={false}
                       interval="preserveStartEnd"
                     />
                     <YAxis
-                      tick={{ fill: "#525252", fontSize: 10, fontWeight: 700 }}
+                      tick={{ fill: "var(--chart-axis)", fontSize: 10, fontWeight: 700 }}
                       axisLine={false}
                       tickLine={false}
                     />
@@ -448,7 +448,7 @@ export default function AnalyticsDashboard() {
 
           {/* Donut Chart: Asset Distribution */}
           <div>
-            <h3 className="text-sm font-black uppercase tracking-widest text-neutral-500 mb-5">
+            <h3 className="text-sm font-black uppercase tracking-widest text-subtle mb-5">
               Asset Distribution
             </h3>
             <div className="h-56 flex items-center justify-center">

--- a/app/frontend/src/components/BidModal.tsx
+++ b/app/frontend/src/components/BidModal.tsx
@@ -51,7 +51,7 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       {/* Blurred backdrop */}
       <div
-        className="absolute inset-0 bg-black/70 backdrop-blur-md"
+        className="absolute inset-0 bg-background/70 backdrop-blur-md"
         onClick={bidState === "loading" ? undefined : handleClose}
       />
 
@@ -59,19 +59,19 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
         {/* Glow aura */}
         <div className="absolute -inset-1 bg-gradient-to-br from-indigo-500/30 via-purple-500/20 to-transparent rounded-3xl blur-xl pointer-events-none" />
 
-        <div className="relative bg-neutral-900/90 border border-white/10 rounded-3xl p-8 shadow-2xl backdrop-blur-2xl">
+        <div className="relative bg-card/90 border border-border-strong rounded-3xl p-8 shadow-2xl backdrop-blur-2xl">
 
           {/* ── SUCCESS STATE ─────────────────────────────── */}
           {bidState === "success" && (
             <div className="text-center py-4 space-y-5">
               <div className="text-6xl animate-bounce">🎉</div>
               <h2 className="text-2xl font-black">Bid Placed!</h2>
-              <p className="text-neutral-400">
+              <p className="text-subtle">
                 You&apos;re leading with{" "}
                 <span className="text-indigo-400 font-bold">{parsedAmount} USDC</span> on{" "}
-                <span className="text-white font-bold">@{listing.username}</span>.
+                <span className="text-foreground font-bold">@{listing.username}</span>.
               </p>
-              <div className="p-4 bg-indigo-500/10 rounded-2xl border border-indigo-500/20 text-left text-xs text-neutral-400 font-mono">
+              <div className="p-4 bg-indigo-500/10 rounded-2xl border border-indigo-500/20 text-left text-xs text-subtle font-mono">
                 <p className="font-bold text-indigo-400 mb-1">tx signed & broadcast ✓</p>
                 <p>Network: Stellar Testnet</p>
                 <p>Asset: USDC</p>
@@ -93,7 +93,7 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
               {/* Header */}
               <div className="flex justify-between items-start mb-6">
                 <div>
-                  <p className="text-xs text-neutral-500 uppercase tracking-widest font-bold mb-1">
+                  <p className="text-xs text-subtle uppercase tracking-widest font-bold mb-1">
                     Place a Bid
                   </p>
                   <h2 className="text-2xl font-black tracking-tight">
@@ -103,7 +103,7 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
                 <button
                   onClick={handleClose}
                   disabled={bidState === "loading"}
-                  className="w-9 h-9 rounded-full bg-white/5 border border-white/10 flex items-center justify-center text-neutral-400 hover:text-white hover:bg-white/10 transition"
+                  className="w-9 h-9 rounded-full bg-surface border border-border-strong flex items-center justify-center text-subtle hover:text-foreground hover:bg-surface-strong transition"
                 >
                   ✕
                 </button>
@@ -118,9 +118,9 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
                 ].map((s) => (
                   <div
                     key={s.label}
-                    className="p-3 bg-white/5 rounded-2xl border border-white/5 text-center"
+                    className="p-3 bg-surface rounded-2xl border border-border text-center"
                   >
-                    <p className="text-[10px] uppercase tracking-widest font-bold text-neutral-500 mb-1">
+                    <p className="text-[10px] uppercase tracking-widest font-bold text-subtle mb-1">
                       {s.label}
                     </p>
                     <p className="font-black text-sm">{s.value}</p>
@@ -129,7 +129,7 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
               </div>
 
               {/* Input */}
-              <label className="block mb-2 text-xs font-bold uppercase tracking-widest text-neutral-500">
+              <label className="block mb-2 text-xs font-bold uppercase tracking-widest text-subtle">
                 Your Bid (USDC)
               </label>
               <div className="relative mb-4">
@@ -141,7 +141,7 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
                   value={amount}
                   onChange={(e) => setAmount(e.target.value)}
                   disabled={bidState === "loading"}
-                  className="w-full bg-white/5 border border-white/10 focus:border-indigo-500/60 rounded-xl px-4 py-4 pr-20 font-bold text-white placeholder-neutral-600 outline-none transition text-lg"
+                  className="w-full bg-surface border border-border-strong focus:border-indigo-500/60 rounded-xl px-4 py-4 pr-20 font-bold text-foreground placeholder-neutral-600 outline-none transition text-lg"
                 />
                 <span className="absolute right-4 top-1/2 -translate-y-1/2 text-xs font-black text-indigo-400 tracking-widest">
                   USDC
@@ -163,7 +163,7 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
               )}
 
               {/* Wallet warning */}
-              <div className="flex items-start gap-3 p-3 mb-5 bg-amber-500/5 border border-amber-500/15 rounded-2xl">
+              <div className="flex items-start gap-3 p-3 mb-5 bg-warning-soft border border-amber-500/15 rounded-2xl">
                 <span className="text-amber-400 mt-0.5">🔑</span>
                 <div className="text-[11px] text-amber-400/80 leading-relaxed">
                   <p className="font-bold mb-1">Wallet Connection Required</p>
@@ -210,7 +210,7 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
                   className={`w-full py-4 rounded-xl font-black text-base tracking-wide transition-all ${
                     isValid
                       ? "bg-indigo-500 text-white hover:bg-indigo-400 shadow-[0_12px_40px_-15px_rgba(99,102,241,0.6)]"
-                      : "bg-white/5 text-neutral-600 cursor-not-allowed"
+                      : "bg-surface text-faint cursor-not-allowed"
                   }`}
                 >
                   Review Bid →
@@ -220,7 +220,7 @@ export function BidModal({ listing, onClose, onBidSuccess }: BidModalProps) {
                   <button
                     onClick={() => setShowPreview(false)}
                     disabled={bidState === "loading"}
-                    className="flex-1 py-4 bg-white/5 text-neutral-400 font-bold rounded-xl hover:bg-white/10 transition"
+                    className="flex-1 py-4 bg-surface text-subtle font-bold rounded-xl hover:bg-surface-strong transition"
                   >
                     Back
                   </button>

--- a/app/frontend/src/components/CreateAPIKeyModal.tsx
+++ b/app/frontend/src/components/CreateAPIKeyModal.tsx
@@ -40,17 +40,17 @@ export default function CreateAPIKeyModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-card backdrop-blur-sm"
         onClick={() => !loading && setModalOpen(false)}
       />
 
       {/* Modal */}
-      <div className="relative w-full max-w-md bg-neutral-900 border border-white/10 rounded-3xl p-8 shadow-2xl space-y-6">
+      <div className="relative w-full max-w-md bg-card border border-border-strong rounded-3xl p-8 shadow-2xl space-y-6">
         <h3 className="text-xl font-black">Create New API Key</h3>
 
         {/* Key name */}
         <div className="space-y-2">
-          <label className="text-xs font-black uppercase tracking-widest text-neutral-500">
+          <label className="text-xs font-black uppercase tracking-widest text-subtle">
             Key Name
           </label>
           <input
@@ -60,13 +60,13 @@ export default function CreateAPIKeyModal({
             onChange={(e) =>
               setNewKey((prev) => ({ ...prev, name: e.target.value }))
             }
-            className="w-full bg-neutral-800 border border-white/10 rounded-xl px-4 py-3 text-white text-sm font-semibold focus:outline-none focus:border-indigo-500/60 placeholder:text-neutral-600"
+            className="w-full bg-surface-strong border border-border-strong rounded-xl px-4 py-3 text-foreground text-sm font-semibold focus:outline-none focus:border-indigo-500/60 placeholder:text-faint"
           />
         </div>
 
         {/* Scope selection */}
         <div className="space-y-2">
-          <label className="text-xs font-black uppercase tracking-widest text-neutral-500">
+          <label className="text-xs font-black uppercase tracking-widest text-subtle">
             Scopes
           </label>
           <div className="space-y-2">
@@ -79,23 +79,23 @@ export default function CreateAPIKeyModal({
                   className={`w-full p-3 rounded-xl border text-left transition flex items-center gap-3 ${
                     active
                       ? "border-indigo-500/40 bg-indigo-500/10"
-                      : "border-white/10 bg-white/5 hover:bg-white/10"
+                      : "border-border-strong bg-surface hover:bg-surface-strong"
                   }`}
                 >
                   <div
                     className={`w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center text-[10px] ${
                       active
                         ? "border-indigo-500 bg-indigo-500 text-white"
-                        : "border-white/20"
+                        : "border-border-strong"
                     }`}
                   >
                     {active && "✓"}
                   </div>
                   <div>
-                    <div className={`text-xs font-bold font-mono ${active ? "text-indigo-300" : "text-neutral-400"}`}>
+                    <div className={`text-xs font-bold font-mono ${active ? "text-brand" : "text-subtle"}`}>
                       {SCOPE_LABELS[scope].label}
                     </div>
-                    <div className="text-xs text-neutral-600 mt-0.5">
+                    <div className="text-xs text-faint mt-0.5">
                       {SCOPE_LABELS[scope].description}
                     </div>
                   </div>
@@ -110,7 +110,7 @@ export default function CreateAPIKeyModal({
           <button
             onClick={() => setModalOpen(false)}
             disabled={loading}
-            className="flex-1 py-3 rounded-xl border border-white/10 text-sm font-semibold text-neutral-400 hover:text-white hover:bg-white/5 disabled:opacity-40 transition"
+            className="flex-1 py-3 rounded-xl border border-border-strong text-sm font-semibold text-subtle hover:text-foreground hover:bg-surface disabled:opacity-40 transition"
           >
             Cancel
           </button>

--- a/app/frontend/src/components/ErrorBoundary.tsx
+++ b/app/frontend/src/components/ErrorBoundary.tsx
@@ -62,18 +62,18 @@ export class ErrorBoundary extends Component<
   render() {
     if (this.state.hasError) {
       return (
-        <section className="mx-auto flex min-h-[60vh] max-w-3xl flex-col items-center justify-center gap-6 rounded-3xl border border-white/10 bg-neutral-950/90 p-8 text-center shadow-2xl shadow-black/20">
-          <p className="text-sm uppercase tracking-[0.22em] text-neutral-400">
+        <section className="mx-auto flex min-h-[60vh] max-w-3xl flex-col items-center justify-center gap-6 rounded-3xl border border-border-strong bg-background/90 p-8 text-center shadow-2xl shadow-black/20">
+          <p className="text-sm uppercase tracking-[0.22em] text-subtle">
             Something went wrong
           </p>
-          <h1 className="text-3xl font-semibold text-white">An error occurred</h1>
-          <p className="max-w-xl text-neutral-300">
+          <h1 className="text-3xl font-semibold text-foreground">An error occurred</h1>
+          <p className="max-w-xl text-muted">
             This issue has been captured and can be reported with your request details.
           </p>
           <button
             type="button"
             onClick={this.handleReportClick}
-            className="rounded-full bg-white px-6 py-3 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-100"
+            className="rounded-full bg-card px-6 py-3 text-sm font-semibold text-foreground transition hover:bg-surface-strong"
           >
             Report Issue
           </button>

--- a/app/frontend/src/components/Header.tsx
+++ b/app/frontend/src/components/Header.tsx
@@ -4,11 +4,12 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LocaleSwitcher } from "@/components/LocaleSwitcher";
 import { NotificationBell } from "@/components/NotificationBell";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import "@/lib/i18n";
 import { useTranslation } from "react-i18next";
 
 const NAV_LINK_CLASS =
-  "rounded-md px-1 py-1 text-neutral-200 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950";
+  "rounded-md px-1 py-1 text-muted transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 export function Header() {
   const { t } = useTranslation();
@@ -18,7 +19,7 @@ export function Header() {
     pathname === href || pathname?.startsWith(`${href}/`);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-white/5 bg-neutral-950/80 backdrop-blur-xl">
+    <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-xl">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-indigo-500 focus:px-3 focus:py-2 focus:text-sm focus:font-semibold focus:text-white"
@@ -36,11 +37,11 @@ export function Header() {
         >
           <div
             aria-hidden="true"
-            className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-500 font-bold italic"
+            className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-500 font-bold italic text-white"
           >
             Q
           </div>
-          <span className="text-xl font-bold tracking-tight text-white">
+          <span className="text-xl font-bold tracking-tight text-foreground">
             QuickEx
           </span>
         </Link>
@@ -50,7 +51,7 @@ export function Header() {
             href="/dashboard"
             aria-current={isActive("/dashboard") ? "page" : undefined}
             className={`${NAV_LINK_CLASS} ${
-              isActive("/dashboard") ? "text-white" : ""
+              isActive("/dashboard") ? "text-foreground" : ""
             }`}
           >
             {t("dashboard")}
@@ -59,7 +60,7 @@ export function Header() {
             href="/generator"
             aria-current={isActive("/generator") ? "page" : undefined}
             className={`${NAV_LINK_CLASS} ${
-              isActive("/generator") ? "text-white" : ""
+              isActive("/generator") ? "text-foreground" : ""
             }`}
           >
             {t("linkGenerator")}
@@ -68,7 +69,7 @@ export function Header() {
             href="/notifications"
             aria-current={isActive("/notifications") ? "page" : undefined}
             className={`${NAV_LINK_CLASS} ${
-              isActive("/notifications") ? "text-white" : ""
+              isActive("/notifications") ? "text-foreground" : ""
             }`}
           >
             Notifications
@@ -77,7 +78,7 @@ export function Header() {
             href="/settings"
             aria-current={isActive("/settings") ? "page" : undefined}
             className={`${NAV_LINK_CLASS} ${
-              isActive("/settings") ? "text-white" : ""
+              isActive("/settings") ? "text-foreground" : ""
             }`}
           >
             {t("profileSettings")}
@@ -85,6 +86,7 @@ export function Header() {
         </div>
 
         <div className="flex items-center gap-4">
+          <ThemeToggle />
           <NotificationBell />
           <LocaleSwitcher />
         </div>

--- a/app/frontend/src/components/ListingDetailModal.tsx
+++ b/app/frontend/src/components/ListingDetailModal.tsx
@@ -33,48 +33,48 @@ export function ListingDetailModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/75 backdrop-blur-md" onClick={onClose} />
+      <div className="absolute inset-0 bg-background/75 backdrop-blur-md" onClick={onClose} />
 
-      <div className="relative z-10 w-full max-w-4xl overflow-hidden rounded-[32px] border border-white/10 bg-neutral-950/90 shadow-2xl">
+      <div className="relative z-10 w-full max-w-4xl overflow-hidden rounded-[32px] border border-border-strong bg-background/90 shadow-2xl">
         <div className="grid gap-0 lg:grid-cols-[1.1fr_0.9fr]">
-          <section className="border-b border-white/10 p-8 lg:border-b-0 lg:border-r">
+          <section className="border-b border-border-strong p-8 lg:border-b-0 lg:border-r">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <p className="text-xs font-black uppercase tracking-[0.3em] text-indigo-300">
+                <p className="text-xs font-black uppercase tracking-[0.3em] text-brand">
                   Listing Detail
                 </p>
-                <h2 className="mt-3 text-4xl font-black text-white">@{listing.username}</h2>
-                <p className="mt-3 max-w-xl text-sm leading-6 text-neutral-400">
+                <h2 className="mt-3 text-4xl font-black text-foreground">@{listing.username}</h2>
+                <p className="mt-3 max-w-xl text-sm leading-6 text-subtle">
                   {CATEGORY_COPY[listing.category]} This listing is receiving live auction updates while the marketplace connection stays active.
                 </p>
               </div>
               <button
                 type="button"
                 onClick={onClose}
-                className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-neutral-300 transition hover:bg-white/10 hover:text-white"
+                className="flex h-10 w-10 items-center justify-center rounded-full border border-border-strong bg-surface text-muted transition hover:bg-surface-strong hover:text-foreground"
               >
                 ✕
               </button>
             </div>
 
             <div className="mt-8 grid gap-4 sm:grid-cols-2">
-              <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-5">
-                <p className="text-[10px] font-black uppercase tracking-[0.25em] text-neutral-500">
+              <div className="rounded-3xl border border-border-strong bg-surface p-5">
+                <p className="text-[10px] font-black uppercase tracking-[0.25em] text-subtle">
                   Current Bid
                 </p>
-                <p className="mt-3 text-3xl font-black text-white">
-                  {listing.currentBid.toLocaleString()} <span className="text-base text-neutral-500">USDC</span>
+                <p className="mt-3 text-3xl font-black text-foreground">
+                  {listing.currentBid.toLocaleString()} <span className="text-base text-subtle">USDC</span>
                 </p>
-                <p className="mt-2 text-xs text-neutral-500">
+                <p className="mt-2 text-xs text-subtle">
                   Minimum next bid: {minimumBid.toLocaleString()} USDC
                 </p>
               </div>
-              <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-5">
-                <p className="text-[10px] font-black uppercase tracking-[0.25em] text-neutral-500">
+              <div className="rounded-3xl border border-border-strong bg-surface p-5">
+                <p className="text-[10px] font-black uppercase tracking-[0.25em] text-subtle">
                   Auction Clock
                 </p>
-                <p className="mt-3 text-3xl font-black text-white">{formatCountdown(listing.endsAt)}</p>
-                <p className="mt-2 text-xs text-neutral-500">
+                <p className="mt-3 text-3xl font-black text-foreground">{formatCountdown(listing.endsAt)}</p>
+                <p className="mt-2 text-xs text-subtle">
                   Created {listing.createdAt.toLocaleDateString()} with live bid refresh enabled
                 </p>
               </div>
@@ -86,20 +86,20 @@ export function ListingDetailModal({
                 { label: "Bid Count", value: listing.bidCount.toLocaleString() },
                 { label: "Seller", value: listing.ownerAddress },
               ].map((item) => (
-                <div key={item.label} className="rounded-2xl border border-white/10 bg-black/20 p-4">
-                  <p className="text-[10px] font-black uppercase tracking-[0.2em] text-neutral-500">
+                <div key={item.label} className="rounded-2xl border border-border-strong bg-card p-4">
+                  <p className="text-[10px] font-black uppercase tracking-[0.2em] text-subtle">
                     {item.label}
                   </p>
-                  <p className="mt-2 text-sm font-semibold text-white">{item.value}</p>
+                  <p className="mt-2 text-sm font-semibold text-foreground">{item.value}</p>
                 </div>
               ))}
             </div>
 
             <div className="mt-8 rounded-[28px] border border-indigo-400/20 bg-indigo-500/10 p-5">
-              <p className="text-xs font-black uppercase tracking-[0.25em] text-indigo-200">
+              <p className="text-xs font-black uppercase tracking-[0.25em] text-brand">
                 Bidding Rules
               </p>
-              <ul className="mt-4 space-y-3 text-sm leading-6 text-indigo-50/90">
+              <ul className="mt-4 space-y-3 text-sm leading-6 text-brand/90">
                 <li>Minimum increments start at 1 USDC above the current high bid.</li>
                 <li>Winning bidders pay only the final amount they confirmed on-chain.</li>
                 <li>Buy-now pricing, when present, ends the auction immediately for the first confirmed buyer.</li>
@@ -109,29 +109,29 @@ export function ListingDetailModal({
           </section>
 
           <aside className="p-8">
-            <div className="rounded-[28px] border border-white/10 bg-white/[0.03] p-5">
-              <p className="text-xs font-black uppercase tracking-[0.25em] text-neutral-500">
+            <div className="rounded-[28px] border border-border-strong bg-surface p-5">
+              <p className="text-xs font-black uppercase tracking-[0.25em] text-subtle">
                 Live Activity Snapshot
               </p>
               <div className="mt-5 space-y-4">
-                <div className="rounded-2xl border border-emerald-400/15 bg-emerald-500/10 p-4">
-                  <p className="text-sm font-semibold text-white">Real-time updates connected</p>
-                  <p className="mt-1 text-xs leading-5 text-emerald-50/80">
+                <div className="rounded-2xl border border-emerald-400/15 bg-success-soft p-4">
+                  <p className="text-sm font-semibold text-foreground">Real-time updates connected</p>
+                  <p className="mt-1 text-xs leading-5 text-success/80">
                     Bid counts and current price refresh automatically whenever listing activity arrives.
                   </p>
                 </div>
-                <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
-                  <p className="text-sm font-semibold text-white">Watchlist status</p>
-                  <p className="mt-1 text-xs leading-5 text-neutral-400">
+                <div className="rounded-2xl border border-border-strong bg-card p-4">
+                  <p className="text-sm font-semibold text-foreground">Watchlist status</p>
+                  <p className="mt-1 text-xs leading-5 text-subtle">
                     {isWatched
                       ? "This listing is already saved to your watchlist."
                       : "Save this listing to your watchlist to revisit it quickly later."}
                   </p>
                 </div>
                 {listing.buyNowPrice && (
-                  <div className="rounded-2xl border border-amber-400/15 bg-amber-500/10 p-4">
-                    <p className="text-sm font-semibold text-white">Buy now available</p>
-                    <p className="mt-1 text-xs leading-5 text-amber-50/80">
+                  <div className="rounded-2xl border border-amber-400/15 bg-warning-soft p-4">
+                    <p className="text-sm font-semibold text-foreground">Buy now available</p>
+                    <p className="mt-1 text-xs leading-5 text-warning/80">
                       Immediate purchase price: {listing.buyNowPrice.toLocaleString()} USDC.
                     </p>
                   </div>
@@ -145,8 +145,8 @@ export function ListingDetailModal({
                 onClick={() => onToggleWatchlist(listing)}
                 className={`rounded-2xl border px-4 py-3 text-sm font-bold transition ${
                   isWatched
-                    ? "border-red-400/30 bg-red-500/15 text-red-100 hover:bg-red-500/20"
-                    : "border-white/10 bg-white/5 text-white hover:bg-white/10"
+                    ? "border-red-400/30 bg-red-500/15 text-danger hover:bg-red-500/20"
+                    : "border-border-strong bg-surface text-foreground hover:bg-surface-strong"
                 }`}
               >
                 {isWatched ? "Remove from watchlist" : "Add to watchlist"}

--- a/app/frontend/src/components/LocaleSwitcher.tsx
+++ b/app/frontend/src/components/LocaleSwitcher.tsx
@@ -14,7 +14,7 @@ export function LocaleSwitcher() {
     <select
       value={i18n.language}
       onChange={(e) => changeLanguage(e.target.value)}
-      className="bg-neutral-900 border border-white/10 rounded-lg px-3 py-1 text-sm"
+      className="bg-card text-foreground border border-border-strong rounded-lg px-3 py-1 text-sm"
     >
       <option value="en">English</option>
       <option value="es">Español</option>

--- a/app/frontend/src/components/NetworkBadge.tsx
+++ b/app/frontend/src/components/NetworkBadge.tsx
@@ -14,9 +14,9 @@ export function NetworkBadge() {
   const normalized = network.toLowerCase();
 
   const badgeStyles: Record<string, string> = {
-    testnet: "bg-yellow-100 text-yellow-800 border border-yellow-200",
-    futurenet: "bg-blue-100 text-blue-800 border border-blue-200",
-    mainnet: "bg-green-100 text-green-800 border border-green-200",
+    testnet: "bg-warning-soft text-warning border border-warning-soft",
+    futurenet: "bg-brand-soft text-brand border border-brand-soft",
+    mainnet: "bg-success-soft text-success border border-success-soft",
   };
 
   const label = {

--- a/app/frontend/src/components/NotificationBell.tsx
+++ b/app/frontend/src/components/NotificationBell.tsx
@@ -71,7 +71,7 @@ export function NotificationBell() {
             : "Open notifications."
         }
         onClick={() => setIsOpen((currentValue) => !currentValue)}
-        className="relative flex h-11 items-center justify-center rounded-full border border-white/10 bg-white/5 px-3.5 text-sm font-semibold text-white transition hover:bg-white/10"
+        className="relative flex h-11 items-center justify-center rounded-full border border-border-strong bg-surface px-3.5 text-sm font-semibold text-foreground transition hover:bg-surface-strong"
       >
         <span aria-hidden="true">Inbox</span>
         {unreadCount > 0 ? (
@@ -84,19 +84,19 @@ export function NotificationBell() {
       {isOpen ? (
         <div
           id="quickex-notification-panel"
-          className="absolute right-0 top-14 z-50 w-[min(26rem,calc(100vw-2rem))] rounded-[2rem] border border-white/10 bg-neutral-950/98 p-5 shadow-[0_30px_80px_-25px_rgba(15,23,42,0.9)] backdrop-blur"
+          className="absolute right-0 top-14 z-50 w-[min(26rem,calc(100vw-2rem))] rounded-[2rem] border border-border-strong bg-background/98 p-5 shadow-[0_30px_80px_-25px_rgba(15,23,42,0.9)] backdrop-blur"
         >
           <div className="flex items-start justify-between gap-4">
             <div>
-              <p className="text-lg font-semibold text-white">Notifications</p>
-              <p className="mt-1 text-sm text-neutral-300">
+              <p className="text-lg font-semibold text-foreground">Notifications</p>
+              <p className="mt-1 text-sm text-muted">
                 Stay on top of payments, escrows, and system updates.
               </p>
             </div>
             <button
               type="button"
               onClick={() => setIsOpen(false)}
-              className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-100 transition hover:bg-white/10"
+              className="rounded-full border border-border-strong bg-surface px-3 py-1.5 text-xs font-semibold text-foreground transition hover:bg-surface-strong"
             >
               Close
             </button>
@@ -110,8 +110,8 @@ export function NotificationBell() {
                 onClick={() => setReadState(option)}
                 className={`rounded-full px-3.5 py-2 text-sm font-semibold transition ${
                   readState === option
-                    ? "bg-white text-neutral-950"
-                    : "border border-white/10 bg-white/5 text-neutral-100 hover:bg-white/10"
+                    ? "bg-card text-foreground"
+                    : "border border-border-strong bg-surface text-foreground hover:bg-surface-strong"
                 }`}
               >
                 {option === "all" ? "All" : "Unread"}
@@ -122,7 +122,7 @@ export function NotificationBell() {
               type="button"
               onClick={() => markAllAsRead()}
               disabled={unreadCount === 0}
-              className="ml-auto rounded-full border border-white/10 bg-white/5 px-3.5 py-2 text-sm font-semibold text-neutral-100 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+              className="ml-auto rounded-full border border-border-strong bg-surface px-3.5 py-2 text-sm font-semibold text-foreground transition hover:bg-surface-strong disabled:cursor-not-allowed disabled:opacity-50"
             >
               Mark all read
             </button>
@@ -139,8 +139,8 @@ export function NotificationBell() {
             />
           </div>
 
-          <div className="mt-5 flex items-center justify-between border-t border-white/10 pt-4">
-            <span className="text-sm text-neutral-400">
+          <div className="mt-5 flex items-center justify-between border-t border-border-strong pt-4">
+            <span className="text-sm text-subtle">
               {unreadCount} unread
             </span>
             <Link

--- a/app/frontend/src/components/NotificationFeed.tsx
+++ b/app/frontend/src/components/NotificationFeed.tsx
@@ -29,14 +29,14 @@ export function NotificationFeed({
 }: NotificationFeedProps) {
   if (notifications.length === 0) {
     return (
-      <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.02] p-8 text-center">
-        <p className="text-lg font-semibold text-white">{emptyTitle}</p>
-        <p className="mt-2 text-sm text-neutral-300">{emptyDescription}</p>
+      <div className="rounded-3xl border border-dashed border-border-strong bg-card/[0.02] p-8 text-center">
+        <p className="text-lg font-semibold text-foreground">{emptyTitle}</p>
+        <p className="mt-2 text-sm text-muted">{emptyDescription}</p>
         {onResetFilters ? (
           <button
             type="button"
             onClick={onResetFilters}
-            className="mt-5 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:bg-white/10"
+            className="mt-5 rounded-full border border-border-strong bg-surface px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-surface-strong"
           >
             Show everything
           </button>
@@ -52,8 +52,8 @@ export function NotificationFeed({
           key={notification.id}
           className={`rounded-3xl border p-4 transition ${
             notification.readAt
-              ? "border-white/8 bg-white/[0.03]"
-              : "border-indigo-400/20 bg-indigo-500/[0.08] shadow-[0_20px_50px_-35px_rgba(99,102,241,0.85)]"
+              ? "border-border bg-card"
+              : "border-brand/40 bg-brand-soft shadow-[0_20px_50px_-35px_rgba(99,102,241,0.85)]"
           }`}
         >
           <div className="flex flex-wrap items-center gap-2">
@@ -63,21 +63,21 @@ export function NotificationFeed({
               {CATEGORY_LABELS[notification.category]}
             </span>
             {!notification.readAt ? (
-              <span className="rounded-full bg-white/10 px-2.5 py-1 text-[11px] font-semibold text-white">
+              <span className="rounded-full border border-border-strong bg-surface-strong px-2.5 py-1 text-[11px] font-semibold text-foreground">
                 Unread
               </span>
             ) : null}
-            <span className="ml-auto text-xs text-neutral-400">
+            <span className="ml-auto text-xs text-subtle">
               {formatRelativeTime(notification.createdAt)}
             </span>
           </div>
 
-          <h3 className="mt-4 text-lg font-semibold text-white">
+          <h3 className="mt-4 text-lg font-semibold text-foreground">
             {notification.title}
           </h3>
           <p
             className={`mt-2 text-sm ${
-              compact ? "text-neutral-300" : "text-neutral-200"
+              compact ? "text-muted" : "text-muted"
             }`}
           >
             {notification.description}
@@ -90,7 +90,7 @@ export function NotificationFeed({
                 onMarkAsRead(notification.id);
                 onNavigate?.();
               }}
-              className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-200"
+              className="rounded-full bg-card px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-surface-strong"
             >
               {notification.actionLabel}
             </Link>
@@ -99,12 +99,12 @@ export function NotificationFeed({
               <button
                 type="button"
                 onClick={() => onMarkAsRead(notification.id)}
-                className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:bg-white/10"
+                className="rounded-full border border-border-strong bg-surface px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-surface-strong"
               >
                 Mark as read
               </button>
             ) : (
-              <span className="text-sm text-neutral-400">
+              <span className="text-sm text-subtle">
                 Already read
               </span>
             )}

--- a/app/frontend/src/components/PWAHandler.tsx
+++ b/app/frontend/src/components/PWAHandler.tsx
@@ -70,28 +70,28 @@ export function PWAHandler() {
 
   return (
     <div className="fixed bottom-6 left-6 right-6 md:left-auto md:right-8 md:w-96 z-50 animate-in fade-in slide-in-from-bottom-5 duration-500">
-      <div className="bg-neutral-900 border border-white/10 rounded-2xl p-5 shadow-2xl backdrop-blur-xl">
+      <div className="bg-card border border-border-strong rounded-2xl p-5 shadow-2xl backdrop-blur-xl">
         <div className="flex items-start gap-4">
           <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-500 to-cyan-500 flex items-center justify-center flex-shrink-0 shadow-lg shadow-purple-500/20">
-            <svg viewBox="0 0 24 24" className="w-6 h-6 text-white fill-current">
+            <svg viewBox="0 0 24 24" className="w-6 h-6 text-foreground fill-current">
                <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/>
             </svg>
           </div>
           <div className="flex-1">
-            <h3 className="font-semibold text-white">Install QuickEx App</h3>
-            <p className="text-sm text-neutral-400 mt-1">
+            <h3 className="font-semibold text-foreground">Install QuickEx App</h3>
+            <p className="text-sm text-subtle mt-1">
               Add QuickEx to your home screen for a faster, offline-ready experience.
             </p>
             <div className="flex gap-3 mt-4">
               <button
                 onClick={handleInstall}
-                className="flex-1 bg-white text-black text-sm font-bold py-2.5 rounded-lg hover:bg-neutral-200 transition-colors"
+                className="flex-1 bg-card text-foreground text-sm font-bold py-2.5 rounded-lg hover:bg-surface-strong transition-colors"
               >
                 Install Now
               </button>
               <button
                 onClick={() => setShowBanner(false)}
-                className="px-4 py-2.5 text-sm font-medium text-neutral-400 hover:text-white transition-colors"
+                className="px-4 py-2.5 text-sm font-medium text-subtle hover:text-foreground transition-colors"
               >
                 Later
               </button>

--- a/app/frontend/src/components/QRPreview.tsx
+++ b/app/frontend/src/components/QRPreview.tsx
@@ -8,14 +8,14 @@ export function QRPreview({ value }: { value?: string }) {
     <div className="relative group">
       <div className="absolute -inset-10 bg-indigo-500/10 blur-[60px] rounded-full opacity-50 group-hover:opacity-80 transition-opacity" />
       
-      <div className="relative w-full aspect-square bg-gradient-to-br from-white/10 to-white/[0.02] backdrop-blur-3xl rounded-[3rem] p-1 border border-white/10 shadow-2xl overflow-hidden group-hover:scale-[1.02] transition-all duration-500">
+      <div className="relative w-full aspect-square bg-gradient-to-br from-white/10 to-white/[0.02] backdrop-blur-3xl rounded-[3rem] p-1 border border-border-strong shadow-2xl overflow-hidden group-hover:scale-[1.02] transition-all duration-500">
 
         <div className="absolute inset-0 bg-gradient-to-b from-transparent via-indigo-500/5 to-transparent h-1/2 w-full -translate-y-full hover:animate-[scan_3s_linear_infinite]" />
         
-        <div className="h-full w-full bg-black/40 rounded-[2.8rem] flex flex-col items-center justify-center p-12 border border-white/5">
+        <div className="h-full w-full bg-card rounded-[2.8rem] flex flex-col items-center justify-center p-12 border border-border">
 
           {/* QR CONTAINER */}
-          <div className="relative p-6 bg-white rounded-3xl shadow-[0_0_30px_rgba(255,255,255,0.05)]">
+          <div className="relative p-6 bg-card rounded-3xl shadow-[0_0_30px_rgba(255,255,255,0.05)]">
             {isValid ? (
               <QRCode
                 value={value!}
@@ -25,15 +25,15 @@ export function QRPreview({ value }: { value?: string }) {
               />
             ) : (
               /* Show your original placeholder */
-              <div className="w-48 h-48 border-4 border-dashed border-neutral-100/30 rounded-2xl flex flex-col items-center justify-center gap-4">
-                <div className="w-12 h-12 bg-black rounded-lg flex items-center justify-center">
+              <div className="w-48 h-48 border-4 border-dashed border-border-strong rounded-2xl flex flex-col items-center justify-center gap-4">
+                <div className="w-12 h-12 bg-background rounded-lg flex items-center justify-center">
                   <div className="w-6 h-6 bg-indigo-500 rounded-sm animate-pulse" />
                 </div>
                 <div className="grid grid-cols-2 gap-1 opacity-20 capitalize">
-                  <div className="w-4 h-4 bg-black rounded-sm" />
-                  <div className="w-4 h-4 bg-black rounded-sm" />
-                  <div className="w-4 h-4 bg-black rounded-sm" />
-                  <div className="w-4 h-4 bg-black rounded-sm" />
+                  <div className="w-4 h-4 bg-background rounded-sm" />
+                  <div className="w-4 h-4 bg-background rounded-sm" />
+                  <div className="w-4 h-4 bg-background rounded-sm" />
+                  <div className="w-4 h-4 bg-background rounded-sm" />
                 </div>
               </div>
             )}
@@ -43,7 +43,7 @@ export function QRPreview({ value }: { value?: string }) {
             <p className="text-xs font-black text-indigo-400 tracking-[0.3em] uppercase">
               Ready to Scan
             </p>
-            <p className="text-sm text-neutral-500 font-medium">
+            <p className="text-sm text-subtle font-medium">
               Point your wallet camera here
             </p>
           </div>

--- a/app/frontend/src/components/ReportIssueModal.tsx
+++ b/app/frontend/src/components/ReportIssueModal.tsx
@@ -97,22 +97,22 @@ export function ReportIssueModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby="report-issue-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/50 px-4 py-6"
       onKeyDown={handleKeyDown}
     >
       <div
         ref={modalRef}
-        className="w-full max-w-2xl rounded-3xl bg-neutral-950 p-8 shadow-2xl shadow-black/50"
+        className="w-full max-w-2xl rounded-3xl bg-background p-8 shadow-2xl shadow-black/50"
       >
         <div className="flex items-start justify-between gap-4">
           <div>
             <h2
               id="report-issue-title"
-              className="text-2xl font-semibold text-white"
+              className="text-2xl font-semibold text-foreground"
             >
               Report an issue
             </h2>
-            <p className="mt-2 text-sm text-neutral-400">
+            <p className="mt-2 text-sm text-subtle">
               We will send a report with your request details and the error
               summary.
             </p>
@@ -120,24 +120,24 @@ export function ReportIssueModal({
           <button
             type="button"
             onClick={handleClose}
-            className="rounded-full bg-white/10 px-4 py-2 text-sm text-white transition hover:bg-white/20"
+            className="rounded-full bg-surface-strong px-4 py-2 text-sm text-foreground transition hover:bg-surface-strong"
           >
             Close
           </button>
         </div>
 
-        <div className="mt-6 space-y-4 rounded-3xl border border-white/10 bg-white/5 p-4">
-          <p className="text-sm font-semibold text-neutral-200">
+        <div className="mt-6 space-y-4 rounded-3xl border border-border-strong bg-surface p-4">
+          <p className="text-sm font-semibold text-muted">
             Error summary
           </p>
-          <p className="whitespace-pre-wrap rounded-2xl bg-neutral-900 p-4 text-sm text-neutral-200">
+          <p className="whitespace-pre-wrap rounded-2xl bg-card p-4 text-sm text-muted">
             {sanitizedSummary || "No summary available."}
           </p>
 
           <div className="grid gap-2 sm:grid-cols-[1fr_auto]">
             <div>
-              <label className="text-sm text-neutral-300">Request ID</label>
-              <div className="mt-2 overflow-hidden rounded-2xl bg-neutral-900 px-3 py-2 text-sm text-neutral-200">
+              <label className="text-sm text-muted">Request ID</label>
+              <div className="mt-2 overflow-hidden rounded-2xl bg-card px-3 py-2 text-sm text-muted">
                 {requestId || "Unavailable"}
               </div>
             </div>
@@ -145,25 +145,25 @@ export function ReportIssueModal({
         </div>
 
         <form onSubmit={handleSubmit} className="mt-6 space-y-4">
-          <label className="block text-sm font-semibold text-neutral-200">
+          <label className="block text-sm font-semibold text-muted">
             Additional details
           </label>
           <textarea
             value={userMessage}
             onChange={(event) => setUserMessage(event.target.value)}
             rows={5}
-            className="w-full rounded-3xl border border-white/10 bg-neutral-900 px-4 py-3 text-sm text-white outline-none transition focus:border-white/30"
+            className="w-full rounded-3xl border border-border-strong bg-card px-4 py-3 text-sm text-foreground outline-none transition focus:border-white/30"
             placeholder="What were you doing when this happened?"
           />
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs text-neutral-400">
+            <p className="text-xs text-subtle">
               Your message will be sanitized before sending.
             </p>
             <button
               ref={submitButtonRef}
               type="submit"
               disabled={status === "submitting" || status === "success"}
-              className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center justify-center rounded-full bg-card px-6 py-3 text-sm font-semibold text-foreground transition hover:bg-surface-strong disabled:cursor-not-allowed disabled:opacity-50"
             >
               {status === "submitting" ? "Sending..." : "Send report"}
             </button>
@@ -171,7 +171,7 @@ export function ReportIssueModal({
         </form>
 
         {status === "success" ? (
-          <div className="mt-4 rounded-3xl bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+          <div className="mt-4 rounded-3xl bg-success-soft px-4 py-3 text-sm text-success">
             Issue report submitted successfully.
           </div>
         ) : null}

--- a/app/frontend/src/components/SearchBar.tsx
+++ b/app/frontend/src/components/SearchBar.tsx
@@ -48,13 +48,13 @@ export function SearchBar() {
   return (
     <div className="relative w-full" ref={dropdownRef}>
       <div className="relative flex items-center">
-        <svg className="absolute left-3 w-4 h-4 text-neutral-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="absolute left-3 w-4 h-4 text-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
         <input 
           type="text" 
           placeholder="Search global profiles..." 
-          className="w-full bg-neutral-900/50 border border-white/10 rounded-full pl-10 pr-10 py-2 text-sm text-white placeholder-neutral-500 focus:outline-none focus:border-indigo-500/50 focus:ring-1 focus:ring-indigo-500/50 transition-all font-medium"
+          className="w-full bg-card/50 border border-border-strong rounded-full pl-10 pr-10 py-2 text-sm text-foreground placeholder-neutral-500 focus:outline-none focus:border-indigo-500/50 focus:ring-1 focus:ring-indigo-500/50 transition-all font-medium"
           value={query}
           onChange={(e) => {
             setQuery(e.target.value);
@@ -66,7 +66,7 @@ export function SearchBar() {
         />
         {query && (
           <button 
-            className="absolute right-3 text-neutral-500 hover:text-white transition"
+            className="absolute right-3 text-subtle hover:text-foreground transition"
             onClick={() => setQuery("")}
             title="Clear"
           >
@@ -78,44 +78,44 @@ export function SearchBar() {
       </div>
 
       {isOpen && query.trim() && (
-        <div className="absolute top-full lg:left-0 -left-10 lg:w-full w-[120%] mt-2 bg-neutral-900 border border-white/10 rounded-2xl shadow-2xl overflow-hidden z-50 animate-in fade-in slide-in-from-top-2 duration-200">
+        <div className="absolute top-full lg:left-0 -left-10 lg:w-full w-[120%] mt-2 bg-card border border-border-strong rounded-2xl shadow-2xl overflow-hidden z-50 animate-in fade-in slide-in-from-top-2 duration-200">
           {isLoading ? (
             <div className="p-2 space-y-1">
               {[...Array(3)].map((_, i) => (
-                <div key={i} className="flex items-center gap-3 p-2 animate-pulse rounded-xl bg-white/[0.02]">
-                  <div className="w-10 h-10 rounded-full bg-white/10"></div>
+                <div key={i} className="flex items-center gap-3 p-2 animate-pulse rounded-xl bg-card/[0.02]">
+                  <div className="w-10 h-10 rounded-full bg-surface-strong"></div>
                   <div className="flex-1 space-y-2">
-                    <div className="h-3 bg-white/10 rounded w-1/3"></div>
-                    <div className="h-2 bg-white/10 rounded w-1/2"></div>
+                    <div className="h-3 bg-surface-strong rounded w-1/3"></div>
+                    <div className="h-2 bg-surface-strong rounded w-1/2"></div>
                   </div>
                 </div>
               ))}
             </div>
           ) : results.length > 0 ? (
             <div className="flex flex-col py-2">
-              <div className="px-4 py-2 text-xs font-semibold text-neutral-500 uppercase tracking-wider mb-1">
+              <div className="px-4 py-2 text-xs font-semibold text-subtle uppercase tracking-wider mb-1">
                 Profiles
               </div>
               {results.map((user) => (
                 <Link 
                   key={user.id} 
                   href={`/profile/${user.username}`} 
-                  className="flex items-center gap-4 px-4 py-2 hover:bg-white/5 transition group"
+                  className="flex items-center gap-4 px-4 py-2 hover:bg-surface transition group"
                   onClick={() => setIsOpen(false)}
                 >
                   <div className={`w-10 h-10 rounded-full flex items-center justify-center font-bold text-sm shadow-inner ${user.avatarColor}`}>
                     {user.name.charAt(0)}
                   </div>
                   <div className="flex-1 flex flex-col items-start overflow-hidden">
-                    <span className="text-sm font-semibold text-white group-hover:text-indigo-400 transition-colors truncate">{user.name}</span>
-                    <span className="text-xs text-neutral-400 truncate">@{user.username}</span>
+                    <span className="text-sm font-semibold text-foreground group-hover:text-indigo-400 transition-colors truncate">{user.name}</span>
+                    <span className="text-xs text-subtle truncate">@{user.username}</span>
                   </div>
                 </Link>
               ))}
             </div>
           ) : (
-            <div className="p-8 text-center text-sm text-neutral-400 flex flex-col items-center gap-3">
-              <div className="w-12 h-12 rounded-full bg-white/5 flex items-center justify-center text-2xl">
+            <div className="p-8 text-center text-sm text-subtle flex flex-col items-center gap-3">
+              <div className="w-12 h-12 rounded-full bg-surface flex items-center justify-center text-2xl">
                 🔍
               </div>
               <p>No results found for &quot;{query}&quot;</p>

--- a/app/frontend/src/components/SigningSummary.tsx
+++ b/app/frontend/src/components/SigningSummary.tsx
@@ -64,19 +64,19 @@ export function SigningSummary({
           <p className="text-[10px] uppercase tracking-widest font-black text-indigo-400/70">
             Secure Signing Request
           </p>
-          <h3 className="text-lg font-black text-white">{actionLabels[action]}</h3>
+          <h3 className="text-lg font-black text-foreground">{actionLabels[action]}</h3>
         </div>
       </div>
 
       {/* Main Summary Card */}
-      <div className="bg-white/5 border border-white/10 rounded-2xl overflow-hidden">
+      <div className="bg-surface border border-border-strong rounded-2xl overflow-hidden">
         {amount && (
-          <div className="p-6 text-center border-b border-white/5 bg-gradient-to-b from-white/[0.02] to-transparent">
-            <p className="text-xs font-bold text-neutral-500 uppercase tracking-widest mb-1">
+          <div className="p-6 text-center border-b border-border bg-gradient-to-b from-white/[0.02] to-transparent">
+            <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-1">
               Transaction Value
             </p>
             <div className="flex items-center justify-center gap-2">
-              <span className="text-3xl font-black text-white">{amount.value}</span>
+              <span className="text-3xl font-black text-foreground">{amount.value}</span>
               <span className="text-lg font-bold text-indigo-400">{amount.asset}</span>
             </div>
           </div>
@@ -85,33 +85,33 @@ export function SigningSummary({
         <div className="p-4 space-y-3">
           {details.map((detail, i) => (
             <div key={i} className="flex justify-between items-center text-sm">
-              <span className="text-neutral-500 font-medium">{detail.label}</span>
-              <span className="text-white font-bold font-mono text-xs">{detail.value}</span>
+              <span className="text-subtle font-medium">{detail.label}</span>
+              <span className="text-foreground font-bold font-mono text-xs">{detail.value}</span>
             </div>
           ))}
 
           {fee && (
             <div className="flex justify-between items-center text-sm">
-              <span className="text-neutral-500 font-medium">{fee.label ?? "Estimated Fee"}</span>
-              <span className={`font-bold ${isHighFee ? "text-red-400" : "text-neutral-300"}`}>
+              <span className="text-subtle font-medium">{fee.label ?? "Estimated Fee"}</span>
+              <span className={`font-bold ${isHighFee ? "text-red-400" : "text-muted"}`}>
                 {fee.value} {fee.asset}
                 {feePercentage !== undefined ? ` (${feePercentage.toFixed(1)}%)` : ""}
               </span>
             </div>
           )}
 
-          <div className="flex justify-between items-center text-sm pt-2 border-t border-white/5">
-            <span className="text-neutral-500 font-medium flex items-center gap-1.5">
+          <div className="flex justify-between items-center text-sm pt-2 border-t border-border">
+            <span className="text-subtle font-medium flex items-center gap-1.5">
               <Wallet size={14} /> Network
             </span>
-            <span className={`font-bold ${isNetworkMismatch ? "text-red-400" : "text-neutral-300"}`}>
+            <span className={`font-bold ${isNetworkMismatch ? "text-red-400" : "text-muted"}`}>
               {network}
             </span>
           </div>
 
           {expiry && (
             <div className="flex justify-between items-center text-sm">
-              <span className="text-neutral-500 font-medium flex items-center gap-1.5">
+              <span className="text-subtle font-medium flex items-center gap-1.5">
                 <Clock size={14} /> Quote Expiry
               </span>
               <span className={`font-bold ${isExpired ? "text-red-400" : "text-emerald-400"}`}>
@@ -142,7 +142,7 @@ export function SigningSummary({
       )}
 
       {!isNetworkMismatch && !isExpired && !isHighFee && (
-        <p className="text-[10px] text-neutral-500 text-center px-4 leading-relaxed italic">
+        <p className="text-[10px] text-subtle text-center px-4 leading-relaxed italic">
           Verify the details above match your intention. This summary is generated from the exact payload that will be sent to your wallet.
         </p>
       )}

--- a/app/frontend/src/components/ThemeProvider.tsx
+++ b/app/frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "quickex-theme";
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.classList.toggle("dark", theme === "dark");
+  root.classList.toggle("light", theme === "light");
+  root.style.colorScheme = theme;
+}
+
+function readInitialTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "dark";
+  }
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+/**
+ * Inline script that runs before paint to set the theme class on <html>,
+ * preventing a flash of the wrong theme (FOUC) on first load.
+ */
+export const themeInitScript = `
+(function () {
+  try {
+    var stored = localStorage.getItem('${THEME_STORAGE_KEY}');
+    var theme = stored === 'light' || stored === 'dark'
+      ? stored
+      : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    var root = document.documentElement;
+    root.classList.add(theme);
+    root.style.colorScheme = theme;
+  } catch (e) {}
+})();
+`;
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("dark");
+
+  // Sync React state with whatever the no-FOUC script already applied.
+  useEffect(() => {
+    setThemeState(readInitialTheme());
+  }, []);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    applyTheme(next);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {
+      /* ignore storage errors (private mode, etc.) */
+    }
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  }, [theme, setTheme]);
+
+  const value = useMemo(
+    () => ({ theme, setTheme, toggleTheme }),
+    [theme, setTheme, toggleTheme],
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/app/frontend/src/components/ThemeToggle.tsx
+++ b/app/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "@/components/ThemeProvider";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      aria-pressed={isDark}
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className="flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-surface text-muted transition hover:bg-surface-strong hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+    >
+      {isDark ? (
+        <Sun aria-hidden="true" className="h-4 w-4" />
+      ) : (
+        <Moon aria-hidden="true" className="h-4 w-4" />
+      )}
+    </button>
+  );
+}

--- a/app/frontend/src/components/UsernameCard.tsx
+++ b/app/frontend/src/components/UsernameCard.tsx
@@ -37,7 +37,7 @@ function UrgencyBar({ endsAt }: { endsAt: Date }) {
       : "bg-indigo-500";
 
   return (
-    <div className="w-full h-[3px] bg-white/5 rounded-full overflow-hidden">
+    <div className="w-full h-[3px] bg-surface rounded-full overflow-hidden">
       <div
         className={`h-full rounded-full ${color} transition-all duration-1000`}
         style={{ width: `${pct}%` }}
@@ -60,7 +60,7 @@ export function UsernameCard({ listing, onBid, onViewDetails }: UsernameCardProp
   };
 
   return (
-    <div className="group relative flex flex-col bg-neutral-900/50 border border-white/5 rounded-3xl overflow-hidden hover:border-indigo-500/30 transition-all duration-300 hover:shadow-[0_0_40px_-15px_rgba(99,102,241,0.25)] hover:-translate-y-1">
+    <div className="group relative flex flex-col bg-card/50 border border-border rounded-3xl overflow-hidden hover:border-indigo-500/30 transition-all duration-300 hover:shadow-[0_0_40px_-15px_rgba(99,102,241,0.25)] hover:-translate-y-1">
       {/* Top glow strip */}
       <div className="h-[2px] w-full bg-gradient-to-r from-indigo-500/0 via-indigo-500/60 to-indigo-500/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
 
@@ -86,7 +86,7 @@ export function UsernameCard({ listing, onBid, onViewDetails }: UsernameCardProp
               className={`w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 ${
                 isWatched
                   ? 'bg-red-500/20 border border-red-500/30 text-red-400 hover:bg-red-500/30'
-                  : 'bg-white/5 border border-white/10 text-neutral-400 hover:text-red-400 hover:bg-red-500/10'
+                  : 'bg-surface border border-border-strong text-subtle hover:text-red-400 hover:bg-red-500/10'
               }`}
               title={isWatched ? 'Remove from watchlist' : 'Add to watchlist'}
             >
@@ -97,30 +97,30 @@ export function UsernameCard({ listing, onBid, onViewDetails }: UsernameCardProp
 
         {/* Username */}
         <div className="flex-1">
-          <p className="text-xs text-neutral-600 font-mono mb-0.5">quickex.to/</p>
-          <h3 className="text-3xl font-black tracking-tight text-white leading-none group-hover:text-indigo-300 transition-colors duration-300">
+          <p className="text-xs text-faint font-mono mb-0.5">quickex.to/</p>
+          <h3 className="text-3xl font-black tracking-tight text-foreground leading-none group-hover:text-brand transition-colors duration-300">
             {listing.username}
           </h3>
         </div>
 
         {/* Stats */}
         <div className="grid grid-cols-2 gap-2">
-          <div className="p-3 rounded-2xl bg-white/[0.03] border border-white/5">
-            <p className="text-[9px] uppercase font-black tracking-widest text-neutral-600 mb-1">
+          <div className="p-3 rounded-2xl bg-surface border border-border">
+            <p className="text-[9px] uppercase font-black tracking-widest text-faint mb-1">
               Current Bid
             </p>
-            <p className="font-black text-base text-white leading-none">
+            <p className="font-black text-base text-foreground leading-none">
               {listing.currentBid.toLocaleString()}
-              <span className="text-[10px] font-bold text-neutral-500 ml-1">USDC</span>
+              <span className="text-[10px] font-bold text-subtle ml-1">USDC</span>
             </p>
           </div>
-          <div className="p-3 rounded-2xl bg-white/[0.03] border border-white/5">
-            <p className="text-[9px] uppercase font-black tracking-widest text-neutral-600 mb-1">
+          <div className="p-3 rounded-2xl bg-surface border border-border">
+            <p className="text-[9px] uppercase font-black tracking-widest text-faint mb-1">
               Ends In
             </p>
             <p
               className={`font-black text-base leading-none ${
-                isUrgent ? "text-red-400 animate-pulse" : "text-white"
+                isUrgent ? "text-red-400 animate-pulse" : "text-foreground"
               }`}
             >
               {countdown}
@@ -131,7 +131,7 @@ export function UsernameCard({ listing, onBid, onViewDetails }: UsernameCardProp
         <UrgencyBar endsAt={listing.endsAt} />
 
         {/* Bottom row: owner + bid count */}
-        <div className="flex items-center justify-between text-[11px] text-neutral-600">
+        <div className="flex items-center justify-between text-[11px] text-faint">
           <span className="font-mono">
             {listing.ownerAddress}
           </span>
@@ -142,9 +142,9 @@ export function UsernameCard({ listing, onBid, onViewDetails }: UsernameCardProp
 
         {/* Buy now price */}
         {listing.buyNowPrice && (
-          <p className="text-[10px] text-neutral-500 -mt-2">
+          <p className="text-[10px] text-subtle -mt-2">
             Buy Now:{" "}
-            <span className="text-white font-bold">
+            <span className="text-foreground font-bold">
               {listing.buyNowPrice.toLocaleString()} USDC
             </span>
           </p>
@@ -154,7 +154,7 @@ export function UsernameCard({ listing, onBid, onViewDetails }: UsernameCardProp
           <button
             type="button"
             onClick={() => onViewDetails(listing)}
-            className="w-full rounded-2xl border border-white/10 bg-white/5 py-3.5 text-sm font-bold tracking-wide text-neutral-100 transition-all duration-200 hover:bg-white/10"
+            className="w-full rounded-2xl border border-border-strong bg-surface py-3.5 text-sm font-bold tracking-wide text-foreground transition-all duration-200 hover:bg-surface-strong"
           >
             View Details
           </button>
@@ -162,7 +162,7 @@ export function UsernameCard({ listing, onBid, onViewDetails }: UsernameCardProp
             id={`bid-btn-${listing.id}`}
             type="button"
             onClick={() => onBid(listing)}
-            className="w-full rounded-2xl border border-indigo-500/30 bg-indigo-500/10 py-3.5 text-sm font-black tracking-wide text-indigo-300 transition-all duration-200 hover:border-indigo-500 hover:bg-indigo-500 hover:text-white hover:shadow-[0_8px_32px_-10px_rgba(99,102,241,0.6)] active:scale-95"
+            className="w-full rounded-2xl border border-indigo-500/30 bg-indigo-500/10 py-3.5 text-sm font-black tracking-wide text-brand transition-all duration-200 hover:border-indigo-500 hover:bg-indigo-500 hover:text-white hover:shadow-[0_8px_32px_-10px_rgba(99,102,241,0.6)] active:scale-95"
           >
             Place Bid
           </button>

--- a/app/frontend/src/components/WorkspaceSwitcher.tsx
+++ b/app/frontend/src/components/WorkspaceSwitcher.tsx
@@ -22,16 +22,16 @@ export function WorkspaceSwitcher() {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-3 px-3 py-2 bg-white/5 border border-white/10 rounded-xl hover:bg-white/10 transition"
+        className="flex items-center gap-3 px-3 py-2 bg-surface border border-border-strong rounded-xl hover:bg-surface-strong transition"
       >
-        <div className="w-6 h-6 bg-indigo-500 rounded flex items-center justify-center text-[10px] font-bold">
+        <div className="w-6 h-6 bg-indigo-500 rounded flex items-center justify-center text-[10px] font-bold text-white">
           {activeWorkspace.name[0]}
         </div>
         <div className="text-left hidden sm:block">
           <p className="text-xs font-bold leading-none mb-1">{activeWorkspace.name}</p>
-          <p className="text-[10px] text-neutral-500 leading-none capitalize">{activeWorkspace.role}</p>
+          <p className="text-[10px] text-subtle leading-none capitalize">{activeWorkspace.role}</p>
         </div>
-        <span className="text-neutral-500 text-xs">▼</span>
+        <span className="text-subtle text-xs">▼</span>
       </button>
 
       {isOpen && (
@@ -40,7 +40,7 @@ export function WorkspaceSwitcher() {
             className="fixed inset-0 z-40" 
             onClick={() => setIsOpen(false)}
           />
-          <div className="absolute top-full left-0 mt-2 w-56 bg-neutral-900 border border-white/10 rounded-2xl shadow-2xl z-50 overflow-hidden backdrop-blur-3xl">
+          <div className="absolute top-full left-0 mt-2 w-56 bg-card border border-border-strong rounded-2xl shadow-2xl z-50 overflow-hidden backdrop-blur-3xl">
             <div className="p-2 space-y-1">
               {workspaces.map((ws) => (
                 <button
@@ -50,20 +50,20 @@ export function WorkspaceSwitcher() {
                     setIsOpen(false);
                   }}
                   className={`w-full flex items-center gap-3 px-3 py-2 rounded-xl transition text-left ${
-                    activeWorkspace.id === ws.id ? "bg-white/10" : "hover:bg-white/5"
+                    activeWorkspace.id === ws.id ? "bg-surface-strong" : "hover:bg-surface"
                   }`}
                 >
-                  <div className="w-8 h-8 bg-neutral-800 rounded-lg flex items-center justify-center font-bold">
+                  <div className="w-8 h-8 bg-surface-strong rounded-lg flex items-center justify-center font-bold">
                     {ws.name[0]}
                   </div>
                   <div>
                     <p className="text-sm font-bold">{ws.name}</p>
-                    <p className="text-[10px] text-neutral-500 capitalize">{ws.role}</p>
+                    <p className="text-[10px] text-subtle capitalize">{ws.role}</p>
                   </div>
                 </button>
               ))}
             </div>
-            <div className="p-2 border-t border-white/5 bg-white/5">
+            <div className="p-2 border-t border-border bg-surface">
               <button className="w-full px-3 py-2 rounded-xl text-xs font-bold text-indigo-400 hover:bg-indigo-500/10 transition text-left">
                 + Create Workspace
               </button>

--- a/app/frontend/src/components/admin/AuditLogs.tsx
+++ b/app/frontend/src/components/admin/AuditLogs.tsx
@@ -59,16 +59,16 @@ export function AuditLogs() {
   const actions = ["ALL", ...Array.from(new Set(logs.map((entry) => entry.action)))];
 
   return (
-    <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+    <div className="bg-card p-6 rounded-lg shadow-sm border border-border">
       <div className="flex justify-between items-center mb-6">
         <div>
-          <h2 className="text-lg font-semibold text-gray-800">Audit Logs</h2>
-          <p className="text-sm text-gray-500">Feature flag changes are persisted here.</p>
+          <h2 className="text-lg font-semibold text-foreground">Audit Logs</h2>
+          <p className="text-sm text-subtle">Feature flag changes are persisted here.</p>
         </div>
         <div className="flex items-center space-x-2">
-          <Filter className="h-4 w-4 text-gray-500" />
+          <Filter className="h-4 w-4 text-subtle" />
           <select
-            className="border border-gray-200 rounded-md py-1.5 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+            className="border border-border rounded-md py-1.5 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand bg-card"
             value={filter}
             onChange={(event) => setFilter(event.target.value)}
           >
@@ -82,14 +82,14 @@ export function AuditLogs() {
       </div>
 
       {error && (
-        <p className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+        <p className="mb-4 rounded-md border border-warning-soft bg-warning-soft px-3 py-2 text-sm text-warning">
           {error}
         </p>
       )}
 
       <div className="overflow-x-auto">
-        <table className="w-full text-left text-sm text-gray-500">
-          <thead className="text-xs text-gray-700 uppercase bg-gray-50 border-b border-gray-200">
+        <table className="w-full text-left text-sm text-subtle">
+          <thead className="text-xs text-muted uppercase bg-background border-b border-border">
             <tr>
               <th className="px-4 py-3 rounded-tl-lg">Timestamp</th>
               <th className="px-4 py-3">Action</th>
@@ -99,12 +99,12 @@ export function AuditLogs() {
           </thead>
           <tbody>
             {filteredLogs.map((log) => (
-              <tr key={log.id} className="border-b border-gray-100 last:border-0 hover:bg-gray-50">
+              <tr key={log.id} className="border-b border-border last:border-0 hover:bg-background">
                 <td className="px-4 py-3 whitespace-nowrap">
                   {new Date(log.createdAt).toLocaleString()}
                 </td>
                 <td className="px-4 py-3">
-                  <span className="bg-gray-100 text-gray-800 px-2 py-1 rounded text-xs font-medium border border-gray-200">
+                  <span className="bg-surface text-foreground px-2 py-1 rounded text-xs font-medium border border-border">
                     {log.action}
                   </span>
                 </td>
@@ -119,7 +119,7 @@ export function AuditLogs() {
             ))}
             {filteredLogs.length === 0 && (
               <tr>
-                <td colSpan={4} className="px-4 py-8 text-center text-gray-500">
+                <td colSpan={4} className="px-4 py-8 text-center text-subtle">
                   No logs found matching the selected filter.
                 </td>
               </tr>

--- a/app/frontend/src/components/admin/FeatureFlags.tsx
+++ b/app/frontend/src/components/admin/FeatureFlags.tsx
@@ -109,20 +109,20 @@ export function FeatureFlags() {
   };
 
   return (
-    <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+    <div className="bg-card p-6 rounded-lg shadow-sm border border-border">
       <div className="flex flex-col gap-4 mb-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-gray-800">Safety Controls</h2>
-            <p className="text-sm text-gray-500">
-              Source: <span className="font-medium text-gray-700">{source}</span>
+            <h2 className="text-lg font-semibold text-foreground">Safety Controls</h2>
+            <p className="text-sm text-subtle">
+              Source: <span className="font-medium text-muted">{source}</span>
             </p>
           </div>
           <div
             className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${
               storeAvailable
-                ? "bg-emerald-50 text-emerald-700"
-                : "bg-amber-50 text-amber-700"
+                ? "bg-success-soft text-success"
+                : "bg-warning-soft text-warning"
             }`}
           >
             {storeAvailable ? <ShieldCheck className="h-3.5 w-3.5" /> : <AlertTriangle className="h-3.5 w-3.5" />}
@@ -130,11 +130,11 @@ export function FeatureFlags() {
           </div>
         </div>
         <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-subtle" />
           <input
             type="text"
             placeholder="Search flags..."
-            className="pl-9 pr-4 py-2 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 w-full"
+            className="pl-9 pr-4 py-2 text-sm border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-brand w-full"
             value={search}
             onChange={(event) => setSearch(event.target.value)}
           />
@@ -142,7 +142,7 @@ export function FeatureFlags() {
       </div>
 
       {error && (
-        <p className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+        <p className="mb-4 rounded-md border border-warning-soft bg-warning-soft px-3 py-2 text-sm text-warning">
           {error}
         </p>
       )}
@@ -151,27 +151,27 @@ export function FeatureFlags() {
         {filteredFlags.map((flag) => (
           <div
             key={flag.key}
-            className="rounded-lg border border-gray-200 px-4 py-4"
+            className="rounded-lg border border-border px-4 py-4"
           >
             <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
               <div className="space-y-1">
                 <div className="flex flex-wrap items-center gap-2">
-                  <p className="font-medium text-gray-900">{flag.name}</p>
-                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-gray-600">
+                  <p className="font-medium text-foreground">{flag.name}</p>
+                  <span className="rounded-full bg-surface px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted">
                     {flag.key}
                   </span>
                 </div>
-                <p className="text-sm text-gray-500">{flag.description}</p>
-                <p className="text-xs text-gray-400">
+                <p className="text-sm text-subtle">{flag.description}</p>
+                <p className="text-xs text-subtle">
                   Rollout {flag.rolloutPercentage}% • Environments {flag.environments.join(", ") || "all"} • Updated by {flag.updatedBy}
                 </p>
               </div>
 
               <div className="grid grid-cols-2 gap-3 sm:w-auto">
-                <label className="flex items-center gap-3 rounded-lg border border-gray-200 px-3 py-2">
+                <label className="flex items-center gap-3 rounded-lg border border-border px-3 py-2">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Enabled</p>
-                    <p className="text-sm text-gray-700">{flag.enabled ? "On" : "Off"}</p>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-subtle">Enabled</p>
+                    <p className="text-sm text-muted">{flag.enabled ? "On" : "Off"}</p>
                   </div>
                   <input
                     type="checkbox"
@@ -182,10 +182,10 @@ export function FeatureFlags() {
                   />
                 </label>
 
-                <label className="flex items-center gap-3 rounded-lg border border-gray-200 px-3 py-2">
+                <label className="flex items-center gap-3 rounded-lg border border-border px-3 py-2">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Kill Switch</p>
-                    <p className="text-sm text-gray-700">{flag.killSwitch ? "Armed" : "Standby"}</p>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-subtle">Kill Switch</p>
+                    <p className="text-sm text-muted">{flag.killSwitch ? "Armed" : "Standby"}</p>
                   </div>
                   <input
                     type="checkbox"
@@ -200,7 +200,7 @@ export function FeatureFlags() {
           </div>
         ))}
         {filteredFlags.length === 0 && (
-          <p className="text-sm text-gray-500 text-center py-4">No flags found.</p>
+          <p className="text-sm text-subtle text-center py-4">No flags found.</p>
         )}
       </div>
     </div>

--- a/app/frontend/src/components/admin/SystemHealth.tsx
+++ b/app/frontend/src/components/admin/SystemHealth.tsx
@@ -61,32 +61,32 @@ export function SystemHealth() {
   }, [apiBase]);
 
   return (
-    <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
-      <h2 className="text-lg font-semibold text-gray-800 mb-4">System Health</h2>
+    <div className="bg-card p-6 rounded-lg shadow-sm border border-border">
+      <h2 className="text-lg font-semibold text-foreground mb-4">System Health</h2>
 
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <div className="p-4 bg-green-50 rounded-lg border border-green-100">
-          <div className="flex items-center space-x-2 text-green-600 mb-2">
+        <div className="p-4 bg-success-soft rounded-lg border border-success-soft">
+          <div className="flex items-center space-x-2 text-success mb-2">
             <Activity className="h-5 w-5" />
             <span className="font-medium">API Status</span>
           </div>
-          <p className="text-2xl font-bold text-gray-800">{apiStatus}</p>
+          <p className="text-2xl font-bold text-foreground">{apiStatus}</p>
         </div>
 
-        <div className="p-4 bg-blue-50 rounded-lg border border-blue-100">
-          <div className="flex items-center space-x-2 text-blue-600 mb-2">
+        <div className="p-4 bg-brand-soft rounded-lg border border-brand-soft">
+          <div className="flex items-center space-x-2 text-brand mb-2">
             <DatabaseZap className="h-5 w-5" />
             <span className="font-medium">Flag Store</span>
           </div>
-          <p className="text-2xl font-bold text-gray-800">{flagStore}</p>
+          <p className="text-2xl font-bold text-foreground">{flagStore}</p>
         </div>
 
-        <div className="p-4 bg-amber-50 rounded-lg border border-amber-100">
-          <div className="flex items-center space-x-2 text-amber-600 mb-2">
+        <div className="p-4 bg-warning-soft rounded-lg border border-warning-soft">
+          <div className="flex items-center space-x-2 text-warning mb-2">
             <ShieldAlert className="h-5 w-5" />
             <span className="font-medium">Uptime</span>
           </div>
-          <p className="text-2xl font-bold text-gray-800">{uptime}</p>
+          <p className="text-2xl font-bold text-foreground">{uptime}</p>
         </div>
       </div>
     </div>

--- a/app/frontend/src/components/payment-states/ActivePaymentState.tsx
+++ b/app/frontend/src/components/payment-states/ActivePaymentState.tsx
@@ -261,23 +261,23 @@ export function ActivePaymentState({
           <div className="w-16 h-16 bg-indigo-500/10 rounded-full flex items-center justify-center mx-auto mb-4 border border-indigo-500/20">
             <WalletCards className="w-8 h-8 text-indigo-400" />
           </div>
-          <h1 className="text-2xl font-black tracking-tight text-white">
+          <h1 className="text-2xl font-black tracking-tight text-foreground">
             {txStep === "completed" ? "Payment Successful" : "Transaction Execution"}
           </h1>
-          <p className="text-neutral-400 text-sm mt-1">
+          <p className="text-subtle text-sm mt-1">
             Simulating, signing, and submitting your Stellar payment
           </p>
         </div>
 
         {/* Stepper Wizard Card */}
-        <div className="bg-neutral-900/90 border border-white/10 rounded-3xl p-6 md:p-8 shadow-2xl relative overflow-hidden backdrop-blur-2xl">
+        <div className="bg-card/90 border border-border-strong rounded-3xl p-6 md:p-8 shadow-2xl relative overflow-hidden backdrop-blur-2xl">
           {/* Subtle Glow backdrop */}
           <div className="absolute -right-20 -top-20 w-40 h-40 bg-indigo-500/10 rounded-full blur-3xl pointer-events-none" />
           
           {/* Stepper Progress Bar */}
           <div className="relative flex items-center justify-between max-w-md mx-auto mb-8">
             {/* Connecting Lines */}
-            <div className="absolute top-5 left-0 right-0 h-[2px] bg-neutral-800 -translate-y-1/2 z-0" />
+            <div className="absolute top-5 left-0 right-0 h-[2px] bg-surface-strong -translate-y-1/2 z-0" />
             
             {/* Segment Progress Highlight */}
             <div 
@@ -294,12 +294,12 @@ export function ActivePaymentState({
               <div 
                 className={`w-10 h-10 rounded-full flex items-center justify-center border-2 font-bold transition-all duration-300 ${
                   simulateStatus === "success"
-                    ? "bg-emerald-500/20 border-emerald-500 text-emerald-400"
+                    ? "bg-success-soft border-emerald-500 text-emerald-400"
                     : simulateStatus === "processing"
                     ? "bg-indigo-500/20 border-indigo-500 text-indigo-400 animate-pulse"
                     : simulateStatus === "error"
                     ? "bg-red-500/20 border-red-500 text-red-400"
-                    : "bg-neutral-950 border-neutral-800 text-neutral-500"
+                    : "bg-background border-border-strong text-subtle"
                 }`}
               >
                 {simulateStatus === "success" ? (
@@ -313,7 +313,7 @@ export function ActivePaymentState({
                 )}
               </div>
               <span className={`text-[11px] font-black uppercase mt-2 tracking-wider ${
-                simulateStatus === "processing" ? "text-indigo-400" : "text-neutral-400"
+                simulateStatus === "processing" ? "text-indigo-400" : "text-subtle"
               }`}>
                 Simulate
               </span>
@@ -324,12 +324,12 @@ export function ActivePaymentState({
               <div 
                 className={`w-10 h-10 rounded-full flex items-center justify-center border-2 font-bold transition-all duration-300 ${
                   signStatus === "success"
-                    ? "bg-emerald-500/20 border-emerald-500 text-emerald-400"
+                    ? "bg-success-soft border-emerald-500 text-emerald-400"
                     : signStatus === "processing"
                     ? "bg-indigo-500/20 border-indigo-500 text-indigo-400 animate-pulse"
                     : signStatus === "error"
                     ? "bg-red-500/20 border-red-500 text-red-400"
-                    : "bg-neutral-950 border-neutral-800 text-neutral-500"
+                    : "bg-background border-border-strong text-subtle"
                 }`}
               >
                 {signStatus === "success" ? (
@@ -343,7 +343,7 @@ export function ActivePaymentState({
                 )}
               </div>
               <span className={`text-[11px] font-black uppercase mt-2 tracking-wider ${
-                signStatus === "processing" ? "text-indigo-400" : "text-neutral-400"
+                signStatus === "processing" ? "text-indigo-400" : "text-subtle"
               }`}>
                 Sign
               </span>
@@ -354,12 +354,12 @@ export function ActivePaymentState({
               <div 
                 className={`w-10 h-10 rounded-full flex items-center justify-center border-2 font-bold transition-all duration-300 ${
                   submitStatus === "success"
-                    ? "bg-emerald-500/20 border-emerald-500 text-emerald-400"
+                    ? "bg-success-soft border-emerald-500 text-emerald-400"
                     : submitStatus === "processing"
                     ? "bg-indigo-500/20 border-indigo-500 text-indigo-400 animate-pulse"
                     : submitStatus === "error"
                     ? "bg-red-500/20 border-red-500 text-red-400"
-                    : "bg-neutral-950 border-neutral-800 text-neutral-500"
+                    : "bg-background border-border-strong text-subtle"
                 }`}
               >
                 {submitStatus === "success" ? (
@@ -373,7 +373,7 @@ export function ActivePaymentState({
                 )}
               </div>
               <span className={`text-[11px] font-black uppercase mt-2 tracking-wider ${
-                submitStatus === "processing" ? "text-indigo-400" : "text-neutral-400"
+                submitStatus === "processing" ? "text-indigo-400" : "text-subtle"
               }`}>
                 Submit
               </span>
@@ -391,7 +391,7 @@ export function ActivePaymentState({
                     {errorType === "rejection" && "Wallet Signature Request Rejected"}
                     {errorType === "network" && "Horizon Network Timeout"}
                   </h4>
-                  <p className="text-xs text-red-300/90 mt-1 leading-relaxed">
+                  <p className="text-xs text-danger/90 mt-1 leading-relaxed">
                     {errorMessage}
                   </p>
                   {errorType === "network" && (
@@ -406,11 +406,11 @@ export function ActivePaymentState({
           )}
 
           {/* Step Detail Status */}
-          <div className="text-center py-4 bg-white/[0.02] border border-white/5 rounded-2xl mb-6">
-            <p className="text-xs text-neutral-500 uppercase tracking-widest font-black mb-1">
+          <div className="text-center py-4 bg-card/[0.02] border border-border rounded-2xl mb-6">
+            <p className="text-xs text-subtle uppercase tracking-widest font-black mb-1">
               Current Status
             </p>
-            <p className="text-sm font-semibold text-white px-6">
+            <p className="text-sm font-semibold text-foreground px-6">
               {simulateStatus === "processing" && "Evaluating balance and routing paths..."}
               {simulateStatus === "error" && "Simulation check failed. Adjust options and retry."}
               {signStatus === "processing" && "Awaiting approval in Stellar Wallet extension..."}
@@ -422,9 +422,9 @@ export function ActivePaymentState({
           </div>
 
           {/* Terminal Console Logs */}
-          <div className="bg-black/90 rounded-2xl border border-white/5 overflow-hidden mb-6 font-mono text-xs shadow-inner">
-            <div className="flex items-center justify-between px-4 py-2 border-b border-white/5 bg-neutral-950">
-              <span className="text-neutral-400 flex items-center gap-2 font-bold text-[10px] uppercase tracking-wider">
+          <div className="bg-background/90 rounded-2xl border border-border overflow-hidden mb-6 font-mono text-xs shadow-inner">
+            <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-background">
+              <span className="text-subtle flex items-center gap-2 font-bold text-[10px] uppercase tracking-wider">
                 <Terminal size={12} className="text-indigo-400" /> Transaction Console Logs
               </span>
               <span className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />
@@ -440,14 +440,14 @@ export function ActivePaymentState({
                       ? "text-emerald-400"
                       : log.includes("SAFE TO RETRY")
                       ? "text-indigo-400 font-bold"
-                      : "text-neutral-300"
+                      : "text-muted"
                   }`}
                 >
                   {log}
                 </div>
               ))}
               {logs.length === 0 && (
-                <div className="text-neutral-600 italic">No output yet. Simulation starting...</div>
+                <div className="text-faint italic">No output yet. Simulation starting...</div>
               )}
             </div>
           </div>
@@ -459,7 +459,7 @@ export function ActivePaymentState({
                 <button
                   type="button"
                   onClick={handleCancel}
-                  className="flex-1 py-3.5 bg-neutral-800 hover:bg-neutral-700 text-neutral-300 font-bold rounded-xl transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300"
+                  className="flex-1 py-3.5 bg-surface-strong hover:bg-surface-strong text-muted font-bold rounded-xl transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300"
                 >
                   Cancel Payment
                 </button>
@@ -478,7 +478,7 @@ export function ActivePaymentState({
               <button
                 type="button"
                 disabled={true}
-                className="w-full py-4 bg-neutral-800 text-neutral-400 font-bold rounded-xl flex items-center justify-center gap-2.5 cursor-not-allowed"
+                className="w-full py-4 bg-surface-strong text-subtle font-bold rounded-xl flex items-center justify-center gap-2.5 cursor-not-allowed"
               >
                 <Loader2 size={18} className="animate-spin text-indigo-400" />
                 Processing Transaction...
@@ -488,25 +488,25 @@ export function ActivePaymentState({
         </div>
 
         {/* ── SIMULATOR CONTROL PANEL (DEV TOOL) ────────────────── */}
-        <div className="bg-neutral-900/60 border border-white/5 rounded-2xl overflow-hidden">
+        <div className="bg-card border border-border rounded-2xl overflow-hidden">
           <button
             type="button"
             onClick={() => setShowDevPanel(!showDevPanel)}
-            className="w-full flex items-center justify-between px-5 py-4 hover:bg-white/[0.02] transition-colors"
+            className="w-full flex items-center justify-between px-5 py-4 hover:bg-card/[0.02] transition-colors"
           >
-            <span className="flex items-center gap-2 text-sm font-bold text-neutral-400">
+            <span className="flex items-center gap-2 text-sm font-bold text-subtle">
               <Settings size={16} className="text-indigo-400" /> Stellar Pipeline Simulator Controls
             </span>
             {showDevPanel ? (
-              <ChevronUp size={16} className="text-neutral-500" />
+              <ChevronUp size={16} className="text-subtle" />
             ) : (
-              <ChevronDown size={16} className="text-neutral-500" />
+              <ChevronDown size={16} className="text-subtle" />
             )}
           </button>
 
           {showDevPanel && (
-            <div className="px-5 pb-5 pt-2 border-t border-white/5 space-y-4 animate-in fade-in duration-200">
-              <p className="text-xs text-neutral-500 leading-normal">
+            <div className="px-5 pb-5 pt-2 border-t border-border space-y-4 animate-in fade-in duration-200">
+              <p className="text-xs text-subtle leading-normal">
                 Toggle the behavior below to simulate and verify different outcomes, network errors, and contract rejections in the transaction stepper.
               </p>
               
@@ -516,12 +516,12 @@ export function ActivePaymentState({
                   onClick={() => setSimulatorOutcome("success")}
                   className={`p-3 rounded-xl border text-xs text-left font-semibold transition ${
                     simulatorOutcome === "success"
-                      ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-400"
-                      : "border-white/5 bg-neutral-950 text-neutral-400 hover:border-white/10"
+                      ? "border-emerald-500/50 bg-success-soft text-emerald-400"
+                      : "border-border bg-background text-subtle hover:border-border-strong"
                   }`}
                 >
                   <p className="font-bold">Always Succeed</p>
-                  <p className="text-[10px] text-neutral-500 mt-0.5">Success path through to PaidState</p>
+                  <p className="text-[10px] text-subtle mt-0.5">Success path through to PaidState</p>
                 </button>
 
                 <button
@@ -530,11 +530,11 @@ export function ActivePaymentState({
                   className={`p-3 rounded-xl border text-xs text-left font-semibold transition ${
                     simulatorOutcome === "fail_simulate"
                       ? "border-red-500/50 bg-red-500/10 text-red-400"
-                      : "border-white/5 bg-neutral-950 text-neutral-400 hover:border-white/10"
+                      : "border-border bg-background text-subtle hover:border-border-strong"
                   }`}
                 >
                   <p className="font-bold">Fail on Simulation</p>
-                  <p className="text-[10px] text-neutral-500 mt-0.5">Simulate contract / funds error</p>
+                  <p className="text-[10px] text-subtle mt-0.5">Simulate contract / funds error</p>
                 </button>
 
                 <button
@@ -543,11 +543,11 @@ export function ActivePaymentState({
                   className={`p-3 rounded-xl border text-xs text-left font-semibold transition ${
                     simulatorOutcome === "fail_sign"
                       ? "border-red-500/50 bg-red-500/10 text-red-400"
-                      : "border-white/5 bg-neutral-950 text-neutral-400 hover:border-white/10"
+                      : "border-border bg-background text-subtle hover:border-border-strong"
                   }`}
                 >
                   <p className="font-bold">Fail on Signing</p>
-                  <p className="text-[10px] text-neutral-500 mt-0.5">Simulate user rejecting wallet pop-up</p>
+                  <p className="text-[10px] text-subtle mt-0.5">Simulate user rejecting wallet pop-up</p>
                 </button>
 
                 <button
@@ -556,11 +556,11 @@ export function ActivePaymentState({
                   className={`p-3 rounded-xl border text-xs text-left font-semibold transition ${
                     simulatorOutcome === "fail_submit"
                       ? "border-red-500/50 bg-red-500/10 text-red-400"
-                      : "border-white/5 bg-neutral-950 text-neutral-400 hover:border-white/10"
+                      : "border-border bg-background text-subtle hover:border-border-strong"
                   }`}
                 >
                   <p className="font-bold">Fail on Submission</p>
-                  <p className="text-[10px] text-neutral-500 mt-0.5">Simulate Horizon network broadcast timeout</p>
+                  <p className="text-[10px] text-subtle mt-0.5">Simulate Horizon network broadcast timeout</p>
                 </button>
               </div>
             </div>
@@ -594,35 +594,35 @@ export function ActivePaymentState({
           </svg>
         </div>
         <h1 className="text-3xl font-bold mb-2">Payment Request</h1>
-        <p className="text-neutral-300">{status.userMessage}</p>
+        <p className="text-muted">{status.userMessage}</p>
       </div>
 
-      <div className="bg-neutral-900/50 border border-white/10 rounded-2xl p-8">
+      <div className="bg-card/50 border border-border-strong rounded-2xl p-8">
         <h2 className="text-xl font-bold mb-6">Payment Details</h2>
 
         <dl className="space-y-4">
-          <div className="flex justify-between items-center py-3 border-b border-white/5">
-            <dt className="text-neutral-300">Recipient</dt>
+          <div className="flex justify-between items-center py-3 border-b border-border">
+            <dt className="text-muted">Recipient</dt>
             <dd className="font-semibold">@{status.username}</dd>
           </div>
 
-          <div className="flex justify-between items-center py-3 border-b border-white/5">
-            <dt className="text-neutral-300">Amount</dt>
-            <dd className="text-2xl font-bold text-indigo-300">
+          <div className="flex justify-between items-center py-3 border-b border-border">
+            <dt className="text-muted">Amount</dt>
+            <dd className="text-2xl font-bold text-brand">
               {status.amount} {status.asset}
             </dd>
           </div>
 
           {status.memo && (
-            <div className="flex justify-between items-center py-3 border-b border-white/5">
-              <dt className="text-neutral-300">Memo</dt>
+            <div className="flex justify-between items-center py-3 border-b border-border">
+              <dt className="text-muted">Memo</dt>
               <dd className="font-mono text-sm">{status.memo}</dd>
             </div>
           )}
 
           {status.expiresAt && (
-            <div className="flex justify-between items-center py-3 border-b border-white/5">
-              <dt className="text-neutral-300">Expires</dt>
+            <div className="flex justify-between items-center py-3 border-b border-border">
+              <dt className="text-muted">Expires</dt>
               <dd className="text-sm">
                 {new Date(status.expiresAt).toLocaleDateString()}
               </dd>
@@ -632,11 +632,11 @@ export function ActivePaymentState({
       </div>
 
       {hasSwapOptions && status.acceptsMultipleAssets && (
-        <div className="bg-neutral-900/50 border border-white/10 rounded-2xl p-8">
+        <div className="bg-card/50 border border-border-strong rounded-2xl p-8">
           <h2 id="payment-options-heading" className="text-xl font-bold mb-4">
             Payment Options
           </h2>
-          <p className="text-sm text-neutral-300 mb-6">
+          <p className="text-sm text-muted mb-6">
             You can pay with any of these assets:
           </p>
 
@@ -650,16 +650,16 @@ export function ActivePaymentState({
               role="radio"
               aria-checked={selectedSourceAsset === null}
               onClick={() => setSelectedSourceAsset(null)}
-              className={`w-full p-4 rounded-xl border transition-all text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+              className={`w-full p-4 rounded-xl border transition-all text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
                 selectedSourceAsset === null
                   ? "border-indigo-500 bg-indigo-500/10"
-                  : "border-white/10 hover:border-white/20"
+                  : "border-border-strong hover:border-border-strong"
               }`}
             >
               <div className="flex justify-between items-center">
                 <div>
                   <p className="font-semibold">Pay with {status.asset}</p>
-                  <p className="text-sm text-neutral-300">Direct payment</p>
+                  <p className="text-sm text-muted">Direct payment</p>
                 </div>
                 <p className="font-bold">
                   {status.amount} {status.asset}
@@ -675,10 +675,10 @@ export function ActivePaymentState({
                 aria-checked={selectedSourceAsset === option.sourceAsset}
                 aria-label={`Pay with ${option.sourceAmount} ${option.sourceAsset}, ${option.hopCount} hops, ${option.rateDescription}`}
                 onClick={() => setSelectedSourceAsset(option.sourceAsset)}
-                className={`w-full p-4 rounded-xl border transition-all text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+                className={`w-full p-4 rounded-xl border transition-all text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
                   selectedSourceAsset === option.sourceAsset
                     ? "border-indigo-500 bg-indigo-500/10"
-                    : "border-white/10 hover:border-white/20"
+                    : "border-border-strong hover:border-border-strong"
                 }`}
               >
                 <div className="flex justify-between items-center">
@@ -686,13 +686,13 @@ export function ActivePaymentState({
                     <p className="font-semibold">
                       Pay with {option.sourceAsset}
                     </p>
-                    <p className="text-sm text-neutral-300">
+                    <p className="text-sm text-muted">
                       {option.rateDescription}
                     </p>
                   </div>
                   <div className="text-right">
                     <p className="font-bold">{option.sourceAmount}</p>
-                    <p className="text-xs text-neutral-400">
+                    <p className="text-xs text-subtle">
                       {option.hopCount} hop(s)
                     </p>
                   </div>
@@ -737,7 +737,7 @@ export function ActivePaymentState({
               ? `Confirm payment to ${status.username}`
               : `Review payment details for ${status.username}`
           }
-          className="w-full py-4 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-bold text-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="w-full py-4 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-bold text-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           {showPreview ? "Open Wallet & Pay" : "Review Payment"}
         </button>
@@ -746,7 +746,7 @@ export function ActivePaymentState({
           type="button"
           onClick={handleCopyLink}
           aria-label="Copy payment link to clipboard"
-          className="w-full py-3 bg-neutral-800 hover:bg-neutral-700 rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="w-full py-3 bg-surface-strong hover:bg-surface-strong rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           Copy Payment Link
         </button>
@@ -757,7 +757,7 @@ export function ActivePaymentState({
       </div>
 
       <div className="bg-blue-500/10 border border-blue-400/30 rounded-xl p-4">
-        <p className="text-sm text-blue-200">
+        <p className="text-sm text-brand">
           <strong>How it works:</strong> Review the transaction summary before your Stellar wallet opens. After confirmation, your wallet will request the signature for this exact payload.
         </p>
       </div>

--- a/app/frontend/src/components/payment-states/ErrorState.tsx
+++ b/app/frontend/src/components/payment-states/ErrorState.tsx
@@ -38,14 +38,14 @@ export function ErrorState({ message, onRetry, retryCount }: ErrorStateProps) {
       </div>
 
       <h2 className="text-2xl font-bold mb-4">Unable to Load Payment</h2>
-      <p className="text-neutral-300 text-center max-w-md mb-8">{message}</p>
+      <p className="text-muted text-center max-w-md mb-8">{message}</p>
 
       {isMultipleFailures && (
-        <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl p-4 mb-8 max-w-md">
-          <p className="text-amber-200 text-sm">
+        <div className="bg-warning-soft border border-amber-500/20 rounded-xl p-4 mb-8 max-w-md">
+          <p className="text-warning text-sm">
             <strong>Multiple failures detected.</strong> This could be due to:
           </p>
-          <ul className="text-amber-200/90 text-sm mt-2 space-y-1 list-disc list-inside">
+          <ul className="text-warning/90 text-sm mt-2 space-y-1 list-disc list-inside">
             <li>Network connectivity issues</li>
             <li>Server temporarily unavailable</li>
             <li>Invalid payment link parameters</li>
@@ -57,21 +57,21 @@ export function ErrorState({ message, onRetry, retryCount }: ErrorStateProps) {
         <button
           type="button"
           onClick={onRetry}
-          className="px-6 py-3 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="px-6 py-3 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           {retryCount === 0 ? "Try Again" : `Retry (Attempt ${retryCount + 1})`}
         </button>
 
         <Link
           href="/"
-          className="px-6 py-3 bg-neutral-800 hover:bg-neutral-700 rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="px-6 py-3 bg-surface-strong hover:bg-surface-strong rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           Go Home
         </Link>
       </div>
 
       {retryCount > 0 && (
-        <p className="mt-6 text-xs text-neutral-300">
+        <p className="mt-6 text-xs text-muted">
           Still having issues? Contact support with the error message above.
         </p>
       )}

--- a/app/frontend/src/components/payment-states/ExpiredPaymentState.tsx
+++ b/app/frontend/src/components/payment-states/ExpiredPaymentState.tsx
@@ -40,36 +40,36 @@ export function ExpiredPaymentState({ status }: ExpiredPaymentStateProps) {
           </svg>
         </div>
         <h1 className="text-3xl font-bold mb-2">Link Expired</h1>
-        <p className="text-neutral-300">{status.userMessage}</p>
+        <p className="text-muted">{status.userMessage}</p>
       </div>
 
       {/* Payment Details Card */}
-      <div className="bg-neutral-900/50 border border-white/10 rounded-2xl p-8">
+      <div className="bg-card/50 border border-border-strong rounded-2xl p-8">
         <h2 className="text-xl font-bold mb-6">Original Payment Details</h2>
 
         <dl className="space-y-4 opacity-80">
-          <div className="flex justify-between items-center py-3 border-b border-white/5">
-            <dt className="text-neutral-300">Recipient</dt>
+          <div className="flex justify-between items-center py-3 border-b border-border">
+            <dt className="text-muted">Recipient</dt>
             <dd className="font-semibold">@{status.username}</dd>
           </div>
 
-          <div className="flex justify-between items-center py-3 border-b border-white/5">
-            <dt className="text-neutral-300">Amount</dt>
+          <div className="flex justify-between items-center py-3 border-b border-border">
+            <dt className="text-muted">Amount</dt>
             <dd className="text-2xl font-bold">
               {status.amount} {status.asset}
             </dd>
           </div>
 
           {status.memo && (
-            <div className="flex justify-between items-center py-3 border-b border-white/5">
-              <dt className="text-neutral-300">Memo</dt>
+            <div className="flex justify-between items-center py-3 border-b border-border">
+              <dt className="text-muted">Memo</dt>
               <dd className="font-mono text-sm">{status.memo}</dd>
             </div>
           )}
 
           {status.expiresAt && (
-            <div className="flex justify-between items-center py-3 border-b border-white/5">
-              <dt className="text-neutral-300">Expired On</dt>
+            <div className="flex justify-between items-center py-3 border-b border-border">
+              <dt className="text-muted">Expired On</dt>
               <dd className="text-sm">
                 {new Date(status.expiresAt).toLocaleDateString()}
               </dd>
@@ -98,10 +98,10 @@ export function ExpiredPaymentState({ status }: ExpiredPaymentStateProps) {
             </svg>
           </div>
           <div>
-            <h3 className="font-semibold text-orange-300 mb-2">
+            <h3 className="font-semibold text-warning mb-2">
               Why did this expire?
             </h3>
-            <p className="text-sm text-orange-200/90">
+            <p className="text-sm text-warning/90">
               Payment links have an expiration date for security reasons. This
               link was not used before it expired. Please contact the recipient
               to generate a new payment link.
@@ -114,7 +114,7 @@ export function ExpiredPaymentState({ status }: ExpiredPaymentStateProps) {
       <div className="space-y-4">
         <Link
           href="/"
-          className="block w-full py-4 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-bold text-lg text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="block w-full py-4 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-bold text-lg text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           Go to Homepage
         </Link>
@@ -122,7 +122,7 @@ export function ExpiredPaymentState({ status }: ExpiredPaymentStateProps) {
         <button
           type="button"
           onClick={() => window.history.back()}
-          className="w-full py-3 bg-neutral-800 hover:bg-neutral-700 rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="w-full py-3 bg-surface-strong hover:bg-surface-strong rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           Go Back
         </button>

--- a/app/frontend/src/components/payment-states/LoadingState.tsx
+++ b/app/frontend/src/components/payment-states/LoadingState.tsx
@@ -10,10 +10,10 @@ export function LoadingState() {
       <div className="relative" aria-hidden="true">
         <div className="w-16 h-16 border-4 border-indigo-500/30 border-t-indigo-500 rounded-full animate-spin" />
       </div>
-      <p className="mt-8 text-lg text-neutral-200">
+      <p className="mt-8 text-lg text-muted">
         Loading payment details...
       </p>
-      <p className="mt-2 text-sm text-neutral-400">
+      <p className="mt-2 text-sm text-subtle">
         Please wait while we fetch the payment information
       </p>
     </div>

--- a/app/frontend/src/components/payment-states/PaidPaymentState.tsx
+++ b/app/frontend/src/components/payment-states/PaidPaymentState.tsx
@@ -44,10 +44,10 @@ export function PaidPaymentState({ status }: PaidPaymentStateProps) {
             />
           </svg>
         </div>
-        <h1 className="text-4xl font-bold mb-3 text-green-300">
+        <h1 className="text-4xl font-bold mb-3 text-success">
           Payment Complete!
         </h1>
-        <p className="text-neutral-300 text-lg">{status.userMessage}</p>
+        <p className="text-muted text-lg">{status.userMessage}</p>
       </div>
 
       {/* Payment Success Card */}
@@ -55,28 +55,28 @@ export function PaidPaymentState({ status }: PaidPaymentStateProps) {
         <h2 className="text-xl font-bold mb-6">Payment Summary</h2>
 
         <dl className="space-y-4">
-          <div className="flex justify-between items-center py-3 border-b border-white/5">
-            <dt className="text-neutral-300">Paid To</dt>
+          <div className="flex justify-between items-center py-3 border-b border-border">
+            <dt className="text-muted">Paid To</dt>
             <dd className="font-semibold">@{status.username}</dd>
           </div>
 
-          <div className="flex justify-between items-center py-3 border-b border-white/5">
-            <dt className="text-neutral-300">Amount Paid</dt>
-            <dd className="text-3xl font-bold text-green-300">
+          <div className="flex justify-between items-center py-3 border-b border-border">
+            <dt className="text-muted">Amount Paid</dt>
+            <dd className="text-3xl font-bold text-success">
               {status.amount} {status.asset}
             </dd>
           </div>
 
           {status.memo && (
-            <div className="flex justify-between items-center py-3 border-b border-white/5">
-              <dt className="text-neutral-300">Memo</dt>
+            <div className="flex justify-between items-center py-3 border-b border-border">
+              <dt className="text-muted">Memo</dt>
               <dd className="font-mono text-sm">{status.memo}</dd>
             </div>
           )}
 
           {status.paidAt && (
-            <div className="flex justify-between items-center py-3 border-b border-white/5">
-              <dt className="text-neutral-300">Completed At</dt>
+            <div className="flex justify-between items-center py-3 border-b border-border">
+              <dt className="text-muted">Completed At</dt>
               <dd className="text-sm">
                 {new Date(status.paidAt).toLocaleString()}
               </dd>
@@ -87,11 +87,11 @@ export function PaidPaymentState({ status }: PaidPaymentStateProps) {
 
       {/* Transaction Hash */}
       {status.transactionHash && (
-        <div className="bg-neutral-900/50 border border-white/10 rounded-2xl p-6">
-          <h3 className="text-sm font-semibold text-neutral-200 mb-3">
+        <div className="bg-card/50 border border-border-strong rounded-2xl p-6">
+          <h3 className="text-sm font-semibold text-muted mb-3">
             Transaction Hash
           </h3>
-          <div className="bg-black/50 rounded-xl p-4 font-mono text-xs break-all">
+          <div className="bg-background/50 rounded-xl p-4 font-mono text-xs break-all">
             {status.transactionHash}
           </div>
 
@@ -101,7 +101,7 @@ export function PaidPaymentState({ status }: PaidPaymentStateProps) {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="View transaction on Stellar explorer (opens in new tab)"
-              className="mt-4 inline-flex items-center gap-2 text-indigo-300 hover:text-indigo-200 underline-offset-4 hover:underline transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded"
+              className="mt-4 inline-flex items-center gap-2 text-brand hover:text-brand underline-offset-4 hover:underline transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded"
             >
               <span>View on Explorer</span>
               <svg
@@ -144,10 +144,10 @@ export function PaidPaymentState({ status }: PaidPaymentStateProps) {
             </svg>
           </div>
           <div>
-            <h3 className="font-semibold text-green-300 mb-2">
+            <h3 className="font-semibold text-success mb-2">
               What&apos;s next?
             </h3>
-            <p className="text-sm text-green-200/90">
+            <p className="text-sm text-success/90">
               Your payment has been confirmed on the Stellar network. The
               recipient has been notified and the funds are now available in
               their account.
@@ -160,7 +160,7 @@ export function PaidPaymentState({ status }: PaidPaymentStateProps) {
       <div className="space-y-4">
         <Link
           href="/"
-          className="block w-full py-4 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-bold text-lg text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="block w-full py-4 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-bold text-lg text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           Back to Homepage
         </Link>
@@ -172,7 +172,7 @@ export function PaidPaymentState({ status }: PaidPaymentStateProps) {
             onClick={() => {
               navigator.clipboard.writeText(status.transactionHash!);
             }}
-            className="w-full py-3 bg-neutral-800 hover:bg-neutral-700 rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            className="w-full py-3 bg-surface-strong hover:bg-surface-strong rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
             Copy Transaction Hash
           </button>

--- a/app/frontend/src/components/payment-states/RefundedPaymentState.tsx
+++ b/app/frontend/src/components/payment-states/RefundedPaymentState.tsx
@@ -41,36 +41,36 @@ export function RefundedPaymentState({ status }: RefundedPaymentStateProps) {
           </svg>
         </div>
         <h1 className="text-3xl font-bold mb-2">Payment Refunded</h1>
-        <p className="text-neutral-300">{status.userMessage}</p>
+        <p className="text-muted">{status.userMessage}</p>
       </div>
 
       {/* Payment Details Card */}
-      <div className="bg-neutral-900/50 border border-white/10 rounded-2xl p-8">
+      <div className="bg-card/50 border border-border-strong rounded-2xl p-8">
         <h2 className="text-xl font-bold mb-6">Refund Details</h2>
 
         <dl className="space-y-4">
-          <div className="flex justify-between items-center py-3 border-b border-white/5">
-            <dt className="text-neutral-300">Original Recipient</dt>
+          <div className="flex justify-between items-center py-3 border-b border-border">
+            <dt className="text-muted">Original Recipient</dt>
             <dd className="font-semibold">@{status.username}</dd>
           </div>
 
-          <div className="flex justify-between items-center py-3 border-b border-white/5">
-            <dt className="text-neutral-300">Refunded Amount</dt>
-            <dd className="text-2xl font-bold text-purple-300">
+          <div className="flex justify-between items-center py-3 border-b border-border">
+            <dt className="text-muted">Refunded Amount</dt>
+            <dd className="text-2xl font-bold text-brand">
               {status.amount} {status.asset}
             </dd>
           </div>
 
           {status.memo && (
-            <div className="flex justify-between items-center py-3 border-b border-white/5">
-              <dt className="text-neutral-300">Original Memo</dt>
+            <div className="flex justify-between items-center py-3 border-b border-border">
+              <dt className="text-muted">Original Memo</dt>
               <dd className="font-mono text-sm">{status.memo}</dd>
             </div>
           )}
 
           {status.paidAt && (
-            <div className="flex justify-between items-center py-3 border-b border-white/5">
-              <dt className="text-neutral-300">Original Payment Date</dt>
+            <div className="flex justify-between items-center py-3 border-b border-border">
+              <dt className="text-muted">Original Payment Date</dt>
               <dd className="text-sm">
                 {new Date(status.paidAt).toLocaleDateString()}
               </dd>
@@ -99,10 +99,10 @@ export function RefundedPaymentState({ status }: RefundedPaymentStateProps) {
             </svg>
           </div>
           <div>
-            <h3 className="font-semibold text-purple-300 mb-2">
+            <h3 className="font-semibold text-brand mb-2">
               About this refund
             </h3>
-            <p className="text-sm text-purple-200/90">
+            <p className="text-sm text-brand/90">
               This payment has been refunded by the recipient. The funds have
               been returned to the original sender&apos;s account. Refunds are
               processed on the Stellar network and may take a few moments to
@@ -116,7 +116,7 @@ export function RefundedPaymentState({ status }: RefundedPaymentStateProps) {
       <div className="space-y-4">
         <Link
           href="/"
-          className="block w-full py-4 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-bold text-lg text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="block w-full py-4 bg-indigo-600 hover:bg-indigo-700 rounded-xl font-bold text-lg text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           Go to Homepage
         </Link>
@@ -124,7 +124,7 @@ export function RefundedPaymentState({ status }: RefundedPaymentStateProps) {
         <button
           type="button"
           onClick={() => window.history.back()}
-          className="w-full py-3 bg-neutral-800 hover:bg-neutral-700 rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="w-full py-3 bg-surface-strong hover:bg-surface-strong rounded-xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           Go Back
         </button>

--- a/app/frontend/src/lib/notifications.ts
+++ b/app/frontend/src/lib/notifications.ts
@@ -21,10 +21,9 @@ export const CATEGORY_LABELS: Record<NotificationCategory, string> = {
 };
 
 export const CATEGORY_STYLES: Record<NotificationCategory, string> = {
-  payments:
-    "border-emerald-400/20 bg-emerald-400/10 text-emerald-100",
-  escrows: "border-indigo-400/20 bg-indigo-400/10 text-indigo-100",
-  system: "border-amber-400/20 bg-amber-400/10 text-amber-100",
+  payments: "border-success-soft bg-success-soft text-success",
+  escrows: "border-brand-soft bg-brand-soft text-brand",
+  system: "border-warning-soft bg-warning-soft text-warning",
 };
 
 export const INITIAL_NOTIFICATIONS: StoredNotification[] = [


### PR DESCRIPTION
Closes #572 

## Summary

This PR introduces a proper **semantic token-based theme system** with a **light/dark toggle**, then migrates the core screens (dashboard, public payment pages, settings, admin) and shared components/charts off hardcoded colors so both themes render consistently and remain readable.
## What changed

## 1. Theme token system — `globals.css`
- CSS variables for **light** (`:root`) and **dark** (`.dark`), exposed as Tailwind v4 utilities via `@theme inline`
- Dedicated chart tokens (`--chart-grid`, `--chart-axis`, `--chart-tooltip-*`) consumed directly by Recharts so charts re-color per theme.

## 2. Theme switching
- **`ThemeProvider.tsx`** — manages the `.dark` class on `<html>`, persists to `localStorage['quickex-theme']`, respects system preference, and ships a **no-FOUC inline script** (set in `layout.tsx` `<head>`) so there's no flash of the wrong theme.
- **`ThemeToggle.tsx`** — sun/moon toggle wired into the `Header`.

## 3. Color migration across the app
- ~40 files converted from hardcoded colors (`bg-black/40`, `text-neutral-400`, `border-white/5`, `bg-white`, `text-gray-800`, …) to semantic tokens.
- **Admin screens** (previously hardcoded light) now use the same tokens and follow the active theme.
- **Charts** (`AnalyticsDashboard`) — grid, axes, tooltips, and donut labels tokenized.
- Literal `text-white` kept only on solid saturated accent buttons (e.g. `bg-indigo-500 text-white`), where white is correct in both themes.

## 4. Result

https://github.com/user-attachments/assets/4f07a14a-9f91-49a1-8c0a-b056e00d4b68


https://github.com/user-attachments/assets/8f7bb223-756f-48e6-ad9a-d11863745d2e


