### PR TITLE
feat(backend): testnet rate-limit allowlist + abuse-control observability (BE-48)

### DIFF
--- a/app/backend/src/auth/guards/custom-throttler.guard.ts
+++ b/app/backend/src/auth/guards/custom-throttler.guard.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, Injectable, Inject } from "@nestjs/common";
+import { ExecutionContext, Injectable, Inject, Logger } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import {
   ThrottlerException,
@@ -7,12 +7,16 @@ import {
 } from "@nestjs/throttler";
 import {
   RATE_LIMIT_GROUP_METADATA_KEY,
+  RateLimitAllowlist,
   RateLimitGroup,
   RateLimitKeyType,
+  rateLimitAllowlist,
   THROTTLER_BURST_NAME,
   throttlerConfig,
 } from "../../config/rate-limit.config";
 import { MetricsService } from "../../metrics/metrics.service";
+
+type AllowlistMatch = { matchedBy: "ip" | "api_key" } | { matchedBy: null };
 
 type RequestWithRateLimitContext = Record<string, unknown> & {
   headers?: Record<string, string | string[] | undefined>;
@@ -28,6 +32,8 @@ type RequestWithRateLimitContext = Record<string, unknown> & {
     group: RateLimitGroup;
     keyType: RateLimitKeyType;
   };
+  /** Set once an allowlist bypass has been audited, to avoid double-logging. */
+  rateLimitAllowlistAudited?: boolean;
 };
 
 @Injectable()
@@ -37,6 +43,8 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
 
   protected readonly reflector = new Reflector();
 
+  private readonly logger = new Logger(CustomThrottlerGuard.name);
+
   protected async handleRequest(
     requestProps: ThrottlerRequest,
   ): Promise<boolean> {
@@ -44,6 +52,15 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     const req = context
       .switchToHttp()
       .getRequest<RequestWithRateLimitContext>();
+
+    // Allowlisted callers (CI and trusted contributors on testnet) bypass
+    // throttling entirely. Every bypass is logged and metered so the allowlist
+    // stays auditable.
+    const allowlistMatch = this.matchAllowlist(req);
+    if (allowlistMatch.matchedBy !== null) {
+      this.auditAllowlistBypass(req, allowlistMatch.matchedBy);
+      return true;
+    }
 
     const group = this.resolveGroup(context, req);
     const window =
@@ -78,13 +95,20 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
         }
 
         const method = req.method ?? "unknown";
-        const routePath = req.route?.path ?? req.path ?? req.originalUrl ?? "unknown";
-        
+        const routePath =
+          req.route?.path ?? req.path ?? req.originalUrl ?? "unknown";
+        const keyType = req.rateLimitContext.keyType;
+
         this.metricsService.recordRateLimitedRequest(
           method,
           routePath,
           group,
-          req.rateLimitContext.keyType,
+          keyType,
+        );
+
+        this.logger.warn(
+          `Rate limit exceeded: ${method} ${routePath} ` +
+            `[group=${group} key_type=${keyType} retry_after=${retryAfterSeconds}s]`,
         );
       }
 
@@ -180,5 +204,71 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     }
 
     return req.ip ?? "unknown";
