### PR TITLE
feat(backend): add release candidate validation report API

### DIFF
--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -51,6 +51,7 @@ import { EnvironmentParityModule } from "./environment-parity/environment-parity
 import { IndexerLagModule } from "./indexer-lag";
 import { SupportBundleModule } from "./support-bundle/support-bundle.module";
 import { OperationsModule } from "./operations/operations.module";
+import { RcValidationModule } from "./rc-validation/rc-validation.module";
 
 type AppImport =
 | Type<unknown>
@@ -96,6 +97,7 @@ EnvironmentParityModule,
 IndexerLagModule,
 SupportBundleModule,
 OperationsModule,
+RcValidationModule,
 ];
 
 try {

--- a/app/backend/src/health/health.module.ts
+++ b/app/backend/src/health/health.module.ts
@@ -11,5 +11,6 @@ import { HealthService } from "./health.service";
   imports: [SupabaseModule, StellarModule, JobQueueModule, IngestionModule, TransactionsModule],
   controllers: [HealthController],
   providers: [HealthService],
+  exports: [HealthService],
 })
 export class HealthModule {}

--- a/app/backend/src/rc-validation/dto/rc-report.dto.ts
+++ b/app/backend/src/rc-validation/dto/rc-report.dto.ts
@@ -1,0 +1,263 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * Severity classification for a release-candidate blocker.
+ *
+ * - `critical`: must be resolved before the RC can ship. Maps to a failed
+ *   smoke check, a missing/incorrect contract registry, or a blocking indexer lag.
+ * - `warning`: should be reviewed but does not strictly block the release.
+ * - `info`: advisory signal an operator may want to be aware of.
+ */
+export type RcBlockerSeverity = "critical" | "warning" | "info";
+
+/**
+ * Which aggregated section a blocker originated from.
+ */
+export type RcBlockerCategory =
+  | "smoke"
+  | "registry"
+  | "lag"
+  | "environment";
+
+/**
+ * Section-level health status. `unknown` is used when a source could not be
+ * evaluated (e.g. it threw), which keeps partial reports renderable.
+ */
+export type RcSectionStatus = "pass" | "warning" | "fail" | "unknown";
+
+/**
+ * Overall release-candidate readiness.
+ *
+ * - `ready`: no critical blockers.
+ * - `degraded`: only warning/info blockers present.
+ * - `blocked`: at least one critical blocker present.
+ */
+export type RcOverallStatus = "ready" | "degraded" | "blocked";
+
+export class RcBlockerDto {
+  @ApiProperty({
+    description: "Stable identifier for the blocker within a report",
+    example: "smoke.horizon.down",
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: "Severity classification",
+    enum: ["critical", "warning", "info"],
+    example: "critical",
+  })
+  severity!: RcBlockerSeverity;
+
+  @ApiProperty({
+    description: "Aggregated section the blocker came from",
+    enum: ["smoke", "registry", "lag", "environment"],
+    example: "smoke",
+  })
+  category!: RcBlockerCategory;
+
+  @ApiProperty({
+    description: "Operator-friendly description of the blocker",
+    example: "Critical dependency 'horizon' is down",
+  })
+  message!: string;
+
+  @ApiProperty({
+    description: "Suggested remediation for the operator",
+    example: "Verify Horizon connectivity and restart ingestion if needed",
+    required: false,
+  })
+  remediation?: string;
+
+  @ApiProperty({
+    description: "ISO-8601 timestamp the blocker was detected",
+    example: "2026-06-27T12:00:00.000Z",
+  })
+  detectedAt!: string;
+}
+
+export class RcSmokeCheckDto {
+  @ApiProperty({ example: "horizon" })
+  name!: string;
+
+  @ApiProperty({ enum: ["up", "down"], example: "up" })
+  status!: "up" | "down";
+
+  @ApiProperty({ required: false, example: "Horizon returned 503" })
+  error?: string;
+}
+
+export class RcSmokeSectionDto {
+  @ApiProperty({ enum: ["pass", "warning", "fail", "unknown"] })
+  status!: RcSectionStatus;
+
+  @ApiProperty({
+    description: "Whether all critical readiness probes passed",
+    example: true,
+  })
+  ready!: boolean;
+
+  @ApiProperty({ type: [RcSmokeCheckDto] })
+  checks!: RcSmokeCheckDto[];
+
+  @ApiProperty({ example: 6 })
+  passed!: number;
+
+  @ApiProperty({ example: 0 })
+  failed!: number;
+}
+
+export class RcRegistrySectionDto {
+  @ApiProperty({ enum: ["pass", "warning", "fail", "unknown"] })
+  status!: RcSectionStatus;
+
+  @ApiProperty({ example: "testnet" })
+  network!: string;
+
+  @ApiProperty({
+    description: "Whether the registry is the authoritative source",
+    example: true,
+  })
+  authoritative!: boolean;
+
+  @ApiProperty({ example: 3 })
+  version!: number;
+
+  @ApiProperty({
+    description: "Number of active (deployed) contract entries",
+    example: 1,
+  })
+  activeContracts!: number;
+
+  @ApiProperty({
+    description: "Contracts expected to be present for this release",
+    example: ["quickex"],
+  })
+  expectedContracts!: string[];
+
+  @ApiProperty({
+    description: "Expected contracts that are missing from the registry",
+    example: [],
+  })
+  missingContracts!: string[];
+}
+
+export class RcLagSectionDto {
+  @ApiProperty({ enum: ["pass", "warning", "fail", "unknown"] })
+  status!: RcSectionStatus;
+
+  @ApiProperty({ nullable: true, example: 123456 })
+  currentNetworkLedger!: number | null;
+
+  @ApiProperty({ nullable: true, example: 123450 })
+  lastIndexedLedger!: number | null;
+
+  @ApiProperty({ nullable: true, example: 6 })
+  lagLedgers!: number | null;
+
+  @ApiProperty({ example: false })
+  isLagging!: boolean;
+
+  @ApiProperty({
+    description: "Whether the indexer-lag guard would block traffic",
+    example: false,
+  })
+  isBlocking!: boolean;
+
+  @ApiProperty({ example: 100 })
+  thresholdLedgers!: number;
+}
+
+export class RcEnvironmentCheckDto {
+  @ApiProperty({ example: "network_configuration" })
+  check!: string;
+
+  @ApiProperty({ enum: ["pass", "fail", "warning"], example: "pass" })
+  status!: "pass" | "fail" | "warning";
+
+  @ApiProperty({ required: false, example: "Network: testnet" })
+  details?: string;
+}
+
+export class RcEnvironmentSectionDto {
+  @ApiProperty({ enum: ["pass", "warning", "fail", "unknown"] })
+  status!: RcSectionStatus;
+
+  @ApiProperty({ type: [RcEnvironmentCheckDto] })
+  checks!: RcEnvironmentCheckDto[];
+
+  @ApiProperty({ example: 7 })
+  passed!: number;
+
+  @ApiProperty({ example: 0 })
+  failed!: number;
+
+  @ApiProperty({ example: 0 })
+  warnings!: number;
+}
+
+export class RcSectionsDto {
+  @ApiProperty({ type: RcSmokeSectionDto })
+  smoke!: RcSmokeSectionDto;
+
+  @ApiProperty({ type: RcRegistrySectionDto })
+  registry!: RcRegistrySectionDto;
+
+  @ApiProperty({ type: RcLagSectionDto })
+  lag!: RcLagSectionDto;
+
+  @ApiProperty({ type: RcEnvironmentSectionDto })
+  environment!: RcEnvironmentSectionDto;
+}
+
+export class RcBlockerSummaryDto {
+  @ApiProperty({ example: 0 })
+  critical!: number;
+
+  @ApiProperty({ example: 1 })
+  warning!: number;
+
+  @ApiProperty({ example: 2 })
+  info!: number;
+}
+
+export class RcValidationReportDto {
+  @ApiProperty({
+    description: "Unique identifier for this report instance",
+    example: "5f0c2c2e-2a3b-4d8e-9c1a-1f2e3d4c5b6a",
+  })
+  reportId!: string;
+
+  @ApiProperty({
+    description: "ISO-8601 timestamp the report was generated",
+    example: "2026-06-27T12:00:00.000Z",
+  })
+  generatedAt!: string;
+
+  @ApiProperty({ example: "testnet" })
+  network!: string;
+
+  @ApiProperty({ example: "staging" })
+  environment!: string;
+
+  @ApiProperty({
+    description: "True when there are no critical blockers",
+    example: true,
+  })
+  releaseReady!: boolean;
+
+  @ApiProperty({
+    description: "Overall readiness derived from blocker severities",
+    enum: ["ready", "degraded", "blocked"],
+    example: "degraded",
+  })
+  overallStatus!: RcOverallStatus;
+
+  @ApiProperty({ type: RcSectionsDto })
+  sections!: RcSectionsDto;
+
+  @ApiProperty({ type: [RcBlockerDto] })
+  blockers!: RcBlockerDto[];
+
+  @ApiProperty({ type: RcBlockerSummaryDto })
+  summary!: RcBlockerSummaryDto;
+}

