### PR TITLE
MOB-39: Preview Environment Switcher

### DIFF
--- a/app/mobile/__tests__/EnvironmentStorage.test.ts
+++ b/app/mobile/__tests__/EnvironmentStorage.test.ts
@@ -1,0 +1,67 @@
+import {
+  loadEnvironment,
+  saveEnvironment,
+  resetEnvironment,
+} from '../services/environment-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { DEFAULT_ENVIRONMENT } from '../src/config/environment';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+}));
+
+describe('Environment Storage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads default environment when nothing is stored', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const env = await loadEnvironment();
+    expect(env).toBe(DEFAULT_ENVIRONMENT);
+  });
+
+  it('persists and loads staging', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+      JSON.stringify({ environmentId: 'staging' }),
+    );
+    expect(await loadEnvironment()).toBe('staging');
+  });
+
+  it('persists and loads testnet', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+      JSON.stringify({ environmentId: 'testnet' }),
+    );
+    expect(await loadEnvironment()).toBe('testnet');
+  });
+
+  it('persists and loads branch-preview', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+      JSON.stringify({ environmentId: 'branch-preview' }),
+    );
+    expect(await loadEnvironment()).toBe('branch-preview');
+  });
+
+  it('calls setItem on save', async () => {
+    await saveEnvironment('staging');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      '@quickex/environment',
+      JSON.stringify({ environmentId: 'staging' }),
+    );
+  });
+
+  it('calls removeItem on reset', async () => {
+    await resetEnvironment();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@quickex/environment');
+  });
+
+  it('falls back to default when stored value is invalid', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+      JSON.stringify({ environmentId: 'invalid-env' }),
+    );
+    expect(await loadEnvironment()).toBe(DEFAULT_ENVIRONMENT);
+  });
+});

