### PR TITLE
Feat/be event replay dashboard

### DIFF
--- a/app/backend/src/ingestion/soroban-event-indexer.service.ts
+++ b/app/backend/src/ingestion/soroban-event-indexer.service.ts
@@ -10,7 +10,7 @@ import { EscrowEventRepository } from "./escrow-event.repository";
 import { PrivacyEventRepository } from "./privacy-event.repository";
 import { AdminEventRepository } from "./admin-event.repository";
 import { StealthEventRepository } from "./stealth-event.repository";
-import { UnparsedSorobanEventRepository } from "./unparsed-soroban-event.repository";
+import { UnparsedSorobanEventRepository, UnparsedSorobanEventReason, UnparsedSorobanEventRecord } from "./unparsed-soroban-event.repository";
 import type {
   QuickExContractEvent,
   EscrowEvent,
@@ -309,16 +309,54 @@ export class SorobanEventIndexerService {
     }
   }
 
-  async listUnparsedEvents(limit = 100) {
-    return this.unparsedRepo.listPending(limit);
+  async listUnparsedEvents(
+    limit = 100,
+    filters?: {
+      contractId?: string;
+      schemaVersion?: number;
+      errorType?: UnparsedSorobanEventReason;
+    },
+  ) {
+    return this.unparsedRepo.listPending(limit, filters);
   }
 
   async replayUnparsedEvents(limit = 100): Promise<ReplayUnparsedResult> {
     const pending = await this.unparsedRepo.listPending(limit);
+    return this.replayBatch(pending);
+  }
+
+  async replaySingleEvent(pagingToken: string): Promise<{ success: boolean; message: string }> {
+    const record = await this.unparsedRepo.getByPagingToken(pagingToken);
+    if (!record) {
+      return { success: false, message: "Event not found" };
+    }
+    if (record.status === "replayed") {
+      return { success: false, message: "Event already replayed" };
+    }
+
+    const result = await this.replayBatch([record]);
+    if (result.replayed === 1) {
+      return { success: true, message: "Event successfully replayed" };
+    }
+    return { success: false, message: "Event failed to replay" };
+  }
+
+  async replaySpecificBatch(pagingTokens: string[]): Promise<ReplayUnparsedResult> {
+    const records: UnparsedSorobanEventRecord[] = [];
+    for (const token of pagingTokens) {
+      const record = await this.unparsedRepo.getByPagingToken(token);
+      if (record && record.status === "pending") {
+        records.push(record);
+      }
+    }
+    return this.replayBatch(records);
+  }
+
+  async replayBatch(records: UnparsedSorobanEventRecord[]): Promise<ReplayUnparsedResult> {
     let replayed = 0;
     let stillUnparsed = 0;
 
-    for (const record of pending) {
+    for (const record of records) {
       const event = this.parser.parse(record.raw);
       if (event) {
         try {
@@ -342,7 +380,7 @@ export class SorobanEventIndexerService {
       }
     }
 
-    return { attempted: pending.length, replayed, stillUnparsed };
+    return { attempted: records.length, replayed, stillUnparsed };
   }
 
   private async captureUnparsedEvent(

--- a/app/backend/src/ingestion/soroban-indexer.controller.ts
+++ b/app/backend/src/ingestion/soroban-indexer.controller.ts
@@ -6,13 +6,14 @@ import {
   HttpCode,
   HttpStatus,
   Post,
+  Param,
   Query,
 } from "@nestjs/common";
 import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
-import { IsBoolean, IsInt, IsNotEmpty, IsOptional, IsString, Min } from "class-validator";
+import { IsBoolean, IsInt, IsNotEmpty, IsOptional, IsString, Min, IsArray } from "class-validator";
 
 import { SorobanEventIndexerService, LedgerRangeResult } from "./soroban-event-indexer.service";
-import type { UnparsedSorobanEventRecord } from "./unparsed-soroban-event.repository";
+import type { UnparsedSorobanEventRecord, UnparsedSorobanEventReason } from "./unparsed-soroban-event.repository";
 
 class ReindexDto {
   @IsString()
@@ -34,6 +35,12 @@ class ReindexDto {
   @IsBoolean()
   @IsOptional()
   force?: boolean;
+}
+
+class ReplayBatchDto {
+  @IsArray()
+  @IsString({ each: true })
+  pagingTokens!: string[];
 }
 
 /**
@@ -79,26 +86,58 @@ export class SorobanIndexerController {
 
   @Get("unparsed-events")
   @ApiOperation({
-    summary: "List pending unparsed Soroban events",
+    summary: "List pending unparsed Soroban events with filters",
     description:
-      "Returns raw contract events retained because their schema version was unknown or parsing failed.",
+      "Returns raw contract events retained because their schema version was unknown or parsing failed. " +
+      "Filter by contractId, schemaVersion, and errorType (unknown_schema_version or parse_failure).",
   })
   @ApiResponse({ status: 200, description: "Pending unparsed events" })
   listUnparsed(
     @Query("limit") limit?: string,
+    @Query("contractId") contractId?: string,
+    @Query("schemaVersion") schemaVersion?: string,
+    @Query("errorType") errorType?: UnparsedSorobanEventReason,
   ): Promise<UnparsedSorobanEventRecord[]> {
-    return this.indexer.listUnparsedEvents(Number(limit ?? 100));
+    return this.indexer.listUnparsedEvents(Number(limit ?? 100), {
+      contractId,
+      schemaVersion: schemaVersion ? Number(schemaVersion) : undefined,
+      errorType,
+    });
   }
 
   @Post("unparsed-events/replay")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: "Replay pending unparsed Soroban events",
+    summary: "Replay pending unparsed Soroban events (batch by limit)",
     description:
       "Attempts to parse and persist retained raw events after schema support has been updated.",
   })
   @ApiResponse({ status: 200, description: "Replay completed" })
   replayUnparsed(@Query("limit") limit?: string) {
     return this.indexer.replayUnparsedEvents(Number(limit ?? 100));
+  }
+
+  @Post("unparsed-events/:pagingToken/replay")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Replay a single specific unparsed Soroban event",
+    description:
+      "Attempts to parse and persist a single retained raw event after schema support has been updated.",
+  })
+  @ApiResponse({ status: 200, description: "Replay result" })
+  replaySingle(@Param("pagingToken") pagingToken: string) {
+    return this.indexer.replaySingleEvent(pagingToken);
+  }
+
+  @Post("unparsed-events/replay/batch")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Replay a specific batch of unparsed Soroban events",
+    description:
+      "Attempts to parse and persist a specific list of retained raw events by their paging tokens.",
+  })
+  @ApiResponse({ status: 200, description: "Replay completed" })
+  async replaySpecificBatch(@Body() dto: ReplayBatchDto) {
+    return this.indexer.replaySpecificBatch(dto.pagingTokens);
   }
 }

--- a/app/backend/src/ingestion/unparsed-soroban-event.repository.ts
+++ b/app/backend/src/ingestion/unparsed-soroban-event.repository.ts
@@ -22,6 +22,7 @@ export interface UnparsedSorobanEventRecord
   ledger: number;
   transactionHash: string;
   attempts: number;
+  status: "pending" | "replayed";
 }
 
 @Injectable()
@@ -60,14 +61,33 @@ export class UnparsedSorobanEventRepository {
     }
   }
 
-  async listPending(limit = 100): Promise<UnparsedSorobanEventRecord[]> {
-    const { data, error } = await this.supabase
+  async listPending(
+    limit = 100,
+    filters?: {
+      contractId?: string;
+      schemaVersion?: number;
+      errorType?: UnparsedSorobanEventReason;
+    },
+  ): Promise<UnparsedSorobanEventRecord[]> {
+    let query = this.supabase
       .getClient()
       .from("unparsed_soroban_events")
       .select("*")
       .eq("status", "pending")
       .order("ledger", { ascending: true })
       .limit(limit);
+
+    if (filters?.contractId) {
+      query = query.eq("contract_id", filters.contractId);
+    }
+    if (filters?.schemaVersion !== undefined) {
+      query = query.eq("schema_version", filters.schemaVersion);
+    }
+    if (filters?.errorType) {
+      query = query.eq("reason", filters.errorType);
+    }
+
+    const { data, error } = await query;
 
     if (error) {
       this.logger.error(`Failed to list unparsed Soroban events: ${error.message}`);
@@ -88,6 +108,7 @@ export class UnparsedSorobanEventRepository {
       ledger: Number(row.ledger),
       transactionHash: String(row.transaction_hash),
       attempts: Number(row.attempts ?? 0),
+      status: row.status as "pending" | "replayed",
     }));
   }
 
@@ -95,7 +116,20 @@ export class UnparsedSorobanEventRepository {
     await this.updateStatus(pagingToken, "replayed");
   }
 
+  private async incrementAttempts(pagingToken: string): Promise<number> {
+    const current = await this.getByPagingToken(pagingToken);
+    if (!current) return 0;
+    const newAttempts = current.attempts + 1;
+    await this.supabase
+      .getClient()
+      .from("unparsed_soroban_events")
+      .update({ attempts: newAttempts })
+      .eq("paging_token", pagingToken);
+    return newAttempts;
+  }
+
   async markFailed(pagingToken: string, errorMessage: string): Promise<void> {
+    await this.incrementAttempts(pagingToken);
     const { error } = await this.supabase
       .getClient()
       .from("unparsed_soroban_events")
@@ -109,11 +143,47 @@ export class UnparsedSorobanEventRepository {
     if (error) throw error;
   }
 
+  async getByPagingToken(pagingToken: string): Promise<UnparsedSorobanEventRecord | null> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from("unparsed_soroban_events")
+      .select("*")
+      .eq("paging_token", pagingToken)
+      .single();
+
+    if (error) {
+      if (error.code === "PGRST116") return null; // No rows returned
+      this.logger.error(`Failed to get unparsed event: ${error.message}`);
+      throw error;
+    }
+
+    return {
+      raw: data.raw_event as RawHorizonContractEvent,
+      reason: data.reason as UnparsedSorobanEventReason,
+      eventName: (data.event_name as string | null) ?? null,
+      schemaVersion:
+        data.schema_version === null || data.schema_version === undefined
+          ? null
+          : Number(data.schema_version),
+      errorMessage: (data.error_message as string | null) ?? null,
+      pagingToken: String(data.paging_token),
+      contractId: String(data.contract_id),
+      ledger: Number(data.ledger),
+      transactionHash: String(data.transaction_hash),
+      attempts: Number(data.attempts ?? 0),
+      status: data.status as "pending" | "replayed",
+    };
+  }
+
   private async updateStatus(pagingToken: string, status: string): Promise<void> {
+    await this.incrementAttempts(pagingToken);
     const { error } = await this.supabase
       .getClient()
       .from("unparsed_soroban_events")
-      .update({ status, updated_at: new Date().toISOString() })
+      .update({ 
+        status,
+        updated_at: new Date().toISOString() 
+      })
       .eq("paging_token", pagingToken);
 
     if (error) throw error;

--- a/app/backend/src/job-queue/job-admin.controller.ts
+++ b/app/backend/src/job-queue/job-admin.controller.ts
@@ -24,6 +24,7 @@ import {
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { JobQueueService } from './job-queue.service';
 import { JobRepository, JobFilters } from './job.repository';
+import { JobReplayRepository } from './job-replay.repository';
 import { JobType, JobStatus, Job } from './types';
 import { ApiKeyGuard } from '../auth/guards/api-key.guard';
 import { RequireScopes } from '../auth/decorators/require-scopes.decorator';
@@ -78,6 +79,7 @@ export class JobAdminController {
   constructor(
     private readonly jobQueueService: JobQueueService,
     private readonly jobRepository: JobRepository,
+    private readonly jobReplayRepository: JobReplayRepository,
   ) {}
 
   /**
@@ -163,6 +165,7 @@ export class JobAdminController {
    * Resets job status to pending, clears failureReason, and sets scheduledAt to now.
    * Rejects retry for completed or cancelled jobs.
    * Preserves original attempts count.
+   * Logs all replays for auditability.
    * 
    * **Validates: Requirements 14.1, 14.2, 14.3, 14.4**
    */
@@ -173,7 +176,7 @@ export class JobAdminController {
   @ApiResponse({ status: 200, description: 'Job retry scheduled' })
   @ApiResponse({ status: 400, description: 'Job cannot be retried' })
   @ApiResponse({ status: 404, description: 'Job not found' })
-  async retryJob(@Param('id') id: string): Promise<{ message: string }> {
+  async retryJob(@Param('id') id: string): Promise<{ message: string; replayLogId: string }> {
     const job = await this.jobQueueService.getJob(id);
 
     if (!job) {
@@ -182,9 +185,33 @@ export class JobAdminController {
 
     // Requirement 14.3: Reject retry for completed or cancelled jobs
     if (job.status === JobStatus.COMPLETED || job.status === JobStatus.CANCELLED) {
+      // Log rejected replay attempt
+      const rejectedLog = await this.jobReplayRepository.createReplayLog({
+        jobId: id,
+        jobType: job.type,
+        status: 'rejected',
+        previousAttempts: job.attempts,
+        reason: `Cannot retry job in ${job.status} status`,
+        triggeredBy: 'api',
+      });
+
       throw new BadRequestException(
         `Cannot retry job in ${job.status} status. Only failed or pending jobs can be retried.`,
       );
+    }
+
+    // Create replay log before updating job status (auditable trail)
+    const replayLog = await this.jobReplayRepository.createReplayLog({
+      jobId: id,
+      jobType: job.type,
+      status: 'queued',
+      previousAttempts: job.attempts,
+      reason: 'Manual replay triggered by operator',
+      triggeredBy: 'api',
+    });
+
+    if (!replayLog) {
+      throw new Error('Failed to create replay audit log');
     }
 
     // Requirement 14.2: Reset status to pending, clear failureReason, set scheduledAt to now
@@ -195,13 +222,17 @@ export class JobAdminController {
       // Note: attempts count is preserved (not reset)
     });
 
-    return { message: `Job ${id} scheduled for retry` };
+    return { 
+      message: `Job ${id} scheduled for retry`,
+      replayLogId: replayLog.id
+    };
   }
 
   /**
    * Bulk retry jobs by type and status
    * 
    * Supports bulk retry for all jobs of a specific type in DLQ (failed status).
+   * Logs all replays for auditability.
    * 
    * **Validates: Requirement 14.5**
    */
@@ -210,7 +241,7 @@ export class JobAdminController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Bulk retry jobs by type' })
   @ApiResponse({ status: 200, description: 'Bulk retry completed' })
-  async bulkRetry(@Body() request: BulkRetryRequestDto): Promise<BulkRetryResponse> {
+  async bulkRetry(@Body() request: BulkRetryRequestDto): Promise<BulkRetryResponse & { replayLogIds: string[] }> {
     const filters: JobFilters = {
       type: request.type,
       status: request.status || JobStatus.FAILED,
@@ -220,10 +251,25 @@ export class JobAdminController {
     const { jobs } = await this.jobQueueService.listJobs(filters);
 
     const retriedJobIds: string[] = [];
+    const replayLogIds: string[] = [];
 
     for (const job of jobs) {
       // Only retry failed jobs (DLQ)
       if (job.status === JobStatus.FAILED) {
+        // Create replay log before updating job status
+        const replayLog = await this.jobReplayRepository.createReplayLog({
+          jobId: job.id,
+          jobType: job.type,
+          status: 'queued',
+          previousAttempts: job.attempts,
+          reason: 'Bulk replay triggered by operator',
+          triggeredBy: 'api',
+        });
+
+        if (replayLog) {
+          replayLogIds.push(replayLog.id);
+        }
+
         await this.jobRepository.updateJobStatus(job.id, JobStatus.PENDING, {
           failureReason: null,
           scheduledAt: new Date(),
@@ -235,7 +281,26 @@ export class JobAdminController {
     return {
       retriedCount: retriedJobIds.length,
       jobIds: retriedJobIds,
+      replayLogIds,
     };
+  }
+
+  /**
+   * Get replay history for a specific job
+   * 
+   * Returns all manual replay attempts for a job, providing full audit trail.
+   */
+  @Get(':id/replays')
+  @RequireScopes('admin')
+  @ApiOperation({ summary: 'Get replay history for a job' })
+  @ApiResponse({ status: 200, description: 'Replay history retrieved' })
+  async getReplayHistory(@Param('id') id: string) {
+    const job = await this.jobQueueService.getJob(id);
+    if (!job) {
+      throw new NotFoundException(`Job not found: ${id}`);
+    }
+
+    return this.jobReplayRepository.getReplayLogsForJob(id);
   }
 
   /**
@@ -305,7 +370,7 @@ export class JobAdminController {
    * Get dead letter queue (DLQ) jobs
    * 
    * Returns jobs where status=failed AND attempts >= maxAttempts.
-   * Supports pagination and filters.
+   * Supports pagination and filters by type, age, and failure reason.
    * 
    * **Validates: Requirement 5.4**
    */
@@ -315,12 +380,18 @@ export class JobAdminController {
   @ApiResponse({ status: 200, description: 'DLQ jobs' })
   async getDeadLetterQueue(
     @Query('type') type?: JobType,
+    @Query('failureReasonContains') failureReasonContains?: string,
+    @Query('createdAfter') createdAfter?: string,
+    @Query('createdBefore') createdBefore?: string,
     @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
     @Query('offset', new ParseIntPipe({ optional: true })) offset?: number,
   ) {
     const filters: JobFilters = {
       type,
       status: JobStatus.FAILED,
+      failureReasonContains,
+      createdAfter: createdAfter ? new Date(createdAfter) : undefined,
+      createdBefore: createdBefore ? new Date(createdBefore) : undefined,
       limit,
       offset,
     };

--- a/app/backend/src/job-queue/job-admin.controller.ts
+++ b/app/backend/src/job-queue/job-admin.controller.ts
@@ -186,7 +186,7 @@ export class JobAdminController {
     // Requirement 14.3: Reject retry for completed or cancelled jobs
     if (job.status === JobStatus.COMPLETED || job.status === JobStatus.CANCELLED) {
       // Log rejected replay attempt
-      const rejectedLog = await this.jobReplayRepository.createReplayLog({
+      await this.jobReplayRepository.createReplayLog({
         jobId: id,
         jobType: job.type,
         status: 'rejected',

--- a/app/backend/src/job-queue/job-queue.module.ts
+++ b/app/backend/src/job-queue/job-queue.module.ts
@@ -8,6 +8,7 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { JobQueueService } from "./job-queue.service";
 import { JobRepository } from "./job.repository";
+import { JobReplayRepository } from "./job-replay.repository";
 import { JobRegistry } from "./job-registry.service";
 import { JobExecutor } from "./job-executor.service";
 import { CancellationStore } from "./cancellation-token";
@@ -63,6 +64,7 @@ import {
   providers: [
     JobQueueService,
     JobRepository,
+    JobReplayRepository,
     JobRegistry,
     JobExecutor,
     CancellationStore,
@@ -78,6 +80,7 @@ import {
     JobQueueService,
     JobRegistry,
     JobRepository,
+    JobReplayRepository,
     JobQueueMetricsService,
     WebhookDeliveryHandler,
     RecurringPaymentHandler,

--- a/app/backend/src/job-queue/job-replay.repository.ts
+++ b/app/backend/src/job-queue/job-replay.repository.ts
@@ -1,0 +1,111 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { SupabaseService } from "../supabase/supabase.service";
+
+export type JobReplayLogStatus =
+  | "queued"
+  | "succeeded"
+  | "failed"
+  | "rejected";
+
+export interface JobReplayLogEntry {
+  id: string;
+  jobId: string;
+  jobType: string;
+  status: JobReplayLogStatus;
+  reason?: string;
+  triggeredBy: string;
+  previousAttempts: number;
+  createdAt: string;
+}
+
+@Injectable()
+export class JobReplayRepository {
+  private readonly logger = new Logger(JobReplayRepository.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async createReplayLog(params: {
+    jobId: string;
+    jobType: string;
+    status: JobReplayLogStatus;
+    previousAttempts: number;
+    reason?: string;
+    triggeredBy?: string;
+  }): Promise<JobReplayLogEntry | null> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from("job_replay_log")
+      .insert({
+        job_id: params.jobId,
+        job_type: params.jobType,
+        status: params.status,
+        previous_attempts: params.previousAttempts,
+        reason: params.reason ?? null,
+        triggered_by: params.triggeredBy ?? "api",
+      })
+      .select(
+        "id, job_id, job_type, status, reason, triggered_by, previous_attempts, created_at",
+      )
+      .single();
+
+    if (error) {
+      this.logger.warn(`Failed to persist job replay log: ${error.message}`);
+      return null;
+    }
+
+    return this.mapRow(data);
+  }
+
+  async updateReplayLog(
+    id: string,
+    updates: {
+      status: JobReplayLogStatus;
+      reason?: string;
+    },
+  ): Promise<void> {
+    const { error } = await this.supabase
+      .getClient()
+      .from("job_replay_log")
+      .update({
+        status: updates.status,
+        reason: updates.reason ?? null,
+      })
+      .eq("id", id);
+
+    if (error) {
+      this.logger.warn(`Failed to update job replay log: ${error.message}`);
+    }
+  }
+
+  async getReplayLogsForJob(jobId: string): Promise<JobReplayLogEntry[]> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from("job_replay_log")
+      .select(
+        "id, job_id, job_type, status, reason, triggered_by, previous_attempts, created_at",
+      )
+      .eq("job_id", jobId)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      this.logger.warn(`Failed to list job replay logs: ${error.message}`);
+      return [];
+    }
+
+    return (data ?? []).map((row) => this.mapRow(row));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private mapRow(row: any): JobReplayLogEntry {
+    return {
+      id: row.id,
+      jobId: row.job_id,
+      jobType: row.job_type,
+      status: row.status as JobReplayLogStatus,
+      reason: row.reason ?? undefined,
+      triggeredBy: row.triggered_by,
+      previousAttempts: row.previous_attempts,
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/app/backend/src/job-queue/job.repository.ts
+++ b/app/backend/src/job-queue/job.repository.ts
@@ -38,6 +38,7 @@ export interface JobFilters {
   status?: JobStatus;
   createdAfter?: Date;
   createdBefore?: Date;
+  failureReasonContains?: string;
   limit?: number;
   offset?: number;
 }
@@ -258,6 +259,9 @@ export class JobRepository {
     }
     if (filters.createdBefore) {
       query = query.lte('created_at', filters.createdBefore.toISOString());
+    }
+    if (filters.failureReasonContains) {
+      query = query.ilike('failure_reason', `%${filters.failureReasonContains}%`);
     }
 
     // Apply pagination and ordering

--- a/app/backend/supabase/migrations/20260630000000_create_job_replay_log.sql
+++ b/app/backend/supabase/migrations/20260630000000_create_job_replay_log.sql
@@ -1,0 +1,19 @@
+-- Create job_replay_log table for tracking manual replays of dead-letter queue jobs
+-- This table maintains an audit trail of all manual replay operations
+
+create table if not exists job_replay_log (
+  id uuid default gen_random_uuid() primary key,
+  job_id uuid not null references jobs(id) on delete cascade,
+  job_type text not null,
+  status text not null check (status in ('queued', 'succeeded', 'failed', 'rejected')),
+  reason text,
+  triggered_by text not null default 'api',
+  previous_attempts integer not null,
+  created_at timestamptz default now() not null
+);
+
+-- Add indexes for efficient querying
+create index if not exists idx_job_replay_log_job_id on job_replay_log(job_id);
+create index if not exists idx_job_replay_log_created_at on job_replay_log(created_at);
+create index if not exists idx_job_replay_log_job_type on job_replay_log(job_type);
+create index if not exists idx_job_replay_log_status on job_replay_log(status);


### PR DESCRIPTION
Closes #547
added comprehensive Dead Letter Queue (DLQ) replay 
APIs for your background job system that meets all your requirements:
built the operator dashboard APIs for viewing, filtering, 
and replaying failed/unparsed Soroban events with all the requested features

Closes #558