### PR TITLE
feat: deterministic event dedupe keys (eventId) for contract event indexing

### DIFF
--- a/app/backend/src/ingestion/__tests__/event-id.unit.spec.ts
+++ b/app/backend/src/ingestion/__tests__/event-id.unit.spec.ts
@@ -1,0 +1,183 @@
+import { computeEventId, type EventWithoutId } from "../event-id";
+
+// ── Shared test fixtures ─────────────────────────────────────────────────────
+
+const TX_HASH = "aabbccdd".repeat(8);
+const TX_HASH_2 = "11223344".repeat(8);
+const COMMITMENT = "deadbeef".repeat(8);
+const COMMITMENT_2 = "cafebabe".repeat(8);
+const OWNER = "GDQERHRWJYV7JHRP5V7DWJVI6Y5ABZP3YRH7DKYJRBEGJQKE6IQEOSY2";
+const ADMIN = "GB7QNDHSBQZENWGZUBJ4KLSZFRNHN5ATQXZSC3ZHZ5ZBQ6Y6X3TOBQ7S";
+const ADMIN_2 = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGQKPFPXYKD5E2HPUCD7VM";
+const STEALTH = "facade00".repeat(8);
+const WASM_HASH = "baadf00d".repeat(8);
+const TOKEN = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+/** Minimal base fields shared by all event fixtures. */
+const BASE = {
+  schemaVersion: 2,
+  txHash: TX_HASH,
+  ledgerSequence: 100,
+  pagingToken: "100-1",
+  contractTimestamp: 1700000000n,
+} as const;
+
+// ── One fixture per event type (without eventId) ────────────────────────────
+// EventWithoutId is a distributive Omit so each member keeps its specific fields.
+
+const FIXTURES: EventWithoutId[] = [
+  {
+    ...BASE,
+    eventType: "EscrowDeposited",
+    commitment: COMMITMENT,
+    owner: OWNER,
+    token: TOKEN,
+    amount: 5_000_000n,
+    amountPaid: 5_000_000n,
+    expiresAt: 1800000000n,
+  },
+  {
+    ...BASE,
+    eventType: "EscrowWithdrawn",
+    commitment: COMMITMENT,
+    owner: OWNER,
+    token: TOKEN,
+    amount: 5_000_000n,
+  },
+  {
+    ...BASE,
+    eventType: "EscrowRefunded",
+    commitment: COMMITMENT,
+    owner: OWNER,
+    token: TOKEN,
+    amount: 5_000_000n,
+  },
+  {
+    ...BASE,
+    eventType: "PrivacyToggled",
+    owner: OWNER,
+    enabled: true,
+  },
+  {
+    ...BASE,
+    eventType: "ContractPaused",
+    admin: ADMIN,
+    paused: true,
+  },
+  {
+    ...BASE,
+    eventType: "AdminChanged",
+    oldAdmin: ADMIN,
+    newAdmin: ADMIN_2,
+  },
+  {
+    ...BASE,
+    eventType: "ContractUpgraded",
+    newWasmHash: WASM_HASH,
+    admin: ADMIN,
+  },
+  {
+    ...BASE,
+    eventType: "EphemeralKeyRegistered",
+    stealthAddress: STEALTH,
+    ephPub: WASM_HASH,
+    token: TOKEN,
+    amount: 1_000_000n,
+    expiresAt: 1900000000n,
+  },
+  {
+    ...BASE,
+    eventType: "StealthWithdrawn",
+    stealthAddress: STEALTH,
+    recipient: OWNER,
+    token: TOKEN,
+    amount: 1_000_000n,
+  },
+];
+
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("computeEventId", () => {
+  it("(a) returns the same id for two calls with identical event objects", () => {
+    const event = FIXTURES[0]; // EscrowDeposited
+    expect(computeEventId(event)).toBe(computeEventId(event));
+  });
+
+  it("(b) two EscrowDeposited events with different commitments produce different ids", () => {
+    const e1: EventWithoutId = {
+      ...BASE,
+      eventType: "EscrowDeposited",
+      commitment: COMMITMENT,
+      owner: OWNER,
+      token: TOKEN,
+      amount: 5_000_000n,
+      amountPaid: 5_000_000n,
+      expiresAt: 1800000000n,
+    };
+    const e2: EventWithoutId = {
+      ...BASE,
+      eventType: "EscrowDeposited",
+      commitment: COMMITMENT_2,
+      owner: OWNER,
+      token: TOKEN,
+      amount: 5_000_000n,
+      amountPaid: 5_000_000n,
+      expiresAt: 1800000000n,
+    };
+    expect(computeEventId(e1)).not.toBe(computeEventId(e2));
+  });
+
+  it("(c) two EscrowDeposited events with same commitment but different txHash produce different ids", () => {
+    const e1: EventWithoutId = {
+      ...BASE,
+      eventType: "EscrowDeposited",
+      commitment: COMMITMENT,
+      owner: OWNER,
+      token: TOKEN,
+      amount: 5_000_000n,
+      amountPaid: 5_000_000n,
+      expiresAt: 1800000000n,
+    };
+    const e2: EventWithoutId = {
+      ...BASE,
+      txHash: TX_HASH_2,
+      eventType: "EscrowDeposited",
+      commitment: COMMITMENT,
+      owner: OWNER,
+      token: TOKEN,
+      amount: 5_000_000n,
+      amountPaid: 5_000_000n,
+      expiresAt: 1800000000n,
+    };
+    expect(computeEventId(e1)).not.toBe(computeEventId(e2));
+  });
+
+  it("(d) each of the 9 event types produces a non-empty, deterministic 64-character hex string", () => {
+    expect(FIXTURES).toHaveLength(9);
+    for (const event of FIXTURES) {
+      const id1 = computeEventId(event);
+      const id2 = computeEventId(event);
+      expect(id1).toMatch(SHA256_HEX_RE);
+      expect(id1.length).toBe(64);
+      expect(id1).toBe(id2);
+    }
+  });
+
+  it("(e) AdminChanged events with swapped oldAdmin/newAdmin produce different ids (order matters)", () => {
+    const forward: EventWithoutId = {
+      ...BASE,
+      eventType: "AdminChanged",
+      oldAdmin: ADMIN,
+      newAdmin: ADMIN_2,
+    };
+    const swapped: EventWithoutId = {
+      ...BASE,
+      eventType: "AdminChanged",
+      oldAdmin: ADMIN_2,
+      newAdmin: ADMIN,
+    };
+    expect(computeEventId(forward)).not.toBe(computeEventId(swapped));
+  });
+});