--- a/app/backend/src/rc-validation/rc-validation.controller.ts
+++ b/app/backend/src/rc-validation/rc-validation.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+
+import { ApiKeyGuard } from "../auth/guards/api-key.guard";
+import { RequireScopes } from "../auth/decorators/require-scopes.decorator";
+import { RcValidationService } from "./rc-validation.service";
+import { RcValidationReportDto } from "./dto/rc-report.dto";
+
+@ApiTags("Release Candidate Validation")
+@Controller("admin/rc-validation")
+@UseGuards(ApiKeyGuard)
+export class RcValidationController {
+  constructor(private readonly rcValidationService: RcValidationService) {}
+
+  @Get("report")
+  @RequireScopes("admin")
+  @ApiOperation({
+    summary: "Generate a release-candidate validation report",
+    description:
+      "Aggregates smoke results, contract registry status, indexer lag metrics, " +
+      "and environment parity into a single operator-friendly report with " +
+      "classified, timestamped blockers so testnet release readiness can be " +
+      "assessed from one endpoint.",
+  })
+  @ApiResponse({ status: 200, type: RcValidationReportDto })
+  async getReport(): Promise<RcValidationReportDto> {
+    return this.rcValidationService.generateReport();
+  }
+}

--- a/app/backend/src/rc-validation/rc-validation.module.ts
+++ b/app/backend/src/rc-validation/rc-validation.module.ts
@@ -1,0 +1,23 @@
+import { Module } from "@nestjs/common";
+
+import { ApiKeysModule } from "../api-keys/api-keys.module";
+import { ApiKeyGuard } from "../auth/guards/api-key.guard";
+import { HealthModule } from "../health/health.module";
+import { ContractsModule } from "../contracts/contracts.module";
+import { IndexerLagModule } from "../indexer-lag";
+import { EnvironmentParityModule } from "../environment-parity/environment-parity.module";
+import { RcValidationController } from "./rc-validation.controller";
+import { RcValidationService } from "./rc-validation.service";
+
+@Module({
+  imports: [
+    ApiKeysModule,
+    HealthModule,
+    ContractsModule,
+    IndexerLagModule,
+    EnvironmentParityModule,
+  ],
+  controllers: [RcValidationController],
+  providers: [RcValidationService, ApiKeyGuard],
+})
+export class RcValidationModule {}

