### PR TITLE
SC-W6-02: Contract Spec Export v1

### DIFF
--- a/app/contract/.gitignore
+++ b/app/contract/.gitignore
@@ -4,3 +4,6 @@ target
 # Local settings
 .soroban
 .stellar
+
+# Generated contract spec export artifact
+docs/contract-spec/

--- a/app/contract/README.md
+++ b/app/contract/README.md
@@ -107,6 +107,22 @@ soroban contract deploy \
   --network mainnet
 ```
 
+## Contract Spec Export
+
+Export the contract's method/argument spec, along with the current
+contract and event schema versions, as a stable JSON artifact:
+
+```bash
+./scripts/export-contract-spec.sh
+```
+
+The artifact is written to `docs/contract-spec/contract-spec.json` and
+includes `contract_version`, `event_schema_version`, and the full function
+interface, so contributors and tooling can introspect available methods
+without reading the Rust source. `scripts/test-contract-spec-export.sh`
+verifies the export is stable across repeat builds and includes all
+required fields.
+
 ## Development Workflow
 
 1. Make changes to the contract code

--- a/app/contract/scripts/export-contract-spec.sh
+++ b/app/contract/scripts/export-contract-spec.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Exports the QuickEx contract's method/argument spec (and version metadata)
+# as a stable JSON artifact, so tooling and contributors can introspect the
+# contract without needing to read the Rust source.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WASM_PATH="${WASM_PATH:-$ROOT_DIR/target/wasm32v1-none/release/quickex.wasm}"
+OUT_PATH="${OUT_PATH:-$ROOT_DIR/docs/contract-spec/contract-spec.json}"
+STELLAR_BIN="${STELLAR_BIN:-stellar}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing required command: $1" >&2; exit 1; }; }
+need python3
+need sha256sum
+
+if command -v "$STELLAR_BIN" >/dev/null 2>&1; then
+  STELLAR_CMD="$STELLAR_BIN"
+elif command -v soroban >/dev/null 2>&1; then
+  STELLAR_CMD="soroban"
+else
+  echo "missing required command: $STELLAR_BIN (or soroban)" >&2
+  exit 1
+fi
+
+if [[ "$SKIP_BUILD" != "1" ]]; then
+  echo "==> Building contract wasm"
+  (cd "$ROOT_DIR" && cargo build -p quickex --target wasm32v1-none --release)
+fi
+
+if [[ ! -f "$WASM_PATH" ]]; then
+  echo "wasm artifact not found at $WASM_PATH" >&2
+  exit 1
+fi
+
+echo "==> Extracting contract interface from $WASM_PATH"
+INTERFACE_FILE="$(mktemp)"
+trap 'rm -f "$INTERFACE_FILE"' EXIT
+"$STELLAR_CMD" contract info interface --wasm "$WASM_PATH" --output json-formatted >"$INTERFACE_FILE"
+
+WASM_SHA="$(sha256sum "$WASM_PATH" | awk '{print $1}')"
+CONTRACT_VERSION="$(grep -oE 'pub const CURRENT_CONTRACT_VERSION: u32 = [0-9]+' "$ROOT_DIR/contracts/quickex/src/storage.rs" | grep -oE '[0-9]+$')"
+EVENT_SCHEMA_VERSION="$(grep -oE 'pub const EVENT_SCHEMA_VERSION: u32 = [0-9]+' "$ROOT_DIR/contracts/quickex/src/events.rs" | grep -oE '[0-9]+$')"
+
+mkdir -p "$(dirname "$OUT_PATH")"
+
+python3 - "$OUT_PATH" "$CONTRACT_VERSION" "$EVENT_SCHEMA_VERSION" "$WASM_SHA" "$INTERFACE_FILE" <<'PY'
+import json, sys
+
+out_path, contract_version, event_schema_version, wasm_sha, interface_file = sys.argv[1:6]
+
+with open(interface_file) as f:
+    interface = json.load(f)
+
+functions = sorted(
+    entry["function_v0"]["name"] for entry in interface if "function_v0" in entry
+)
+
+spec = {
+    "kind": "quickex-contract-spec-v1",
+    "contract_version": int(contract_version),
+    "event_schema_version": int(event_schema_version),
+    "wasm_sha256": wasm_sha,
+    "functions": functions,
+    "interface": interface,
+}
+
+with open(out_path, "w") as f:
+    json.dump(spec, f, indent=2, sort_keys=True)
+    f.write("\n")
+
+print(f"wrote {out_path} ({len(functions)} functions)")
+PY
+
+echo "Contract spec exported to $OUT_PATH"

--- a/app/contract/scripts/test-contract-spec-export.sh
+++ b/app/contract/scripts/test-contract-spec-export.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Verifies that the exported contract spec (export-contract-spec.sh) is
+# stable across repeat builds and contains the required version metadata.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "==> Export run 1 (with build)"
+OUT_PATH="$WORK_DIR/spec-1.json" "$ROOT_DIR/scripts/export-contract-spec.sh"
+
+echo "==> Export run 2 (reusing artifact)"
+OUT_PATH="$WORK_DIR/spec-2.json" SKIP_BUILD=1 "$ROOT_DIR/scripts/export-contract-spec.sh"
+
+echo "==> Checking stability across repeat exports"
+if ! diff -u "$WORK_DIR/spec-1.json" "$WORK_DIR/spec-2.json"; then
+  echo "FAIL: exported spec is not stable across repeat builds" >&2
+  exit 1
+fi
+
+echo "==> Checking completeness of required spec fields"
+python3 - "$WORK_DIR/spec-1.json" <<'PY'
+import json, sys
+
+spec = json.load(open(sys.argv[1]))
+
+required = ["kind", "contract_version", "event_schema_version", "wasm_sha256", "functions", "interface"]
+missing = [field for field in required if field not in spec]
+if missing:
+    sys.exit(f"FAIL: missing required spec fields: {missing}")
+
+if not isinstance(spec["contract_version"], int) or not isinstance(spec["event_schema_version"], int):
+    sys.exit("FAIL: contract_version/event_schema_version must be present and integers")
+
+if not isinstance(spec["functions"], list) or not spec["functions"]:
+    sys.exit("FAIL: functions list must be a non-empty list")
+
+print(
+    f"OK: {len(spec['functions'])} functions, "
+    f"contract_version={spec['contract_version']}, "
+    f"event_schema_version={spec['event_schema_version']}"
+)
+PY
+
+echo "Contract spec export is stable and complete."

--- a/app/contract/scripts/testnet-upgrade-rehearsal.sh
+++ b/app/contract/scripts/testnet-upgrade-rehearsal.sh
@@ -38,6 +38,12 @@ else
   WASM_SHA="$(sha256sum "$WASM_PATH" | awk '{print $1}')"
 fi
 
+if [[ -f "$WASM_PATH" ]] && command -v "$STELLAR_BIN" >/dev/null 2>&1; then
+  echo "==> Exporting contract spec for this testnet build"
+  WASM_PATH="$WASM_PATH" OUT_PATH="$OUT_DIR/contract-spec.json" SKIP_BUILD=1 STELLAR_BIN="$STELLAR_BIN" \
+    "$ROOT_DIR/scripts/export-contract-spec.sh"
+fi
+
 BEFORE_METADATA='{}'
 AFTER_METADATA='{}'
 HEALTH='unknown'
@@ -77,6 +83,7 @@ manifest={
   "operator": source or None,
   "target_version": int(new_version) if new_version else None,
   "wasm": {"path": wasm_path, "sha256": wasm_sha or None},
+  "contract_spec": str(out/'contract-spec.json') if (out/'contract-spec.json').exists() else None,
   "checks": {
     "local_upgrade_tests": True,
     "health_check": health,


### PR DESCRIPTION
## Summary
- Adds `scripts/export-contract-spec.sh`, which builds the contract and exports its method/argument interface (via `stellar contract info interface`) plus `contract_version` and `event_schema_version` into a stable JSON artifact (`docs/contract-spec/contract-spec.json`).
- Adds `scripts/test-contract-spec-export.sh`, which runs the export twice and verifies the output is stable across repeat builds and contains all required fields (completeness).
- Wires the export into `scripts/testnet-upgrade-rehearsal.sh` so the spec artifact is produced as part of the testnet deploy workflow.

## Test plan
- [x] `./scripts/export-contract-spec.sh` produces `docs/contract-spec/contract-spec.json` with `contract_version`, `event_schema_version`, and the full function interface.
- [x] `./scripts/test-contract-spec-export.sh` passes, confirming stability across repeat builds and completeness of required fields.
- [x] `cargo test` (existing suite) still passes — no contract source changes.

Closes #563