### PR TITLE
MOB-42: Add notification deep link recovery and fallback routing

### DIFF
--- a/app/mobile/__tests__/notification-routing.test.ts
+++ b/app/mobile/__tests__/notification-routing.test.ts
@@ -1,4 +1,4 @@
-import { routeFromPushPayload, parsePushNotificationPayload } from "../services/notification-routing";
+import { routeFromNotificationResponse, routeFromPushPayload, parsePushNotificationPayload } from "../services/notification-routing";
 import { PUSH_NOTIFICATION_TYPES } from "../types/push-notification";
 
 describe("notification routing payload contracts", () => {
@@ -40,5 +40,60 @@ describe("notification routing payload contracts", () => {
       pathname: "/listing/[id]",
       params: { id: "listing_01", sellerId: "unknown" },
     });
+  });
+
+  it("routes partial transaction payloads to transaction detail with defaults", () => {
+    const push = jest.fn();
+    routeFromPushPayload(
+      { push } as any,
+      {
+        type: PUSH_NOTIFICATION_TYPES.transactionDetail,
+        transactionId: "tx_200",
+      },
+    );
+
+    expect(push).toHaveBeenCalledWith({
+      pathname: "/transaction/[id]",
+      params: {
+        id: "tx_200",
+        txHash: "tx_200",
+        amount: "0",
+        asset: "XLM",
+        status: "Success",
+        timestamp: expect.any(String),
+        source: "notification",
+        destination: "notification",
+      },
+    });
+  });
+
+  it("recovers malformed notification payloads by routing to inbox", () => {
+    const push = jest.fn();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    routeFromNotificationResponse(
+      { push } as any,
+      {
+        notification: {
+          request: {
+            content: {
+              data: {
+                type: "unknown_type",
+              },
+            },
+          },
+        },
+      } as any,
+    );
+
+    expect(push).toHaveBeenCalledWith({
+      pathname: "/inbox",
+      params: {
+        source: "notification_recovery",
+        reason: "invalid_payload",
+      },
+    });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -27,6 +27,7 @@ import { WalletSyncBridge } from "../components/wallet/WalletSyncBridge";
 
 import { resolveDeepLink, type DeepLinkRoute } from "@/utils/deep-link-routing";
 import {
+  routeFromNotificationResponse,
   parsePushNotificationPayload,
   routeFromPushPayload,
 } from "../services/notification-routing";
@@ -67,11 +68,7 @@ function useDeepLinkHandler(
 function useNotificationTapRouting(onRoute: (route: DeepLinkRoute) => void) {
   useEffect(() => {
     function routeResponse(response: Notifications.NotificationResponse | null | undefined) {
-      const payload = parsePushNotificationPayload(
-        response?.notification?.request?.content?.data,
-      );
-      if (!payload) return;
-      routeFromPushPayload({ push: (route: DeepLinkRoute) => onRoute(route) } as any, payload);
+      routeFromNotificationResponse({ push: (route: DeepLinkRoute) => onRoute(route) } as any, response);
     }
 
     Notifications.getLastNotificationResponseAsync()
@@ -242,6 +239,7 @@ function AppShell() {
         <Stack.Screen name="transaction/[id]" />
         <Stack.Screen name="escrow/[id]" />
         <Stack.Screen name="listing/[id]" />
+        <Stack.Screen name="inbox" />
         <Stack.Screen name="notification-debug" />
         <Stack.Screen name="deep-link-debug" />
         <Stack.Screen name="link-error" />

--- a/app/mobile/services/notification-routing.ts
+++ b/app/mobile/services/notification-routing.ts
@@ -58,39 +58,96 @@ export function parsePushNotificationPayload(
   return null;
 }
 
+function trackNotificationDeepLinkFailure(
+  message: string,
+  payload: unknown,
+) {
+  const payloadDetails = typeof payload === 'object' && payload !== null
+    ? JSON.stringify(payload)
+    : String(payload);
+
+  console.warn('Notification deep link recovery:', message, payloadDetails);
+}
+
+function pushInboxFallback(router: Router, reason: string) {
+  router.push({
+    pathname: '/inbox',
+    params: {
+      source: 'notification_recovery',
+      reason,
+    },
+  });
+}
+
 export function routeFromPushPayload(
   router: Router,
   payload: PushNotificationPayload,
 ) {
   if (payload.type === PUSH_NOTIFICATION_TYPES.transactionDetail) {
+    if (!payload.transactionId) {
+      trackNotificationDeepLinkFailure(
+        'Missing transactionId for transaction detail notification',
+        payload,
+      );
+      pushInboxFallback(router, 'missing_transaction_id');
+      return;
+    }
+
     router.push({
-      pathname: "/transaction/[id]",
+      pathname: '/transaction/[id]',
       params: {
         id: payload.transactionId,
         txHash: payload.txHash ?? payload.transactionId,
-        amount: payload.amount ?? "0",
-        asset: payload.asset ?? "XLM",
-        status: payload.status ?? "Success",
+        amount: payload.amount ?? '0',
+        asset: payload.asset ?? 'XLM',
+        status: payload.status ?? 'Success',
         timestamp: new Date().toISOString(),
-        source: "notification",
-        destination: "notification",
+        source: 'notification',
+        destination: 'notification',
       },
     });
     return;
   }
 
   if (payload.type === PUSH_NOTIFICATION_TYPES.escrowDetail) {
+    if (!payload.escrowId) {
+      trackNotificationDeepLinkFailure(
+        'Missing escrowId for escrow detail notification',
+        payload,
+      );
+      pushInboxFallback(router, 'missing_escrow_id');
+      return;
+    }
+
     router.push({
-      pathname: "/escrow/[id]",
-      params: { id: payload.escrowId, status: payload.status ?? "open" },
+      pathname: '/escrow/[id]',
+      params: { id: payload.escrowId, status: payload.status ?? 'open' },
     });
     return;
   }
 
-  router.push({
-    pathname: "/listing/[id]",
-    params: { id: payload.listingId, sellerId: payload.sellerId ?? "unknown" },
-  });
+  if (payload.type === PUSH_NOTIFICATION_TYPES.listingDetail) {
+    if (!payload.listingId) {
+      trackNotificationDeepLinkFailure(
+        'Missing listingId for listing detail notification',
+        payload,
+      );
+      pushInboxFallback(router, 'missing_listing_id');
+      return;
+    }
+
+    router.push({
+      pathname: '/listing/[id]',
+      params: { id: payload.listingId, sellerId: payload.sellerId ?? 'unknown' },
+    });
+    return;
+  }
+
+  trackNotificationDeepLinkFailure(
+    'Unsupported notification payload type',
+    payload,
+  );
+  pushInboxFallback(router, 'unsupported_payload_type');
 }
 
 export function routeFromNotificationResponse(
@@ -100,7 +157,15 @@ export function routeFromNotificationResponse(
   const payload = parsePushNotificationPayload(
     response?.notification?.request?.content?.data,
   );
-  if (!payload) return false;
+  if (!payload) {
+    trackNotificationDeepLinkFailure(
+      'Malformed or incomplete push notification payload',
+      response?.notification?.request?.content?.data,
+    );
+    pushInboxFallback(router, 'invalid_payload');
+    return true;
+  }
+
   routeFromPushPayload(router, payload);
   return true;
 }


### PR DESCRIPTION
close #587 
PR description
Added recovery logic for stale, invalid, or partial notification deep links in notification-routing.ts
Added fallback routing to /inbox when notification payloads are malformed or missing required IDs
Added diagnostic logging for notification deep link failures
Updated notification tap handling in _layout.tsx to use shared recovery routing