--- a/app/backend/src/rc-validation/rc-validation.service.ts
+++ b/app/backend/src/rc-validation/rc-validation.service.ts
@@ -1,0 +1,373 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { randomUUID } from "crypto";
+
+import { AppConfigService } from "../config";
+import { HealthService } from "../health/health.service";
+import { ContractRegistryService } from "../contracts/contract-registry.service";
+import { IndexerLagService } from "../indexer-lag/indexer-lag.service";
+import { EnvironmentParityService } from "../environment-parity/environment-parity.service";
+import {
+  RcBlockerDto,
+  RcEnvironmentSectionDto,
+  RcLagSectionDto,
+  RcOverallStatus,
+  RcRegistrySectionDto,
+  RcSmokeSectionDto,
+  RcValidationReportDto,
+} from "./dto/rc-report.dto";
+
+/**
+ * Aggregates the signals an operator needs to decide whether a testnet
+ * release candidate is safe to ship, into a single reproducible report:
+ *
+ *  - smoke results      -> deep readiness probes (HealthService)
+ *  - registry status    -> active contract deployments (ContractRegistryService)
+ *  - lag metrics        -> indexer lag vs. network head (IndexerLagService)
+ *  - environment health -> staging/prod parity checks (EnvironmentParityService)
+ *
+ * Each source is evaluated defensively so that a failure in one section still
+ * yields a usable (partial) report instead of failing the whole endpoint.
+ */
+@Injectable()
+export class RcValidationService {
+  private readonly logger = new Logger(RcValidationService.name);
+  private readonly expectedContracts: string[];
+
+  constructor(
+    private readonly config: AppConfigService,
+    private readonly health: HealthService,
+    private readonly registry: ContractRegistryService,
+    private readonly indexerLag: IndexerLagService,
+    private readonly environmentParity: EnvironmentParityService,
+  ) {
+    // Mirror ContractRegistryService's expected-set source so the report
+    // agrees with the registry's own notion of a complete deployment.
+    this.expectedContracts = (
+      process.env.CONTRACT_REGISTRY_EXPECTED_SET ?? "quickex"
+    )
+      .split(",")
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+  }
+
+  /**
+   * Generate an on-demand release-candidate validation report. The report is
+   * stamped with a unique id and a single generation timestamp so it is
+   * reproducible and auditable.
+   */
+  async generateReport(): Promise<RcValidationReportDto> {
+    const generatedAt = new Date().toISOString();
+    const blockers: RcBlockerDto[] = [];
+
+    const [smoke, registry, lag, environment] = await Promise.all([
+      this.buildSmokeSection(generatedAt, blockers),
+      this.buildRegistrySection(generatedAt, blockers),
+      this.buildLagSection(generatedAt, blockers),
+      this.buildEnvironmentSection(generatedAt, blockers),
+    ]);
+
+    const summary = {
+      critical: blockers.filter((b) => b.severity === "critical").length,
+      warning: blockers.filter((b) => b.severity === "warning").length,
+      info: blockers.filter((b) => b.severity === "info").length,
+    };
+
+    const overallStatus: RcOverallStatus =
+      summary.critical > 0
+        ? "blocked"
+        : summary.warning > 0 || summary.info > 0
+          ? "degraded"
+          : "ready";
+
+    return {
+      reportId: randomUUID(),
+      generatedAt,
+      network: this.config.network,
+      environment: this.config.environmentName ?? this.config.nodeEnv,
+      releaseReady: summary.critical === 0,
+      overallStatus,
+      sections: { smoke, registry, lag, environment },
+      blockers,
+      summary,
+    };
+  }
+
+  // ── Smoke (deep readiness probes) ──────────────────────────────────────────
+
+  private async buildSmokeSection(
+    detectedAt: string,
+    blockers: RcBlockerDto[],
+  ): Promise<RcSmokeSectionDto> {
+    try {
+      const readiness = await this.health.getReadinessStatus();
+      const checks = readiness.checks.map((check) => ({
+        name: check.name,
+        status: check.status,
+        error: check.error,
+      }));
+      const failed = checks.filter((c) => c.status === "down");
+      const passed = checks.length - failed.length;
+
+      for (const check of failed) {
+        blockers.push({
+          id: `smoke.${check.name}.down`,
+          severity: "critical",
+          category: "smoke",
+          message: `Smoke check '${check.name}' failed${
+            check.error ? `: ${check.error}` : ""
+          }`,
+          remediation: `Restore the '${check.name}' dependency before releasing`,
+          detectedAt,
+        });
+      }
+
+      return {
+        status: readiness.ready ? "pass" : "fail",
+        ready: readiness.ready,
+        checks,
+        passed,
+        failed: failed.length,
+      };
+    } catch (error) {
+      this.logger.error("Smoke section evaluation failed", error as Error);
+      blockers.push({
+        id: "smoke.unavailable",
+        severity: "critical",
+        category: "smoke",
+        message: "Unable to evaluate smoke/readiness checks",
+        remediation: "Investigate the health subsystem",
+        detectedAt,
+      });
+      return {
+        status: "unknown",
+        ready: false,
+        checks: [],
+        passed: 0,
+        failed: 0,
+      };
+    }
+  }
+
+  // ── Registry (active contract deployments) ─────────────────────────────────
+
+  private async buildRegistrySection(
+    detectedAt: string,
+    blockers: RcBlockerDto[],
+  ): Promise<RcRegistrySectionDto> {
+    try {
+      const registry = await this.registry.getRegistry();
+      const activeNames = Object.keys(registry.data).map((name) =>
+        name.toLowerCase(),
+      );
+      const missing = this.expectedContracts.filter(
+        (name) => !activeNames.includes(name),
+      );
+
+      let status: RcRegistrySectionDto["status"] = "pass";
+      if (missing.length > 0) {
+        status = "fail";
+        blockers.push({
+          id: "registry.missing-contracts",
+          severity: "critical",
+          category: "registry",
+          message: `Registry is missing expected contract(s): ${missing.join(
+            ", ",
+          )}`,
+          remediation:
+            "Publish the missing contract deployment(s) to the registry",
+          detectedAt,
+        });
+      }
+
+      if (!registry.authoritative) {
+        status = status === "fail" ? "fail" : "warning";
+        blockers.push({
+          id: "registry.not-authoritative",
+          severity: "warning",
+          category: "registry",
+          message: "Contract registry is not marked authoritative",
+          remediation: "Finalize registry dual-read before release",
+          detectedAt,
+        });
+      }
+
+      return {
+        status,
+        network: registry.network,
+        authoritative: registry.authoritative,
+        version: registry.version,
+        activeContracts: activeNames.length,
+        expectedContracts: this.expectedContracts,
+        missingContracts: missing,
+      };
+    } catch (error) {
+      this.logger.error("Registry section evaluation failed", error as Error);
+      blockers.push({
+        id: "registry.unavailable",
+        severity: "critical",
+        category: "registry",
+        message: "Unable to read contract registry status",
+        remediation: "Investigate the contract registry subsystem",
+        detectedAt,
+      });
+      return {
+        status: "unknown",
+        network: this.config.network,
+        authoritative: false,
+        version: 0,
+        activeContracts: 0,
+        expectedContracts: this.expectedContracts,
+        missingContracts: this.expectedContracts,
+      };
+    }
+  }
+
+  // ── Lag metrics (indexer vs. network head) ─────────────────────────────────
+
+  private buildLagSection(
+    detectedAt: string,
+    blockers: RcBlockerDto[],
+  ): RcLagSectionDto {
+    try {
+      const status = this.indexerLag.getStatus();
+      const isBlocking = this.indexerLag.isBlocked();
+
+      let sectionStatus: RcLagSectionDto["status"] = "pass";
+      if (isBlocking) {
+        sectionStatus = "fail";
+        blockers.push({
+          id: "lag.blocking",
+          severity: "critical",
+          category: "lag",
+          message: `Indexer lag (${status.lagLedgers} ledgers) exceeds threshold (${status.thresholdLedgers}) and is blocking traffic`,
+          remediation: "Allow the indexer to catch up before releasing",
+          detectedAt,
+        });
+      } else if (status.isLagging) {
+        // Lagging but not blocking (guard disabled or overridden).
+        sectionStatus = "warning";
+        blockers.push({
+          id: "lag.lagging",
+          severity: "warning",
+          category: "lag",
+          message: `Indexer is lagging by ${status.lagLedgers} ledgers (threshold ${status.thresholdLedgers}) but the guard is not enforcing`,
+          remediation: "Verify the indexer-lag guard configuration",
+          detectedAt,
+        });
+      } else if (
+        status.currentNetworkLedger === null ||
+        status.lastIndexedLedger === null
+      ) {
+        // Lag cannot be computed yet — surface as advisory, not a hard block.
+        sectionStatus = "warning";
+        blockers.push({
+          id: "lag.unknown",
+          severity: "info",
+          category: "lag",
+          message: "Indexer lag could not be computed (no ledger data yet)",
+          remediation: "Confirm ingestion is running and reporting checkpoints",
+          detectedAt,
+        });
+      }
+
+      return {
+        status: sectionStatus,
+        currentNetworkLedger: status.currentNetworkLedger,
+        lastIndexedLedger: status.lastIndexedLedger,
+        lagLedgers: status.lagLedgers,
+        isLagging: status.isLagging,
+        isBlocking,
+        thresholdLedgers: status.thresholdLedgers,
+      };
+    } catch (error) {
+      this.logger.error("Lag section evaluation failed", error as Error);
+      blockers.push({
+        id: "lag.unavailable",
+        severity: "warning",
+        category: "lag",
+        message: "Unable to read indexer lag metrics",
+        remediation: "Investigate the indexer-lag subsystem",
+        detectedAt,
+      });
+      return {
+        status: "unknown",
+        currentNetworkLedger: null,
+        lastIndexedLedger: null,
+        lagLedgers: null,
+        isLagging: false,
+        isBlocking: false,
+        thresholdLedgers: 0,
+      };
+    }
+  }
+
+  // ── Environment health (staging/prod parity) ───────────────────────────────
+
+  private buildEnvironmentSection(
+    detectedAt: string,
+    blockers: RcBlockerDto[],
+  ): RcEnvironmentSectionDto {
+    try {
+      const results = this.environmentParity.getResults();
+      const failed = results.filter((r) => r.status === "fail");
+      const warnings = results.filter((r) => r.status === "warning");
+      const passed = results.filter((r) => r.status === "pass");
+
+      for (const result of failed) {
+        blockers.push({
+          id: `environment.${result.check}.fail`,
+          severity: "warning",
+          category: "environment",
+          message: `Environment parity check '${result.check}' failed${
+            result.details ? `: ${result.details}` : ""
+          }`,
+          remediation: "Reconcile staging configuration with production",
+          detectedAt,
+        });
+      }
+
+      for (const result of warnings) {
+        blockers.push({
+          id: `environment.${result.check}.warning`,
+          severity: "info",
+          category: "environment",
+          message: `Environment parity check '${result.check}' raised a warning${
+            result.details ? `: ${result.details}` : ""
+          }`,
+          detectedAt,
+        });
+      }
+
+      const status: RcEnvironmentSectionDto["status"] =
+        failed.length > 0 ? "fail" : warnings.length > 0 ? "warning" : "pass";
+
+      return {
+        status,
+        checks: results,
+        passed: passed.length,
+        failed: failed.length,
+        warnings: warnings.length,
+      };
+    } catch (error) {
+      this.logger.error(
+        "Environment section evaluation failed",
+        error as Error,
+      );
+      blockers.push({
+        id: "environment.unavailable",
+        severity: "warning",
+        category: "environment",
+        message: "Unable to read environment parity results",
+        remediation: "Investigate the environment-parity subsystem",
+        detectedAt,
+      });
+      return {
+        status: "unknown",
+        checks: [],
+        passed: 0,
+        failed: 0,
+        warnings: 0,
+      };
+    }
+  }
+}