+  }
+
+  /**
+   * Resolves the active allowlist. Indirection keeps the guard testable without
+   * mutating process state.
+   */
+  protected getAllowlist(): RateLimitAllowlist {
+    return rateLimitAllowlist;
+  }
+
+  /**
+   * Returns how the request matched the allowlist, if at all. API keys are
+   * checked before IPs so a trusted token wins over a shared egress IP.
+   */
+  private matchAllowlist(req: RequestWithRateLimitContext): AllowlistMatch {
+    const allowlist = this.getAllowlist();
+
+    const apiKey = this.getApiKeyValue(req);
+    if (apiKey && allowlist.apiKeys.includes(apiKey)) {
+      return { matchedBy: "api_key" };
+    }
+
+    const ip = this.getIp(req);
+    if (ip && ip !== "unknown" && allowlist.ips.includes(ip)) {
+      return { matchedBy: "ip" };
+    }
+
+    return { matchedBy: null };
+  }
+
+  /** Logs and meters an allowlist bypass exactly once per request. */
+  private auditAllowlistBypass(
+    req: RequestWithRateLimitContext,
+    matchedBy: "ip" | "api_key",
+  ): void {
+    if (req.rateLimitAllowlistAudited) {
+      return;
+    }
+    req.rateLimitAllowlistAudited = true;
+
+    const method = req.method ?? "unknown";
+    const routePath =
+      req.route?.path ?? req.path ?? req.originalUrl ?? "unknown";
+
+    this.metricsService.recordRateLimitAllowlistBypass(
+      method,
+      routePath,
+      matchedBy,
+    );
+
+    const principal =
+      matchedBy === "api_key"
+        ? `api_key=${this.redactSecret(this.getApiKeyValue(req))}`
+        : `ip=${this.getIp(req)}`;
+
+    this.logger.log(
+      `Rate limit bypassed via allowlist: ${method} ${routePath} ` +
+        `[matched_by=${matchedBy} ${principal}]`,
+    );
+  }
+
+  /** Redacts a secret for safe logging, keeping only a short identifying prefix. */
+  private redactSecret(value?: string): string {
+    if (!value) return "unknown";
+    if (value.length <= 4) return "****";
+    return `${value.slice(0, 4)}****`;
   }
 }