--- a/app/mobile/__tests__/EnvironmentSwitcher.test.tsx
+++ b/app/mobile/__tests__/EnvironmentSwitcher.test.tsx
@@ -1,0 +1,332 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import { EnvironmentSwitcher } from '../components/EnvironmentSwitcher';
+import {
+  EnvironmentProvider,
+  useEnvironment,
+} from '../contexts/EnvironmentContext';
+import {
+  saveEnvironment,
+  resetEnvironment,
+} from '../services/environment-storage';
+import { ENVIRONMENTS } from '../src/config/environment';
+const DEFAULT_ENVIRONMENT = 'production';
+
+jest.mock('../src/theme/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: {
+      background: '#FFFFFF',
+      surface: '#F5F5F5',
+      surfaceElevated: '#EEEEEE',
+      border: '#DDDDDD',
+      borderLight: '#E5E5E5',
+      textPrimary: '#111111',
+      textSecondary: '#444444',
+      textMuted: '#666666',
+      chipActiveBg: '#E8F4FD',
+      chipActiveText: '#0066CC',
+      chipBg: '#F0F0F0',
+      buttonPrimaryBg: '#0066CC',
+      buttonPrimaryText: '#FFFFFF',
+      buttonSecondaryBg: '#F5F5F5',
+      buttonSecondaryText: '#111111',
+      buttonSecondaryBorder: '#DDDDDD',
+      buttonDangerBg: '#FEE2E2',
+      buttonDangerText: '#DC2626',
+      status: {
+        success: '#16A34A',
+        successBg: '#DCFCE7',
+        warning: '#F59E0B',
+        warningBg: '#FEF3C7',
+        error: '#DC2626',
+        errorBg: '#FEE2E2',
+        info: '#3B82F6',
+        infoBg: '#DBEAFE',
+      },
+    },
+  }),
+}));
+
+jest.mock('../services/environment-storage', () => ({
+  __esModule: true,
+  loadEnvironment: jest.fn(async () => 'production'),
+  saveEnvironment: jest.fn(async () => undefined),
+  resetEnvironment: jest.fn(async () => undefined),
+}));
+
+// ── Context tests ──────────────────────────────────────────────────────────
+
+describe('Environment Context', () => {
+  function TestConsumer() {
+    const { currentId, switchEnvironment, resetToDefault } = useEnvironment();
+    return (
+      <>
+        <Text testID="current-id">{currentId}</Text>
+        <Text
+          testID="switch-staging"
+          onPress={() => switchEnvironment('staging')}
+        >
+          Staging
+        </Text>
+        <Text
+          testID="switch-testnet"
+          onPress={() => switchEnvironment('testnet')}
+        >
+          Testnet
+        </Text>
+        <Text
+          testID="switch-branch-preview"
+          onPress={() => switchEnvironment('branch-preview')}
+        >
+          Branch Preview
+        </Text>
+        <Text testID="reset" onPress={() => resetToDefault()}>
+          Reset
+        </Text>
+      </>
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts with default environment', async () => {
+    let tree: ReturnType<typeof create>;
+    await act(async () => {
+      tree = create(
+        <EnvironmentProvider>
+          <TestConsumer />
+        </EnvironmentProvider>,
+      );
+    });
+
+    expect(
+      tree.root.findByProps({ testID: 'current-id' }).props.children,
+    ).toBe(DEFAULT_ENVIRONMENT);
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+
+  it('switches to staging and persists', async () => {
+    let tree: ReturnType<typeof create>;
+    await act(async () => {
+      tree = create(
+        <EnvironmentProvider>
+          <TestConsumer />
+        </EnvironmentProvider>,
+      );
+    });
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'switch-staging' }).props.onPress();
+    });
+
+    expect(
+      tree.root.findByProps({ testID: 'current-id' }).props.children,
+    ).toBe('staging');
+    expect(saveEnvironment).toHaveBeenCalledWith('staging');
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+
+  it('switches to testnet', async () => {
+    let tree: ReturnType<typeof create>;
+    await act(async () => {
+      tree = create(
+        <EnvironmentProvider>
+          <TestConsumer />
+        </EnvironmentProvider>,
+      );
+    });
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'switch-testnet' }).props.onPress();
+    });
+
+    expect(
+      tree.root.findByProps({ testID: 'current-id' }).props.children,
+    ).toBe('testnet');
+    expect(saveEnvironment).toHaveBeenCalledWith('testnet');
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+
+  it('switches to branch-preview', async () => {
+    let tree: ReturnType<typeof create>;
+    await act(async () => {
+      tree = create(
+        <EnvironmentProvider>
+          <TestConsumer />
+        </EnvironmentProvider>,
+      );
+    });
+
+    await act(async () => {
+      tree.root
+        .findByProps({ testID: 'switch-branch-preview' })
+        .props.onPress();
+    });
+
+    expect(
+      tree.root.findByProps({ testID: 'current-id' }).props.children,
+    ).toBe('branch-preview');
+    expect(saveEnvironment).toHaveBeenCalledWith('branch-preview');
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+
+  it('resets to default after switching', async () => {
+    let tree: ReturnType<typeof create>;
+    await act(async () => {
+      tree = create(
+        <EnvironmentProvider>
+          <TestConsumer />
+        </EnvironmentProvider>,
+      );
+    });
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'switch-staging' }).props.onPress();
+    });
+
+    expect(
+      tree.root.findByProps({ testID: 'current-id' }).props.children,
+    ).toBe('staging');
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'reset' }).props.onPress();
+    });
+
+    expect(
+      tree.root.findByProps({ testID: 'current-id' }).props.children,
+    ).toBe(DEFAULT_ENVIRONMENT);
+    expect(resetEnvironment).toHaveBeenCalled();
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+});
+
+// ── Component tests ────────────────────────────────────────────────────────
+
+describe('Environment Switcher Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        appVersion: '2.0.0',
+        minAppVersion: '1.0.0',
+        environment: 'staging',
+        stellarNetwork: 'testnet',
+      }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders all environment options', async () => {
+    let tree: ReturnType<typeof create>;
+    await act(async () => {
+      tree = create(
+        <EnvironmentProvider>
+          <EnvironmentSwitcher />
+        </EnvironmentProvider>,
+      );
+    });
+
+    expect(tree.root.findByProps({ testID: 'switch-production' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'switch-staging' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'switch-testnet' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'switch-branch-preview' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'reset-environment' })).toBeDefined();
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+
+  it('switches environment when a Pressable is tapped', async () => {
+    let tree: ReturnType<typeof create>;
+    await act(async () => {
+      tree = create(
+        <EnvironmentProvider>
+          <EnvironmentSwitcher />
+        </EnvironmentProvider>,
+      );
+    });
+
+    const pressable = tree.root.findByProps({ testID: 'switch-testnet' });
+    await act(async () => {
+      pressable.props.onPress();
+    });
+
+    expect(saveEnvironment).toHaveBeenCalledWith('testnet');
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+
+  it('shows compatibility section for non-production environment', async () => {
+    let tree: ReturnType<typeof create>;
+    await act(async () => {
+      tree = create(
+        <EnvironmentProvider>
+          <EnvironmentSwitcher />
+        </EnvironmentProvider>,
+      );
+    });
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'switch-staging' }).props.onPress();
+    });
+
+    expect(tree.root.findByProps({ testID: 'reset-environment' })).toBeDefined();
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+
+  it('can reset to default', async () => {
+    let tree: ReturnType<typeof create>;
+    await act(async () => {
+      tree = create(
+        <EnvironmentProvider>
+          <EnvironmentSwitcher />
+        </EnvironmentProvider>,
+      );
+    });
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'switch-staging' }).props.onPress();
+    });
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'reset-environment' }).props.onPress();
+    });
+
+    expect(resetEnvironment).toHaveBeenCalled();
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+});
+
+