--- a/app/backend/src/rc-validation/rc-validation.service.unit.spec.ts
+++ b/app/backend/src/rc-validation/rc-validation.service.unit.spec.ts
@@ -1,0 +1,267 @@
+import { Test, TestingModule } from "@nestjs/testing";
+
+import { RcValidationService } from "./rc-validation.service";
+import { AppConfigService } from "../config";
+import { HealthService } from "../health/health.service";
+import { ContractRegistryService } from "../contracts/contract-registry.service";
+import { IndexerLagService } from "../indexer-lag/indexer-lag.service";
+import { EnvironmentParityService } from "../environment-parity/environment-parity.service";
+
+describe("RcValidationService", () => {
+  let service: RcValidationService;
+  let mockConfig: Partial<AppConfigService>;
+  let mockHealth: { getReadinessStatus: jest.Mock };
+  let mockRegistry: { getRegistry: jest.Mock };
+  let mockIndexerLag: { getStatus: jest.Mock; isBlocked: jest.Mock };
+  let mockParity: { getResults: jest.Mock };
+
+  // Healthy defaults — each test overrides only what it needs.
+  const healthyReadiness = () => ({
+    ready: true,
+    timestamp: new Date().toISOString(),
+    checks: [
+      { name: "supabase", status: "up" as const },
+      { name: "migrations", status: "up" as const },
+      { name: "queue", status: "up" as const },
+      { name: "horizon", status: "up" as const },
+    ],
+  });
+
+  const healthyRegistry = () => ({
+    network: "testnet",
+    authoritative: true,
+    version: 3,
+    etag: 'W/"contract-registry-testnet-3"',
+    data: { quickex: { id: "C123", wasmHash: "abc", version: 1 } },
+  });
+
+  const healthyLag = () => ({
+    currentNetworkLedger: 1000,
+    lastIndexedLedger: 998,
+    lagLedgers: 2,
+    isLagging: false,
+    isEnabled: true,
+    isOverridden: false,
+    thresholdLedgers: 100,
+  });
+
+  const healthyParity = () => [
+    { check: "network_configuration", status: "pass" as const, details: "ok" },
+    { check: "supabase_configuration", status: "pass" as const },
+  ];
+
+  beforeEach(async () => {
+    mockConfig = {
+      network: "testnet",
+      environmentName: "staging",
+      nodeEnv: "test",
+    };
+    mockHealth = { getReadinessStatus: jest.fn().mockResolvedValue(healthyReadiness()) };
+    mockRegistry = { getRegistry: jest.fn().mockResolvedValue(healthyRegistry()) };
+    mockIndexerLag = {
+      getStatus: jest.fn().mockReturnValue(healthyLag()),
+      isBlocked: jest.fn().mockReturnValue(false),
+    };
+    mockParity = { getResults: jest.fn().mockReturnValue(healthyParity()) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RcValidationService,
+        { provide: AppConfigService, useValue: mockConfig },
+        { provide: HealthService, useValue: mockHealth },
+        { provide: ContractRegistryService, useValue: mockRegistry },
+        { provide: IndexerLagService, useValue: mockIndexerLag },
+        { provide: EnvironmentParityService, useValue: mockParity },
+      ],
+    }).compile();
+
+    service = module.get<RcValidationService>(RcValidationService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("complete (healthy) report", () => {
+    it("returns a ready report with no blockers", async () => {
+      const report = await service.generateReport();
+
+      expect(report.releaseReady).toBe(true);
+      expect(report.overallStatus).toBe("ready");
+      expect(report.blockers).toHaveLength(0);
+      expect(report.summary).toEqual({ critical: 0, warning: 0, info: 0 });
+
+      expect(report.sections.smoke.status).toBe("pass");
+      expect(report.sections.registry.status).toBe("pass");
+      expect(report.sections.lag.status).toBe("pass");
+      expect(report.sections.environment.status).toBe("pass");
+    });
+
+    it("is timestamped and uniquely identified (reproducible/auditable)", async () => {
+      const first = await service.generateReport();
+      const second = await service.generateReport();
+
+      expect(first.reportId).not.toEqual(second.reportId);
+      expect(new Date(first.generatedAt).toString()).not.toBe("Invalid Date");
+      expect(first.network).toBe("testnet");
+      expect(first.environment).toBe("staging");
+      // All blockers share the report's generation timestamp.
+      const blocky = await (async () => {
+        mockIndexerLag.isBlocked.mockReturnValue(true);
+        return service.generateReport();
+      })();
+      expect(blocky.blockers[0].detectedAt).toBe(blocky.generatedAt);
+    });
+  });
+
+  describe("degraded report", () => {
+    it("classifies a non-blocking lag as a warning and stays release-ready", async () => {
+      mockIndexerLag.getStatus.mockReturnValue({
+        ...healthyLag(),
+        lagLedgers: 250,
+        isLagging: true,
+      });
+      mockIndexerLag.isBlocked.mockReturnValue(false); // guard overridden/disabled
+
+      const report = await service.generateReport();
+
+      expect(report.overallStatus).toBe("degraded");
+      expect(report.releaseReady).toBe(true);
+      expect(report.summary.critical).toBe(0);
+      expect(report.summary.warning).toBe(1);
+
+      const lagBlocker = report.blockers.find((b) => b.category === "lag");
+      expect(lagBlocker?.severity).toBe("warning");
+      expect(lagBlocker?.detectedAt).toBe(report.generatedAt);
+    });
+
+    it("classifies environment parity warnings as info-level blockers", async () => {
+      mockParity.getResults.mockReturnValue([
+        ...healthyParity(),
+        { check: "feature_flags", status: "warning", details: "none set" },
+      ]);
+
+      const report = await service.generateReport();
+
+      expect(report.overallStatus).toBe("degraded");
+      expect(report.releaseReady).toBe(true);
+      expect(report.summary.info).toBe(1);
+      expect(report.sections.environment.status).toBe("warning");
+      const envBlocker = report.blockers.find((b) => b.category === "environment");
+      expect(envBlocker?.severity).toBe("info");
+    });
+  });
+
+  describe("blocked report", () => {
+    it("flags a failed smoke check as a critical blocker", async () => {
+      mockHealth.getReadinessStatus.mockResolvedValue({
+        ready: false,
+        timestamp: new Date().toISOString(),
+        checks: [
+          { name: "supabase", status: "up" },
+          { name: "horizon", status: "down", error: "Horizon returned 503" },
+        ],
+      });
+
+      const report = await service.generateReport();
+
+      expect(report.overallStatus).toBe("blocked");
+      expect(report.releaseReady).toBe(false);
+      expect(report.summary.critical).toBe(1);
+      const smokeBlocker = report.blockers.find((b) => b.category === "smoke");
+      expect(smokeBlocker?.severity).toBe("critical");
+      expect(smokeBlocker?.message).toContain("horizon");
+      expect(report.sections.smoke.failed).toBe(1);
+    });
+
+    it("flags missing expected contracts as a critical blocker", async () => {
+      mockRegistry.getRegistry.mockResolvedValue({
+        ...healthyRegistry(),
+        data: {}, // quickex missing
+      });
+
+      const report = await service.generateReport();
+
+      expect(report.releaseReady).toBe(false);
+      expect(report.sections.registry.status).toBe("fail");
+      expect(report.sections.registry.missingContracts).toContain("quickex");
+      const regBlocker = report.blockers.find((b) => b.category === "registry");
+      expect(regBlocker?.severity).toBe("critical");
+    });
+
+    it("flags a blocking indexer lag as critical", async () => {
+      mockIndexerLag.getStatus.mockReturnValue({
+        ...healthyLag(),
+        lagLedgers: 500,
+        isLagging: true,
+      });
+      mockIndexerLag.isBlocked.mockReturnValue(true);
+
+      const report = await service.generateReport();
+
+      expect(report.overallStatus).toBe("blocked");
+      expect(report.sections.lag.status).toBe("fail");
+      expect(report.sections.lag.isBlocking).toBe(true);
+      const lagBlocker = report.blockers.find((b) => b.category === "lag");
+      expect(lagBlocker?.severity).toBe("critical");
+    });
+  });
+
+  describe("partial report (degraded sources)", () => {
+    it("still produces a report when the registry source throws", async () => {
+      mockRegistry.getRegistry.mockRejectedValue(new Error("supabase down"));
+
+      const report = await service.generateReport();
+
+      // Other sections still evaluated.
+      expect(report.sections.smoke.status).toBe("pass");
+      expect(report.sections.lag.status).toBe("pass");
+      // Failed source surfaced as unknown + critical blocker.
+      expect(report.sections.registry.status).toBe("unknown");
+      const regBlocker = report.blockers.find(
+        (b) => b.id === "registry.unavailable",
+      );
+      expect(regBlocker?.severity).toBe("critical");
+      expect(report.releaseReady).toBe(false);
+    });
+
+    it("treats a missing lag computation as an info-level advisory", async () => {
+      mockIndexerLag.getStatus.mockReturnValue({
+        ...healthyLag(),
+        currentNetworkLedger: null,
+        lastIndexedLedger: null,
+        lagLedgers: null,
+      });
+
+      const report = await service.generateReport();
+
+      expect(report.sections.lag.status).toBe("warning");
+      const lagBlocker = report.blockers.find((b) => b.id === "lag.unknown");
+      expect(lagBlocker?.severity).toBe("info");
+      expect(report.releaseReady).toBe(true);
+    });
+
+    it("aggregates multiple blocker severities into the summary counts", async () => {
+      mockHealth.getReadinessStatus.mockResolvedValue({
+        ready: false,
+        timestamp: new Date().toISOString(),
+        checks: [{ name: "queue", status: "down", error: "timeout" }],
+      });
+      mockIndexerLag.getStatus.mockReturnValue({
+        ...healthyLag(),
+        lagLedgers: 250,
+        isLagging: true,
+      });
+      mockParity.getResults.mockReturnValue([
+        { check: "feature_flags", status: "warning", details: "none" },
+      ]);
+
+      const report = await service.generateReport();
+
+      expect(report.summary.critical).toBe(1); // smoke
+      expect(report.summary.warning).toBe(1); // lag
+      expect(report.summary.info).toBe(1); // environment
+      expect(report.overallStatus).toBe("blocked");
+    });
+  });
+});


### PR DESCRIPTION
Closes #561 

### Summary
Adds a single operator-facing endpoint that aggregates release-candidate readiness
signals — smoke results, contract registry status, indexer lag metrics, and
environment parity — into one reproducible, timestamped report with classified
blockers. Operators can now assess testnet release readiness from one call instead
of polling four separate subsystems.

### Endpoint
`GET /admin/rc-validation/report` — admin-scoped, protected by `ApiKeyGuard` +
`@RequireScopes("admin")` (consistent with the existing `OperationsController`).

### What the report contains
- **smoke** — derived from `HealthService.getReadinessStatus()` (deep dependency probes)
- **registry** — `ContractRegistryService.getRegistry()`, including expected vs. missing contracts
- **lag** — `IndexerLagService` ledger lag vs. network head and guard state
- **environment** — `EnvironmentParityService` staging/production parity checks
- **blockers[]** — each classified as `critical` / `warning` / `info`, with a message,
  remediation hint, and timestamp
- **summary / overallStatus** — `ready` | `degraded` | `blocked`, plus `releaseReady`,
  `reportId`, `generatedAt`, `network`, and `environment`

### Blocker classification
| Source       | Condition                                  | Severity  |
|--------------|--------------------------------------------|-----------|
| smoke        | critical readiness probe down              | critical  |
| registry     | expected contract missing                  | critical  |
| registry     | registry not authoritative                 | warning   |
| lag          | indexer-lag guard blocking traffic         | critical  |
| lag          | lagging but guard not enforcing            | warning   |
| lag          | lag uncomputable (no ledger data yet)      | info      |
| environment  | parity check failed                        | warning   |
| environment  | parity check warning                       | info      |

`overallStatus` is `blocked` if any critical blocker exists, `degraded` if only
warning/info blockers exist, otherwise `ready`. `releaseReady` is true when there
are zero critical blockers.

### Design notes
- Each source is evaluated defensively (`Promise.all` with per-section try/catch), so
  a failure in one subsystem still yields a usable partial report rather than failing
  the whole endpoint.
- A single generation timestamp stamps the report and every blocker, making reports
  reproducible and auditable.

### Changes
- `src/rc-validation/dto/rc-report.dto.ts` — report schema (Swagger-documented)
- `src/rc-validation/rc-validation.service.ts` — aggregation and blocker classification
- `src/rc-validation/rc-validation.controller.ts` — admin-scoped endpoint
- `src/rc-validation/rc-validation.module.ts` — module wiring
- `src/app.module.ts` — register `RcValidationModule`
- `src/health/health.module.ts` — export `HealthService` for aggregation
- `src/rc-validation/rc-validation.service.unit.spec.ts` — unit tests

### Testing
- `pnpm type-check` — passes
- `pnpm lint` (new files) — passes
- New unit suite — 11/11 passing, covering complete, degraded, blocked, and partial
  (failing-source) reports

### Acceptance criteria
- [x] Operators can assess testnet release readiness from one endpoint
- [x] Blockers are clearly categorized (critical/warning/info) and actionable
- [x] Reports are reproducible and timestamped

### Out of scope
A pre-existing DI issue (`IngestionBootstrapService` cannot resolve
`ContractRegistryService` in `IngestionModule`) currently blocks the full-app e2e
smoke boot, and four unrelated unit suites (metrics, support-bundle, ingestion) fail
identically on the base branch. Both were verified as pre-existing and are not
addressed here.