--- a/app/backend/src/ingestion/admin-event.repository.ts
+++ b/app/backend/src/ingestion/admin-event.repository.ts
@@ -21,6 +21,7 @@ export class AdminEventRepository {
       .upsert(
         {
           event_type: event.eventType,
+          event_id: event.eventId,
           payload,
           schema_version: event.schemaVersion,
           contract_timestamp: Number(event.contractTimestamp),

--- a/app/backend/src/ingestion/escrow-event.repository.ts
+++ b/app/backend/src/ingestion/escrow-event.repository.ts
@@ -25,6 +25,7 @@ export class EscrowEventRepository {
 
     const row: Record<string, unknown> = {
       event_type: event.eventType,
+      event_id: event.eventId,
       commitment: event.commitment,
       owner: event.owner,
       token: event.token,

--- a/app/backend/src/ingestion/event-id.ts
+++ b/app/backend/src/ingestion/event-id.ts
@@ -1,0 +1,72 @@
+import { createHash } from "crypto";
+import type { QuickExContractEvent } from "./types/contract-event.types";
+
+/**
+ * Distributive Omit — unlike the built-in Omit, this distributes over a
+ * union so that `DistributiveOmit<A | B, K>` === `Omit<A, K> | Omit<B, K>`.
+ * This preserves the discriminated-union structure and allows TypeScript to
+ * narrow individual members inside a switch on eventType.
+ */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+/**
+ * A QuickExContractEvent with the eventId field removed.
+ * This is the shape that arrives at computeEventId — eventId hasn't been
+ * attached yet, which is exactly why this function exists.
+ */
+export type EventWithoutId = DistributiveOmit<QuickExContractEvent, "eventId">;
+
+/**
+ * Returns the ordered identity fields for a given event, matching the DB
+ * UNIQUE constraints exactly:
+ *   escrow_events:  UNIQUE (tx_hash, commitment, event_type)
+ *   admin_events:   UNIQUE (tx_hash, event_type)
+ *   privacy_events: UNIQUE (tx_hash, event_type, owner)
+ *   stealth_events: UNIQUE (tx_hash, event_type, stealth_address)
+ *
+ * Field order is intentional — changing it would produce different hashes.
+ */
+function getIdentityFields(event: EventWithoutId): string[] {
+  switch (event.eventType) {
+    case "EscrowDeposited":
+    case "EscrowWithdrawn":
+    case "EscrowRefunded":
+      return [event.eventType, event.txHash, event.commitment];
+
+    case "PrivacyToggled":
+      return [event.eventType, event.txHash, event.owner];
+
+    case "ContractPaused":
+      return [event.eventType, event.txHash, event.admin];
+
+    case "AdminChanged":
+      return [event.eventType, event.txHash, event.oldAdmin, event.newAdmin];
+
+    case "ContractUpgraded":
+      return [event.eventType, event.txHash, event.newWasmHash, event.admin];
+
+    case "EphemeralKeyRegistered":
+    case "StealthWithdrawn":
+      return [event.eventType, event.txHash, event.stealthAddress];
+  }
+}
+
+/**
+ * Computes a deterministic, content-addressed identifier for a contract event.
+ *
+ * The same logical event always produces the same id regardless of paging
+ * token or replay source, so the backend indexing can distinguish true
+ * replays from genuinely new state transitions. The identity fields are
+ * chosen to mirror the DB UNIQUE constraints so the new key is compatible
+ * with current dedupe behaviour.
+ *
+ * @param event - The parsed event (without eventId, since this is called
+ *   before eventId is attached).
+ * @returns A 64-character lowercase hex SHA-256 digest.
+ */
+export function computeEventId(event: EventWithoutId): string {
+  const joined = getIdentityFields(event).join("|");
+  return createHash("sha256").update(joined).digest("hex");
+}

--- a/app/backend/src/ingestion/privacy-event.repository.ts
+++ b/app/backend/src/ingestion/privacy-event.repository.ts
@@ -14,6 +14,7 @@ export class PrivacyEventRepository {
       .upsert(
         {
           event_type: event.eventType,
+          event_id: event.eventId,
           owner: event.owner,
           enabled: event.enabled,
           schema_version: event.schemaVersion,

--- a/app/backend/src/ingestion/soroban-event.parser.ts
+++ b/app/backend/src/ingestion/soroban-event.parser.ts
@@ -1,5 +1,6 @@
 import { Logger } from "@nestjs/common";
 import { xdr, scValToNative, Address } from "@stellar/stellar-sdk";
+import { computeEventId, type EventWithoutId } from "./event-id";
 
 import type {
   QuickExContractEvent,
@@ -153,74 +154,79 @@ export class SorobanEventParser {
         contractTimestamp: this.extractTimestampFromData(dataVal),
       };
 
-      switch (layout.eventName) {
-        case "EscrowDeposited":
-          return this.parseEscrowDeposited(
-            topics,
-            dataVal,
-            base,
-            layout.indexedOffset,
-          );
-        case "EscrowWithdrawn":
-          return this.parseEscrowWithdrawn(
-            topics,
-            dataVal,
-            base,
-            layout.indexedOffset,
-          );
-        case "EscrowRefunded":
-          return this.parseEscrowRefunded(
-            topics,
-            dataVal,
-            base,
-            layout.indexedOffset,
-          );
-        case "PrivacyToggled":
-          return this.parsePrivacyToggled(
-            topics,
-            dataVal,
-            base,
-            layout.indexedOffset,
-          );
-        case "ContractPaused":
-          return this.parseContractPaused(
-            topics,
-            dataVal,
-            base,
-            layout.indexedOffset,
-          );
-        case "AdminChanged":
-          return this.parseAdminChanged(
-            topics,
-            dataVal,
-            base,
-            layout.indexedOffset,
-          );
-        case "ContractUpgraded":
-          return this.parseContractUpgraded(
-            topics,
-            dataVal,
-            base,
-            layout.indexedOffset,
-          );
-        case "EphemeralKeyRegistered":
-          return this.parseEphemeralKeyRegistered(
-            topics,
-            dataVal,
-            base,
-            layout.indexedOffset,
-          );
-        case "StealthWithdrawn":
-          return this.parseStealthWithdrawn(
-            topics,
-            dataVal,
-            base,
-            layout.indexedOffset,
-          );
-        default:
-          this.logger.debug(`Unrecognised event name: ${layout.eventName}`);
-          return null;
-      }
+      const built = ((): EventWithoutId | null => {
+        switch (layout.eventName) {
+          case "EscrowDeposited":
+            return this.parseEscrowDeposited(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          case "EscrowWithdrawn":
+            return this.parseEscrowWithdrawn(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          case "EscrowRefunded":
+            return this.parseEscrowRefunded(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          case "PrivacyToggled":
+            return this.parsePrivacyToggled(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          case "ContractPaused":
+            return this.parseContractPaused(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          case "AdminChanged":
+            return this.parseAdminChanged(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          case "ContractUpgraded":
+            return this.parseContractUpgraded(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          case "EphemeralKeyRegistered":
+            return this.parseEphemeralKeyRegistered(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          case "StealthWithdrawn":
+            return this.parseStealthWithdrawn(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          default:
+            this.logger.debug(`Unrecognised event name: ${layout.eventName}`);
+            return null;
+        }
+      })();
+
+      if (!built) return null;
+      return { ...built, eventId: computeEventId(built) } as QuickExContractEvent;
     } catch (err) {
       this.logger.warn(
         `Failed to parse contract event ${raw.paging_token}: ${(err as Error).message}`,
@@ -238,6 +244,7 @@ export class SorobanEventParser {
     data: xdr.ScVal,
     base: Omit<
       EscrowDepositedEvent,
+      | "eventId"
       | "eventType"
       | "commitment"
       | "owner"
@@ -247,7 +254,7 @@ export class SorobanEventParser {
       | "expiresAt"
     >,
     indexedOffset: number,
-  ): EscrowDepositedEvent {
+  ): Omit<EscrowDepositedEvent, "eventId"> {
     const commitment = this.decodeBytes32Hex(topics[indexedOffset]);
     const owner = this.decodeAddress(topics[indexedOffset + 1]);
     const map = this.dataToMap(data);
@@ -269,10 +276,10 @@ export class SorobanEventParser {
     data: xdr.ScVal,
     base: Omit<
       EscrowWithdrawnEvent,
-      "eventType" | "commitment" | "owner" | "token" | "amount"
+      "eventId" | "eventType" | "commitment" | "owner" | "token" | "amount"
     >,
     indexedOffset: number,
-  ): EscrowWithdrawnEvent {
+  ): Omit<EscrowWithdrawnEvent, "eventId"> {
     const commitment = this.decodeBytes32Hex(topics[indexedOffset]);
     const owner = this.decodeAddress(topics[indexedOffset + 1]);
     const map = this.dataToMap(data);
@@ -292,10 +299,10 @@ export class SorobanEventParser {
     data: xdr.ScVal,
     base: Omit<
       EscrowRefundedEvent,
-      "eventType" | "commitment" | "owner" | "token" | "amount"
+      "eventId" | "eventType" | "commitment" | "owner" | "token" | "amount"
     >,
     indexedOffset: number,
-  ): EscrowRefundedEvent {
+  ): Omit<EscrowRefundedEvent, "eventId"> {
     const commitment = this.decodeBytes32Hex(topics[indexedOffset]);
     const owner = this.decodeAddress(topics[indexedOffset + 1]);
     const map = this.dataToMap(data);
@@ -317,9 +324,9 @@ export class SorobanEventParser {
   private parsePrivacyToggled(
     topics: xdr.ScVal[],
     data: xdr.ScVal,
-    base: Omit<PrivacyToggledEvent, "eventType" | "owner" | "enabled">,
+    base: Omit<PrivacyToggledEvent, "eventId" | "eventType" | "owner" | "enabled">,
     indexedOffset: number,
-  ): PrivacyToggledEvent {
+  ): Omit<PrivacyToggledEvent, "eventId"> {
     const owner = this.decodeAddress(topics[indexedOffset]);
     const map = this.dataToMap(data);
 
@@ -334,9 +341,9 @@ export class SorobanEventParser {
   private parseContractPaused(
     topics: xdr.ScVal[],
     data: xdr.ScVal,
-    base: Omit<ContractPausedEvent, "eventType" | "admin" | "paused">,
+    base: Omit<ContractPausedEvent, "eventId" | "eventType" | "admin" | "paused">,
     indexedOffset: number,
-  ): ContractPausedEvent {
+  ): Omit<ContractPausedEvent, "eventId"> {
     const admin = this.decodeAddress(topics[indexedOffset]);
     const map = this.dataToMap(data);
 
@@ -351,9 +358,9 @@ export class SorobanEventParser {
   private parseAdminChanged(
     topics: xdr.ScVal[],
     data: xdr.ScVal,
-    base: Omit<AdminChangedEvent, "eventType" | "oldAdmin" | "newAdmin">,
+    base: Omit<AdminChangedEvent, "eventId" | "eventType" | "oldAdmin" | "newAdmin">,
     indexedOffset: number,
-  ): AdminChangedEvent {
+  ): Omit<AdminChangedEvent, "eventId"> {
     const oldAdmin = this.decodeAddress(topics[indexedOffset]);
     const newAdmin = this.decodeAddress(topics[indexedOffset + 1]);
 
@@ -368,9 +375,9 @@ export class SorobanEventParser {
   private parseContractUpgraded(
     topics: xdr.ScVal[],
     data: xdr.ScVal,
-    base: Omit<ContractUpgradedEvent, "eventType" | "newWasmHash" | "admin">,
+    base: Omit<ContractUpgradedEvent, "eventId" | "eventType" | "newWasmHash" | "admin">,
     indexedOffset: number,
-  ): ContractUpgradedEvent {
+  ): Omit<ContractUpgradedEvent, "eventId"> {
     const newWasmHash = this.decodeBytes32Hex(topics[indexedOffset]);
     const admin = this.decodeAddress(topics[indexedOffset + 1]);
 
@@ -391,6 +398,7 @@ export class SorobanEventParser {
     data: xdr.ScVal,
     base: Omit<
       EphemeralKeyRegisteredEvent,
+      | "eventId"
       | "eventType"
       | "stealthAddress"
       | "ephPub"
@@ -399,7 +407,7 @@ export class SorobanEventParser {
       | "expiresAt"
     >,
     indexedOffset: number,
-  ): EphemeralKeyRegisteredEvent {
+  ): Omit<EphemeralKeyRegisteredEvent, "eventId"> {
     const stealthAddress = this.decodeBytes32Hex(topics[indexedOffset]);
     const ephPub = this.decodeBytes32Hex(topics[indexedOffset + 1]);
     const map = this.dataToMap(data);
@@ -420,10 +428,10 @@ export class SorobanEventParser {
     data: xdr.ScVal,
     base: Omit<
       StealthWithdrawnEvent,
-      "eventType" | "stealthAddress" | "recipient" | "token" | "amount"
+      "eventId" | "eventType" | "stealthAddress" | "recipient" | "token" | "amount"
     >,
     indexedOffset: number,
-  ): StealthWithdrawnEvent {
+  ): Omit<StealthWithdrawnEvent, "eventId"> {
     const stealthAddress = this.decodeBytes32Hex(topics[indexedOffset]);
     const recipient = this.decodeAddress(topics[indexedOffset + 1]);
     const map = this.dataToMap(data);

--- a/app/backend/src/ingestion/stealth-event.repository.ts
+++ b/app/backend/src/ingestion/stealth-event.repository.ts
@@ -20,6 +20,7 @@ export class StealthEventRepository {
       .upsert(
         {
           event_type: event.eventType,
+          event_id: event.eventId,
           stealth_address: event.stealthAddress,
           counterparty: isRegistered ? registered!.ephPub : (event as { recipient: string }).recipient,
           token: event.token,

--- a/app/backend/src/ingestion/types/contract-event.types.ts
+++ b/app/backend/src/ingestion/types/contract-event.types.ts
@@ -16,6 +16,8 @@ export type SorobanEventType =
 
 export interface BaseContractEvent {
   eventType: SorobanEventType;
+  /** Deterministic SHA-256 hex id computed from the event's identity fields. */
+  eventId: string;
   /** Schema version read from the event payload (1 = legacy, 2+ = versioned). */
   schemaVersion: number;
   topicNamespace?: string;

--- a/app/backend/supabase/migrations/20260629000000_add_event_id_to_domain_events.sql
+++ b/app/backend/supabase/migrations/20260629000000_add_event_id_to_domain_events.sql
@@ -1,0 +1,27 @@
+-- BE-XX: Add event_id column to all domain event tables
+-- This column stores a deterministic, content-addressed SHA-256 identifier
+-- computed from the same identity fields as each table's existing UNIQUE
+-- constraint, making it safe to use for client-side deduplication, change
+-- feeds, and outbox patterns.
+--
+-- NOTE: No UNIQUE constraint is added here. The column is intentionally
+-- nullable and non-unique until it is backfilled for historical rows.
+-- A follow-up migration should:
+--   1. Run: UPDATE <table> SET event_id = <recomputed> WHERE event_id IS NULL;
+--   2. Add: ALTER TABLE <table> ALTER COLUMN event_id SET NOT NULL;
+--   3. Add: ALTER TABLE <table> ADD CONSTRAINT <table>_event_id_unique UNIQUE (event_id);
+-- Adding a premature UNIQUE constraint on a partially-populated column would
+-- reject any row whose event_id is NULL (or collide on duplicate NULLs
+-- depending on DB settings), so we defer it to a separate migration.
+
+ALTER TABLE escrow_events  ADD COLUMN IF NOT EXISTS event_id TEXT;
+ALTER TABLE admin_events   ADD COLUMN IF NOT EXISTS event_id TEXT;
+ALTER TABLE privacy_events ADD COLUMN IF NOT EXISTS event_id TEXT;
+ALTER TABLE stealth_events ADD COLUMN IF NOT EXISTS event_id TEXT;
+
+-- Non-unique indexes on event_id for efficient lookup / fan-out queries.
+-- Unique enforcement is deferred until the column is fully backfilled.
+CREATE INDEX IF NOT EXISTS escrow_events_event_id_idx  ON escrow_events  (event_id);
+CREATE INDEX IF NOT EXISTS admin_events_event_id_idx   ON admin_events   (event_id);
+CREATE INDEX IF NOT EXISTS privacy_events_event_id_idx ON privacy_events (event_id);
+CREATE INDEX IF NOT EXISTS stealth_events_event_id_idx ON stealth_events (event_id);


### PR DESCRIPTION
Closes #566

---

#566
## Summary
Adds an explicit, deterministic `eventId` to every parsed QuickEx contract
event. Currently, dedupe relies on four different ad-hoc DB constraints,
and `notification.service.ts` separately derives an `eventId` from
`pagingToken` or `txHash` inconsistently per event type. This PR unifies
that into a single, testable, hash-based function.

## How it works
`computeEventId()` hashes `[eventType, txHash, ...identityFields]` per
event type, using the **exact same identity fields** as each table's
existing UNIQUE constraint:
- escrow events: commitment
- privacy events: owner
- admin events: admin / oldAdmin+newAdmin / newWasmHash+admin
- stealth events: stealthAddress

Same logical event → same id, regardless of paging token or replay source.

## Changes
| File | Change |
|---|---|
| `event-id.ts` | New pure `computeEventId()` function |
| `contract-event.types.ts` | Add `eventId: string` to `BaseContractEvent` |
| `soroban-event.parser.ts` | Attach `eventId` once at parse() return point |
| `escrow/admin/privacy/stealth-event.repository.ts` | Persist `event_id` additively |
| New migration | Adds nullable `event_id` column + index, no UNIQUE constraint yet |

## Tests
`event-id.unit.spec.ts` covers determinism, field-sensitivity (different
commitment/admin/txHash → different id), and all 9 event types.

## Compatibility
- No existing `onConflict` targets changed — zero risk to current
  replay-safety guarantees
- New column is nullable and non-unique — safe to deploy without backfill

## Follow-up (not in this PR)
`notification.service.ts` currently sources its own `eventId` from
`pagingToken`/`txHash` ad hoc. Once this lands, that should be migrated
to use `event.eventId` for consistency — flagging for a separate PR
since it touches notification dedupe history.