--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -22,6 +22,7 @@ import { usePaymentListener } from "../hooks/usePaymentListener";
 import { useOnboarding } from "../hooks/useOnboarding";
 import { WalletProvider } from "../hooks/useWalletContext";
 import { NetworkGuardProvider } from "../contexts/NetworkGuardContext";
+import { EnvironmentProvider } from "../contexts/EnvironmentContext";
 import { GlobalNetworkBanner } from "../components/wallet/GlobalNetworkBanner";
 import { WalletSyncBridge } from "../components/wallet/WalletSyncBridge";
 
@@ -136,7 +137,8 @@ function ThemeBridge() {
 
   return (
     <ThemeProvider value={navTheme}>
-      <SecurityProvider>
+      <EnvironmentProvider>
+        <SecurityProvider>
         <WalletProvider>
           <NetworkGuardProvider expectedNetwork="testnet">
             <NotificationProvider>
@@ -155,6 +157,7 @@ function ThemeBridge() {
           </NetworkGuardProvider>
         </WalletProvider>
       </SecurityProvider>
+      </EnvironmentProvider>
       <StatusBar style={isDark ? "light" : "dark"} />
     </ThemeProvider>
   );

--- a/app/mobile/app/settings.tsx
+++ b/app/mobile/app/settings.tsx
@@ -1,5 +1,6 @@
 import { Link, useRouter } from "expo-router";
 import React from "react";
+import { EnvironmentSwitcher } from "../components/EnvironmentSwitcher";
 import {
   Alert,
   Platform,
@@ -404,6 +405,8 @@ export default function SettingsScreen() {
           </Pressable>
           <Text style={[styles.helper, { color: theme.textMuted }]}>Remove all cached and secure data, sign out, and reset the app state.</Text>
         </View>
+
+        <EnvironmentSwitcher />
 
         {Platform.OS !== "web" ? (
           <View style={styles.section}>

--- a/app/mobile/components/EnvironmentSwitcher.tsx
+++ b/app/mobile/components/EnvironmentSwitcher.tsx
@@ -1,0 +1,331 @@
+import React, { useEffect } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useEnvironment } from '../contexts/EnvironmentContext';
+import { useTheme } from '../src/theme/ThemeContext';
+
+export function EnvironmentSwitcher() {
+  const { theme } = useTheme();
+  const {
+    currentId,
+    available,
+    switchEnvironment,
+    resetToDefault,
+    metadata,
+    compatibility,
+    isFetchingMetadata,
+    fetchMetadata,
+  } = useEnvironment();
+
+  useEffect(() => {
+    if (currentId !== 'production') {
+      fetchMetadata();
+    }
+  }, [currentId, fetchMetadata]);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: theme.surface, borderColor: theme.border },
+      ]}
+    >
+      <Text style={[styles.title, { color: theme.textPrimary }]}>
+        Environment
+      </Text>
+      <Text style={[styles.helper, { color: theme.textMuted }]}>
+        Switch between backend environments for testing.
+      </Text>
+
+      <View style={styles.environmentList}>
+        {available.map((env) => {
+          const isActive = env.id === currentId;
+          return (
+            <Pressable
+              key={env.id}
+              testID={`switch-${env.id}`}
+              style={[
+                styles.environmentItem,
+                {
+                  backgroundColor: isActive
+                    ? theme.chipActiveBg
+                    : theme.background,
+                  borderColor: isActive
+                    ? theme.buttonPrimaryBg
+                    : theme.borderLight,
+                },
+              ]}
+              onPress={() => {
+                switchEnvironment(env.id);
+              }}
+            >
+              <View style={styles.environmentInfo}>
+                <Text
+                  style={[
+                    styles.environmentLabel,
+                    {
+                      color: isActive
+                        ? theme.chipActiveText
+                        : theme.textPrimary,
+                    },
+                  ]}
+                >
+                  {env.label}
+                </Text>
+                <Text
+                  style={[
+                    styles.environmentUrl,
+                    { color: theme.textMuted },
+                  ]}
+                >
+                  {env.apiUrl}
+                </Text>
+                {env.buildTag ? (
+                  <View
+                    style={[
+                      styles.tag,
+                      { backgroundColor: theme.chipBg },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.tagText,
+                        { color: theme.textMuted },
+                      ]}
+                    >
+                      {env.buildTag}
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+              {isActive ? (
+                <View
+                  style={[
+                    styles.activeDot,
+                    { backgroundColor: theme.status.success },
+                  ]}
+                />
+              ) : null}
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {currentId !== 'production' ? (
+        <View
+          style={[
+            styles.metadataCard,
+            {
+              backgroundColor: theme.surfaceElevated,
+              borderColor: theme.borderLight,
+            },
+          ]}
+        >
+          {isFetchingMetadata ? (
+            <View style={styles.loadingRow}>
+              <ActivityIndicator size="small" color={theme.textMuted} />
+              <Text style={[styles.metadataText, { color: theme.textMuted }]}>
+                Fetching backend metadata...
+              </Text>
+            </View>
+          ) : null}
+
+          {metadata ? (
+            <View style={styles.metadataRow}>
+              <Text style={[styles.metadataLabel, { color: theme.textSecondary }]}>
+                Backend version:
+              </Text>
+              <Text style={[styles.metadataValue, { color: theme.textPrimary }]}>
+                {metadata.appVersion}
+              </Text>
+            </View>
+          ) : null}
+
+          {compatibility ? (
+            <View
+              style={[
+                styles.compatibilityBadge,
+                {
+                  backgroundColor: compatibility.compatible
+                    ? theme.status.successBg
+                    : theme.status.errorBg,
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.compatibilityText,
+                  {
+                    color: compatibility.compatible
+                      ? theme.status.success
+                      : theme.status.error,
+                  },
+                ]}
+              >
+                {compatibility.compatible
+                  ? 'Compatible'
+                  : `Warning: ${compatibility.reason}`}
+              </Text>
+            </View>
+          ) : null}
+
+          <Pressable
+            style={[
+              styles.fetchButton,
+              { borderColor: theme.buttonSecondaryBorder },
+            ]}
+            onPress={fetchMetadata}
+          >
+            <Text
+              style={[
+                styles.fetchButtonText,
+                { color: theme.textPrimary },
+              ]}
+            >
+              Check Compatibility
+            </Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      <Pressable
+        testID="reset-environment"
+        style={[
+          styles.resetButton,
+          { borderColor: theme.status.error },
+        ]}
+        onPress={resetToDefault}
+      >
+        <Text
+          style={[styles.resetButtonText, { color: theme.status.error }]}
+        >
+          Reset to Default ({ENVIRONMENT_LABELS['production']})
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const ENVIRONMENT_LABELS: Record<string, string> = {
+  production: 'Production',
+  staging: 'Staging',
+  testnet: 'Shared Testnet',
+  'branch-preview': 'Branch Preview',
+};
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 18,
+    padding: 18,
+    borderWidth: 1,
+    gap: 14,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  helper: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  environmentList: {
+    gap: 8,
+  },
+  environmentItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 14,
+  },
+  environmentInfo: {
+    flex: 1,
+    gap: 4,
+  },
+  environmentLabel: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  environmentUrl: {
+    fontSize: 12,
+  },
+  tag: {
+    alignSelf: 'flex-start',
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  tagText: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+  activeDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    marginLeft: 8,
+  },
+  metadataCard: {
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 14,
+    gap: 8,
+  },
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  metadataRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  metadataLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  metadataValue: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  compatibilityBadge: {
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  compatibilityText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  fetchButton: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    alignItems: 'center',
+  },
+  fetchButtonText: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  resetButton: {
+    borderWidth: 1,
+    borderRadius: 14,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+  },
+  resetButtonText: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+});

--- a/app/mobile/contexts/EnvironmentContext.tsx
+++ b/app/mobile/contexts/EnvironmentContext.tsx
@@ -1,0 +1,183 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import {
+  type EnvironmentId,
+  type EnvironmentConfig,
+  type BackendMetadata,
+  type CompatibilityResult,
+  ENVIRONMENTS,
+  DEFAULT_ENVIRONMENT,
+} from '../src/config/environment';
+import {
+  loadEnvironment,
+  saveEnvironment,
+  resetEnvironment,
+} from '../services/environment-storage';
+
+export interface EnvironmentContextValue {
+  currentId: EnvironmentId;
+  current: EnvironmentConfig;
+  available: EnvironmentConfig[];
+  isReady: boolean;
+  switchEnvironment: (id: EnvironmentId) => Promise<void>;
+  resetToDefault: () => Promise<void>;
+  metadata: BackendMetadata | null;
+  compatibility: CompatibilityResult | null;
+  isFetchingMetadata: boolean;
+  fetchMetadata: () => Promise<void>;
+}
+
+const EnvironmentContext = createContext<EnvironmentContextValue | undefined>(
+  undefined,
+);
+
+export function EnvironmentProvider({ children }: { children: React.ReactNode }) {
+  const [currentId, setCurrentId] = useState<EnvironmentId>(DEFAULT_ENVIRONMENT);
+  const [isReady, setIsReady] = useState(false);
+  const [metadata, setMetadata] = useState<BackendMetadata | null>(null);
+  const [compatibility, setCompatibility] = useState<CompatibilityResult | null>(null);
+  const [isFetchingMetadata, setIsFetchingMetadata] = useState(false);
+
+  const current = ENVIRONMENTS[currentId];
+
+  const available = useMemo(
+    () => Object.values(ENVIRONMENTS),
+    [],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const id = await loadEnvironment();
+      if (cancelled) return;
+      setCurrentId(id);
+      setIsReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const fetchMetadata = useCallback(async () => {
+    setIsFetchingMetadata(true);
+    setCompatibility(null);
+    try {
+      const response = await fetch(`${current.apiUrl}/health`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!response.ok) {
+        setCompatibility({
+          compatible: false,
+          reason: `Backend returned status ${response.status}`,
+        });
+        return;
+      }
+      const data = (await response.json()) as BackendMetadata;
+      setMetadata(data);
+
+      const minVersion = data.minAppVersion ?? '0.0.0';
+      const appVersion = '1.0.0'; // In production, read from build config
+
+      if (compareVersions(appVersion, minVersion) < 0) {
+        setCompatibility({
+          compatible: false,
+          reason: `App version ${appVersion} is below minimum required ${minVersion}. Please update the app.`,
+        });
+      } else if (data.stellarNetwork && data.stellarNetwork !== current.stellarNetwork) {
+        setCompatibility({
+          compatible: false,
+          reason: `Stellar network mismatch: backend runs on ${data.stellarNetwork} but environment expects ${current.stellarNetwork}.`,
+        });
+      } else {
+        setCompatibility({ compatible: true });
+      }
+    } catch (error) {
+      setCompatibility({
+        compatible: false,
+        reason: error instanceof Error ? error.message : 'Failed to reach backend',
+      });
+    } finally {
+      setIsFetchingMetadata(false);
+    }
+  }, [current.apiUrl, current.stellarNetwork]);
+
+  const switchEnvironment = useCallback(
+    async (id: EnvironmentId) => {
+      setCurrentId(id);
+      setMetadata(null);
+      setCompatibility(null);
+      await saveEnvironment(id);
+    },
+    [],
+  );
+
+  const resetToDefault = useCallback(async () => {
+    setCurrentId(DEFAULT_ENVIRONMENT);
+    setMetadata(null);
+    setCompatibility(null);
+    await resetEnvironment();
+  }, []);
+
+  const value: EnvironmentContextValue = useMemo(
+    () => ({
+      currentId,
+      current,
+      available,
+      isReady,
+      switchEnvironment,
+      resetToDefault,
+      metadata,
+      compatibility,
+      isFetchingMetadata,
+      fetchMetadata,
+    }),
+    [
+      currentId,
+      current,
+      available,
+      isReady,
+      switchEnvironment,
+      resetToDefault,
+      metadata,
+      compatibility,
+      isFetchingMetadata,
+      fetchMetadata,
+    ],
+  );
+
+  return (
+    <EnvironmentContext.Provider value={value}>
+      {children}
+    </EnvironmentContext.Provider>
+  );
+}
+
+export function useEnvironment(): EnvironmentContextValue {
+  const ctx = useContext(EnvironmentContext);
+  if (!ctx) {
+    throw new Error(
+      'useEnvironment must be used within an <EnvironmentProvider>',
+    );
+  }
+  return ctx;
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na > nb) return 1;
+    if (na < nb) return -1;
+  }
+  return 0;
+}

--- a/app/mobile/services/environment-storage.ts
+++ b/app/mobile/services/environment-storage.ts
@@ -1,0 +1,43 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { EnvironmentId } from '../src/config/environment';
+import { DEFAULT_ENVIRONMENT } from '../src/config/environment';
+
+const STORAGE_KEY = '@quickex/environment';
+
+export async function loadEnvironment(): Promise<EnvironmentId> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_ENVIRONMENT;
+    const parsed = JSON.parse(raw) as { environmentId: EnvironmentId };
+    if (isValidEnvironmentId(parsed.environmentId)) {
+      return parsed.environmentId;
+    }
+    return DEFAULT_ENVIRONMENT;
+  } catch {
+    return DEFAULT_ENVIRONMENT;
+  }
+}
+
+export async function saveEnvironment(environmentId: EnvironmentId): Promise<void> {
+  try {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ environmentId }),
+    );
+  } catch {
+    // Swallow — preference will be re-read on next launch.
+  }
+}
+
+export async function resetEnvironment(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Swallow
+  }
+}
+
+function isValidEnvironmentId(id: string): id is EnvironmentId {
+  return ['production', 'staging', 'testnet', 'branch-preview'].includes(id);
+}

--- a/app/mobile/services/local-data.ts
+++ b/app/mobile/services/local-data.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import { clearSecurityData } from "./security";
+import { resetEnvironment } from "./environment-storage";
 import { clearWalletSession } from "./wallet-session";
 
 export async function clearLocalData(): Promise<void> {
@@ -22,5 +23,11 @@ export async function clearLocalData(): Promise<void> {
     await clearWalletSession();
   } catch (error) {
     console.error("Failed to clear wallet session during local data wipe", error);
+  }
+
+  try {
+    await resetEnvironment();
+  } catch (error) {
+    console.error("Failed to reset environment during local data wipe", error);
   }
 }

--- a/app/mobile/src/config/environment.ts
+++ b/app/mobile/src/config/environment.ts
@@ -1,0 +1,53 @@
+export type EnvironmentId = 'production' | 'staging' | 'testnet' | 'branch-preview';
+
+export interface EnvironmentConfig {
+  id: EnvironmentId;
+  label: string;
+  apiUrl: string;
+  stellarNetwork: 'mainnet' | 'testnet';
+  buildTag?: string;
+}
+
+export const ENVIRONMENTS: Record<EnvironmentId, EnvironmentConfig> = {
+  production: {
+    id: 'production',
+    label: 'Production',
+    apiUrl: 'https://api.quickex.to',
+    stellarNetwork: 'mainnet',
+  },
+  staging: {
+    id: 'staging',
+    label: 'Staging',
+    apiUrl: 'https://staging-api.quickex.to',
+    stellarNetwork: 'testnet',
+    buildTag: 'staging',
+  },
+  testnet: {
+    id: 'testnet',
+    label: 'Shared Testnet',
+    apiUrl: 'https://testnet-api.quickex.to',
+    stellarNetwork: 'testnet',
+    buildTag: 'testnet',
+  },
+  'branch-preview': {
+    id: 'branch-preview',
+    label: 'Branch Preview',
+    apiUrl: 'https://preview-api.quickex.to',
+    stellarNetwork: 'testnet',
+    buildTag: 'preview',
+  },
+};
+
+export const DEFAULT_ENVIRONMENT: EnvironmentId = 'production';
+
+export interface BackendMetadata {
+  appVersion: string;
+  minAppVersion: string;
+  environment: string;
+  stellarNetwork: string;
+}
+
+export interface CompatibilityResult {
+  compatible: boolean;
+  reason?: string;
+}


### PR DESCRIPTION
## summary

- Add environment configuration types for production, staging, testnet, and branch-preview
- Persist selected environment via AsyncStorage (@quickex/environment)
- Add EnvironmentContext provider with switch/reset/fetchMetadata
- Add EnvironmentSwitcher UI component in debug section of settings
- Auto-fetch /health metadata after switching, validate app version and network
- Show compatibility warning for incompatible backends
- Wire environment reset into clearLocalData
- Add 16 tests covering storage, context switching, persistence, reset, and component rendering

Closes #584