--- a/app/backend/src/auth/guards/custom-throttler.guard.unit.spec.ts
+++ b/app/backend/src/auth/guards/custom-throttler.guard.unit.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from "@nestjs/common";
+import { ExecutionContext, Logger } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import {
   ThrottlerException,
@@ -9,6 +9,7 @@ import {
 import { CustomThrottlerGuard } from "./custom-throttler.guard";
 import {
   RATE_LIMIT_GROUP_METADATA_KEY,
+  RateLimitAllowlist,
   THROTTLER_BURST_NAME,
   THROTTLER_SUSTAINED_NAME,
   throttlerConfig,
@@ -29,6 +30,7 @@ type ReqShape = {
 interface GuardSurface {
   handleRequest(requestProps: ThrottlerRequest): Promise<boolean>;
   getTracker(req: ReqShape): Promise<string>;
+  getAllowlist(): RateLimitAllowlist;
 }
 
 function buildContext(
@@ -66,10 +68,13 @@ function buildProps(
 
 const throttlerProto = ThrottlerGuard.prototype as unknown as GuardSurface;
 
+const EMPTY_ALLOWLIST: RateLimitAllowlist = { ips: [], apiKeys: [] };
+
 describe("CustomThrottlerGuard", () => {
   let guard: GuardSurface;
   let superHandleRequest: jest.SpyInstance;
   let metricsServiceRecordMock: jest.Mock;
+  let metricsServiceBypassMock: jest.Mock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -93,13 +98,20 @@ describe("CustomThrottlerGuard", () => {
           provide: MetricsService,
           useValue: {
             recordRateLimitedRequest: jest.fn(),
+            recordRateLimitAllowlistBypass: jest.fn(),
           },
         },
       ],
     }).compile();
 
     guard = module.get(CustomThrottlerGuard) as unknown as GuardSurface;
-    metricsServiceRecordMock = module.get(MetricsService).recordRateLimitedRequest as jest.Mock;
+    const metrics = module.get(MetricsService);
+    metricsServiceRecordMock = metrics.recordRateLimitedRequest as jest.Mock;
+    metricsServiceBypassMock =
+      metrics.recordRateLimitAllowlistBypass as jest.Mock;
+
+    // Default: no allowlist entries unless a test overrides this.
+    jest.spyOn(guard, "getAllowlist").mockReturnValue(EMPTY_ALLOWLIST);
 
     superHandleRequest = jest
       .spyOn(throttlerProto, "handleRequest")
@@ -212,6 +224,119 @@ describe("CustomThrottlerGuard", () => {
       "public",
       "ip",
     );
+  });
+
+  it("logs a warning when a request is throttled", async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, "warn");
+
+    const context = buildContext({
+      ip: "127.0.0.1",
+      baseUrl: "/links",
+      route: { path: "/metadata" },
+      method: "GET",
+    });
+    const props = buildProps(context, THROTTLER_BURST_NAME);
+
+    superHandleRequest.mockRejectedValueOnce(new ThrottlerException());
+
+    await expect(guard.handleRequest(props)).rejects.toBeInstanceOf(
+      ThrottlerException,
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("Rate limit exceeded");
+    expect(warnSpy.mock.calls[0][0]).toContain("GET /metadata");
+  });
+
+  it("bypasses throttling for an allowlisted IP", async () => {
+    (guard.getAllowlist as jest.Mock).mockReturnValue({
+      ips: ["203.0.113.7"],
+      apiKeys: [],
+    });
+
+    const context = buildContext({
+      ip: "203.0.113.7",
+      baseUrl: "/stellar",
+      route: { path: "/quote" },
+      method: "POST",
+    });
+    const props = buildProps(context, THROTTLER_BURST_NAME);
+
+    const result = await guard.handleRequest(props);
+
+    expect(result).toBe(true);
+    expect(superHandleRequest).not.toHaveBeenCalled();
+    expect(metricsServiceBypassMock).toHaveBeenCalledWith(
+      "POST",
+      "/quote",
+      "ip",
+    );
+  });
+
+  it("bypasses throttling for an allowlisted API key", async () => {
+    (guard.getAllowlist as jest.Mock).mockReturnValue({
+      ips: [],
+      apiKeys: ["ci-bypass-token"],
+    });
+
+    const context = buildContext({
+      headers: { "x-api-key": "ci-bypass-token" },
+      ip: "198.51.100.4",
+      baseUrl: "/links",
+      route: { path: "/scan" },
+      method: "POST",
+    });
+    const props = buildProps(context, THROTTLER_BURST_NAME);
+
+    const result = await guard.handleRequest(props);
+
+    expect(result).toBe(true);
+    expect(superHandleRequest).not.toHaveBeenCalled();
+    expect(metricsServiceBypassMock).toHaveBeenCalledWith(
+      "POST",
+      "/scan",
+      "api_key",
+    );
+  });
+
+  it("does not bypass throttling for a non-allowlisted identity", async () => {
+    (guard.getAllowlist as jest.Mock).mockReturnValue({
+      ips: ["203.0.113.7"],
+      apiKeys: ["ci-bypass-token"],
+    });
+
+    const context = buildContext({
+      ip: "10.0.0.1",
+      baseUrl: "/links",
+      route: { path: "/scan" },
+      method: "POST",
+    });
+    const props = buildProps(context, THROTTLER_BURST_NAME);
+
+    await guard.handleRequest(props);
+
+    expect(superHandleRequest).toHaveBeenCalledTimes(1);
+    expect(metricsServiceBypassMock).not.toHaveBeenCalled();
+  });
+
+  it("audits an allowlist bypass only once across burst and sustained windows", async () => {
+    (guard.getAllowlist as jest.Mock).mockReturnValue({
+      ips: ["203.0.113.7"],
+      apiKeys: [],
+    });
+
+    const req = {
+      ip: "203.0.113.7",
+      baseUrl: "/stellar",
+      route: { path: "/quote" },
+      method: "POST",
+    };
+    const context = buildContext(req);
+
+    await guard.handleRequest(buildProps(context, THROTTLER_BURST_NAME));
+    await guard.handleRequest(buildProps(context, THROTTLER_SUSTAINED_NAME));
+
+    expect(metricsServiceBypassMock).toHaveBeenCalledTimes(1);
   });
 
   it("builds tracker from user id when available", async () => {

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -261,6 +261,21 @@ export const envSchema = Joi.object({
       "Preferred key order for rate-limit identity. Allowed values: user_id,api_key,ip",
     ),
 
+  RATE_LIMIT_ALLOWLIST_IPS: Joi.string()
+    .empty("")
+    .optional()
+    .description(
+      "Comma-separated client IPs that bypass rate limiting entirely. " +
+        "Intended for CI and trusted contributors on testnet. Matched exactly.",
+    ),
+  RATE_LIMIT_ALLOWLIST_API_KEYS: Joi.string()
+    .empty("")
+    .optional()
+    .description(
+      "Comma-separated x-api-key values that bypass rate limiting entirely. " +
+        "Treat as shared testnet bypass tokens; every use is logged.",
+    ),
+
   // ---------------------------------------------------------------------------
   // Sentry Error Monitoring (optional; omit to disable)
   // ---------------------------------------------------------------------------
@@ -403,6 +418,8 @@ export interface EnvConfig {
   RATE_LIMIT_WEBHOOKS_SUSTAINED_LIMIT: number;
   RATE_LIMIT_WEBHOOKS_SUSTAINED_TTL_MS: number;
   RATE_LIMIT_KEY_ORDER: string;
+  RATE_LIMIT_ALLOWLIST_IPS?: string;
+  RATE_LIMIT_ALLOWLIST_API_KEYS?: string;
   SENTRY_DSN?: string;
   SENTRY_ENVIRONMENT?: string;
   SENTRY_RELEASE?: string;

--- a/app/backend/src/config/rate-limit.config.ts
+++ b/app/backend/src/config/rate-limit.config.ts
@@ -21,7 +21,32 @@ export type RateLimitConfig = {
   keyOrder: RateLimitKeyType[];
 };
 
+/**
+ * Identities that bypass rate limiting entirely. Intended for testnet so CI
+ * jobs and trusted contributors are not throttled while exercising the public
+ * API. Matching is exact (no wildcards/CIDR) to keep the bypass surface small
+ * and auditable.
+ */
+export type RateLimitAllowlist = {
+  /** Client IPs, matched exactly against the resolved request IP. */
+  ips: string[];
+  /**
+   * API-key identifiers, matched exactly against the `x-api-key` header (or a
+   * resolved `apiKey.id`). On testnet these act as shared bypass tokens.
+   */
+  apiKeys: string[];
+};
+
 const DEFAULT_KEY_ORDER: RateLimitKeyType[] = ["user_id", "api_key", "ip"];
+
+function parseCsvList(raw?: string): string[] {
+  if (!raw) return [];
+
+  return raw
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
 
 function parseKeyOrder(raw?: string): RateLimitKeyType[] {
   if (!raw) return DEFAULT_KEY_ORDER;
@@ -37,6 +62,19 @@ function parseKeyOrder(raw?: string): RateLimitKeyType[] {
   );
 
   return ordered.length > 0 ? ordered : DEFAULT_KEY_ORDER;
+}
+
+/**
+ * Builds the rate-limit allowlist from the environment. Exposed as a pure
+ * function so it can be unit-tested without mutating process state.
+ */
+export function parseRateLimitAllowlist(
+  env: NodeJS.ProcessEnv = process.env,
+): RateLimitAllowlist {
+  return {
+    ips: parseCsvList(env["RATE_LIMIT_ALLOWLIST_IPS"]),
+    apiKeys: parseCsvList(env["RATE_LIMIT_ALLOWLIST_API_KEYS"]),
+  };
 }
 
 export const throttlerConfig: RateLimitConfig = {
@@ -88,6 +126,9 @@ export const throttlerConfig: RateLimitConfig = {
   },
   keyOrder: parseKeyOrder(process.env["RATE_LIMIT_KEY_ORDER"]),
 };
+
+export const rateLimitAllowlist: RateLimitAllowlist =
+  parseRateLimitAllowlist();
 
 export const throttlerModuleProfiles = [
   {

--- a/app/backend/src/config/rate-limit.config.unit.spec.ts
+++ b/app/backend/src/config/rate-limit.config.unit.spec.ts
@@ -1,0 +1,38 @@
+import { parseRateLimitAllowlist } from "./rate-limit.config";
+
+describe("parseRateLimitAllowlist", () => {
+  it("returns empty lists when the env vars are unset", () => {
+    const allowlist = parseRateLimitAllowlist({});
+
+    expect(allowlist).toEqual({ ips: [], apiKeys: [] });
+  });
+
+  it("parses comma-separated IPs and API keys", () => {
+    const allowlist = parseRateLimitAllowlist({
+      RATE_LIMIT_ALLOWLIST_IPS: "203.0.113.7,198.51.100.4",
+      RATE_LIMIT_ALLOWLIST_API_KEYS: "ci-token,contributor-token",
+    });
+
+    expect(allowlist.ips).toEqual(["203.0.113.7", "198.51.100.4"]);
+    expect(allowlist.apiKeys).toEqual(["ci-token", "contributor-token"]);
+  });
+
+  it("trims whitespace and drops empty entries", () => {
+    const allowlist = parseRateLimitAllowlist({
+      RATE_LIMIT_ALLOWLIST_IPS: " 203.0.113.7 , , 198.51.100.4 ,",
+      RATE_LIMIT_ALLOWLIST_API_KEYS: "  ci-token ,",
+    });
+
+    expect(allowlist.ips).toEqual(["203.0.113.7", "198.51.100.4"]);
+    expect(allowlist.apiKeys).toEqual(["ci-token"]);
+  });
+
+  it("treats empty strings as no allowlist", () => {
+    const allowlist = parseRateLimitAllowlist({
+      RATE_LIMIT_ALLOWLIST_IPS: "",
+      RATE_LIMIT_ALLOWLIST_API_KEYS: "",
+    });
+
+    expect(allowlist).toEqual({ ips: [], apiKeys: [] });
+  });
+});

--- a/app/backend/src/metrics/metrics.service.ts
+++ b/app/backend/src/metrics/metrics.service.ts
@@ -7,6 +7,7 @@ export class MetricsService implements OnModuleInit {
   private httpRequestDuration: client.Histogram<string>;
   private httpRequestTotal: client.Counter<string>;
   private rateLimitedRequestsTotal: client.Counter<string>;
+  private rateLimitAllowlistBypassTotal: client.Counter<string>;
   private activeConnections: client.Gauge<string>;
   private ingestionLagSeconds: client.Gauge<string>;
   private webhookRetryTotal: client.Counter<string>;
@@ -46,6 +47,12 @@ export class MetricsService implements OnModuleInit {
         name: "http_rate_limited_requests_total",
         help: "Total number of requests blocked by rate limiting",
         labelNames: ["method", "route", "group", "key_type"],
+      });
+
+      this.rateLimitAllowlistBypassTotal = new client.Counter({
+        name: "http_rate_limit_allowlist_bypass_total",
+        help: "Total number of requests that bypassed rate limiting via the allowlist",
+        labelNames: ["method", "route", "matched_by"],
       });
 
       this.activeConnections = new client.Gauge({
@@ -134,6 +141,7 @@ export class MetricsService implements OnModuleInit {
       this.register.registerMetric(this.httpRequestDuration);
       this.register.registerMetric(this.httpRequestTotal);
       this.register.registerMetric(this.rateLimitedRequestsTotal);
+      this.register.registerMetric(this.rateLimitAllowlistBypassTotal);
       this.register.registerMetric(this.activeConnections);
       this.register.registerMetric(this.ingestionLagSeconds);
       this.register.registerMetric(this.webhookRetryTotal);
@@ -214,6 +222,22 @@ export class MetricsService implements OnModuleInit {
 
     try {
       this.rateLimitedRequestsTotal.labels(method, route, group, keyType).inc();
+    } catch (error) {}
+  }
+
+  recordRateLimitAllowlistBypass(
+    method: string,
+    route: string,
+    matchedBy: string,
+  ) {
+    if (!this.initialized || !this.rateLimitAllowlistBypassTotal) {
+      return;
+    }
+
+    try {
+      this.rateLimitAllowlistBypassTotal
+        .labels(method, route, matchedBy)
+        .inc();
     } catch (error) {}
   }
 

--- a/app/backend/src/metrics/metrics.service.unit.spec.ts
+++ b/app/backend/src/metrics/metrics.service.unit.spec.ts
@@ -140,7 +140,13 @@ describe("MetricsService", () => {
         labelNames: ["service", "error_type"],
       });
 
-      expect(mockRegistry.registerMetric).toHaveBeenCalledTimes(14);
+      expect(client.Counter).toHaveBeenCalledWith({
+        name: "http_rate_limit_allowlist_bypass_total",
+        help: "Total number of requests that bypassed rate limiting via the allowlist",
+        labelNames: ["method", "route", "matched_by"],
+      });
+
+      expect(mockRegistry.registerMetric).toHaveBeenCalledTimes(18);
     });
 
     it("should handle initialization errors gracefully", () => {
@@ -392,6 +398,26 @@ describe("MetricsService", () => {
         "public",
         "ip",
       );
+      expect(mockRateLimitedCounter.labels).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recordRateLimitAllowlistBypass", () => {
+    it("should record allowlist bypasses when initialized", () => {
+      service.onModuleInit();
+
+      service.recordRateLimitAllowlistBypass("POST", "/stellar/quote", "ip");
+
+      expect(mockRateLimitedCounter.labels).toHaveBeenCalledWith(
+        "POST",
+        "/stellar/quote",
+        "ip",
+      );
+      expect(mockRateLimitedCounter.inc).toHaveBeenCalled();
+    });
+
+    it("should be a no-op when service is not initialized", () => {
+      service.recordRateLimitAllowlistBypass("POST", "/stellar/quote", "ip");
       expect(mockRateLimitedCounter.labels).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary

Implements **BE-48 (#507)** — testnet-focused abuse protection so contributor testing and public demos don't exhaust API/RPC resources.

The backend already ships a `CustomThrottlerGuard` with per-group (public / authenticated / webhooks) burst + sustained limits, per-IP / per-API-key / per-user identity tracking, `Retry-After` headers, and a `http_rate_limited_requests_total` metric. This PR closes the two gaps the issue calls out: a **trusted allowlist** and **logging/observability for blocked + bypassed requests**.

## What changed

- **Allowlist for CI & trusted contributors** — two new optional env vars let allowlisted callers bypass throttling entirely on testnet:
  - `RATE_LIMIT_ALLOWLIST_IPS` — comma-separated client IPs
  - `RATE_LIMIT_ALLOWLIST_API_KEYS` — comma-separated `x-api-key` bypass tokens
  
  Matching is **exact** (no wildcards/CIDR) to keep the bypass surface small and auditable. Defaults to empty (no bypass) when unset.
- **Auditable & safe** — every allowlist bypass is logged (api-key values **redacted** to a 4-char prefix) and exported as a new `http_rate_limit_allowlist_bypass_total{method,route,matched_by}` counter. Auditing fires once per request (deduped across the burst/sustained windows).
- **Logs for blocked requests** — throttled (429) requests now emit a `Logger.warn` alongside the existing metric, so operators can observe throttling in logs as well as metrics.

## Endpoints

The public endpoints named in the issue — `POST /stellar/quote` (+ `GET /stellar/quote/:id`), `GET /assets` (asset metadata), `POST /links/scan` — are already covered by the global `CustomThrottlerGuard`. They keep the existing public-by-default / higher-with-API-key grouping; this PR adds the allowlist + observability layer on top globally rather than per-route, so the behaviour is uniform.

## Acceptance criteria

- [x] Abuse patterns are throttled without breaking normal contributor workflows (existing limits unchanged; allowlist only *relaxes* for trusted callers)
- [x] Operators can observe throttling in metrics (`http_rate_limited_requests_total`) **and** logs (new warn) + allowlist usage (`http_rate_limit_allowlist_bypass_total`)
- [x] Trusted allowlist paths are audited and safe (exact match, empty by default, every bypass logged + metered, secrets redacted)

## Testing

All run locally against `app/backend`:

- `pnpm run lint` — clean
- `pnpm run build` (`nest build`) — clean
- `pnpm run test:unit` (touched suites) — green:
  - `custom-throttler.guard.unit.spec.ts` — added allowlist-bypass (IP + API key), non-allowlisted, once-only-audit, and block-logging cases
  - `rate-limit.config.unit.spec.ts` — new: allowlist env parsing
  - `metrics.service.unit.spec.ts` — added the new counter (also corrected the registration-count assertion, which was stale)

Closes #507