### PR TITLE
feat(contract): compact quickex escrow storage (#567)

### DIFF
--- a/app/contract/contracts/quickex/src/bench_test.rs
+++ b/app/contract/contracts/quickex/src/bench_test.rs
@@ -19,7 +19,10 @@
 extern crate std;
 
 use crate::{
-    storage::{put_escrow, DataKey, PRIVACY_ENABLED_KEY},
+    storage::{
+        compact_escrow_storage_footprint_bytes, legacy_escrow_storage_footprint_bytes, put_escrow,
+        DataKey, PRIVACY_ENABLED_KEY,
+    },
     EscrowEntry, EscrowStatus, QuickexContract, QuickexContractClient,
 };
 use soroban_sdk::{
@@ -98,6 +101,13 @@ fn print_budget(env: &Env, label: &str) {
 
 fn legacy_privacy_storage_key(env: &Env, owner: &Address) -> (Symbol, Address) {
     (Symbol::new(env, PRIVACY_ENABLED_KEY), owner.clone())
+}
+
+fn print_storage_delta(label: &str, legacy_bytes: usize, compact_bytes: usize) {
+    let saved = legacy_bytes.saturating_sub(compact_bytes);
+    std::println!(
+        "[bench] {label:<35}  legacy={legacy_bytes:<6} compact={compact_bytes:<6} saved={saved}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -369,4 +379,57 @@ fn bench_resolve_dispute_recipient() {
     env.cost_estimate().budget().reset_default();
     client.resolve_dispute(&arbiter, &commitment, &false, &recipient);
     print_budget(&env, "resolve_dispute_recipient");
+}
+
+/// Benchmark: common escrow storage footprint before/after compaction.
+///
+/// Measures the serialized storage bytes for the typical no-arbiter escrow.
+#[test]
+fn bench_common_escrow_storage_footprint() {
+    let env = Env::default();
+    let commitment: Bytes = Bytes::from_array(&env, &[0x11; 32]);
+    let entry = EscrowEntry {
+        token: Address::generate(&env),
+        amount_due: 1_000_000,
+        amount_paid: 1_000_000,
+        owner: Address::generate(&env),
+        status: EscrowStatus::Pending,
+        created_at: env.ledger().timestamp(),
+        expires_at: 0,
+        arbiter: None,
+        arbiters: Vec::new(&env),
+        arbiter_threshold: 0,
+    };
+
+    let legacy_bytes = legacy_escrow_storage_footprint_bytes(&env, &commitment, &entry);
+    let compact_bytes = compact_escrow_storage_footprint_bytes(&env, &commitment, &entry);
+
+    print_storage_delta("common_escrow_storage", legacy_bytes, compact_bytes);
+    assert!(compact_bytes < legacy_bytes);
+}
+
+/// Benchmark: arbiter escrow storage footprint before/after compaction.
+///
+/// Documents the tradeoff for less-common escrows that opt into dispute config.
+#[test]
+fn bench_arbiter_escrow_storage_footprint() {
+    let env = Env::default();
+    let commitment: Bytes = Bytes::from_array(&env, &[0x22; 32]);
+    let entry = EscrowEntry {
+        token: Address::generate(&env),
+        amount_due: 1_000_000,
+        amount_paid: 1_000_000,
+        owner: Address::generate(&env),
+        status: EscrowStatus::Pending,
+        created_at: env.ledger().timestamp(),
+        expires_at: 0,
+        arbiter: Some(Address::generate(&env)),
+        arbiters: Vec::new(&env),
+        arbiter_threshold: 0,
+    };
+
+    let legacy_bytes = legacy_escrow_storage_footprint_bytes(&env, &commitment, &entry);
+    let compact_bytes = compact_escrow_storage_footprint_bytes(&env, &commitment, &entry);
+
+    print_storage_delta("arbiter_escrow_storage", legacy_bytes, compact_bytes);
 }

--- a/app/contract/contracts/quickex/src/escrow.rs
+++ b/app/contract/contracts/quickex/src/escrow.rs
@@ -67,9 +67,9 @@ use crate::{
     errors::QuickexError,
     escrow_id, events, fee_router, hook,
     storage::{
-        count_dispute_votes, get_dispute_vote, get_escrow, get_escrow_id_mapping, has_dispute_vote,
-        has_escrow, put_dispute_vote, put_escrow, put_escrow_id_mapping, remove_escrow,
-        LEDGER_THRESHOLD, SIX_MONTHS_IN_LEDGERS,
+        count_dispute_votes, extend_escrow_storage_ttl, get_dispute_vote, get_escrow,
+        get_escrow_id_mapping, has_dispute_vote, has_escrow, put_dispute_vote, put_escrow,
+        put_escrow_id_mapping, remove_escrow,
     },
     types::{DisputeVote, EscrowEntry, EscrowStatus, HookEventKind, Role},
 };
@@ -662,15 +662,9 @@ pub fn refund(env: &Env, commitment: BytesN<32>, caller: Address) -> Result<(), 
 /// Any user can call this to keep an escrow from being archived.
 pub fn extend_escrow_ttl(env: &Env, commitment: BytesN<32>) -> Result<(), QuickexError> {
     let commitment_bytes: Bytes = commitment.into();
-    if !has_escrow(env, &commitment_bytes) {
+    if !extend_escrow_storage_ttl(env, &commitment_bytes) {
         return Err(QuickexError::CommitmentNotFound);
     }
-
-    env.storage().persistent().extend_ttl(
-        &crate::storage::DataKey::Escrow(commitment_bytes),
-        LEDGER_THRESHOLD,
-        SIX_MONTHS_IN_LEDGERS,
-    );
     Ok(())
 }
 

--- a/app/contract/contracts/quickex/src/storage.rs
+++ b/app/contract/contracts/quickex/src/storage.rs
@@ -8,7 +8,9 @@
 //!
 //! | Key Variant            | Value Type     | Description |
 //! |------------------------|----------------|-------------|
-//! | [`Escrow`](DataKey::Escrow) | `EscrowEntry`  | Escrow entry keyed by commitment hash (32 bytes). One entry per unique deposit. |
+//! | [`Escrow`](DataKey::Escrow) | `EscrowEntry`  | Legacy escrow entry keyed by commitment hash (32 bytes). Read as a fallback during lazy migration. |
+//! | [`EscrowCore`](DataKey::EscrowCore) | `CompactEscrowEntry` | Compact escrow record used for new writes and hot-path reads. |
+//! | [`EscrowDispute`](DataKey::EscrowDispute) | `EscrowDisputeConfig` | Optional dispute-only metadata written only when an escrow uses arbiters. |
 //! | [`EscrowCounter`](DataKey::EscrowCounter) | `u64`       | Global monotonic counter for escrow creation. |
 //! | [`ContractVersion`](DataKey::ContractVersion) | `u32` | Stored schema/version marker for upgrade migrations. |
 //! | [`Admin`](DataKey::Admin) | `Address`     | Contract admin address. Set during initialisation, transferable by admin. |
@@ -38,8 +40,14 @@
 //! - **Add** new variants for new keys; they will not collide with existing ones.
 //! - **Value layout**: Changing `EscrowEntry` fields may require migration logic; adding optional
 //!   fields can be done carefully with defaults.
+//! - **Lazy migration**: Reads still fall back to the legacy [`DataKey::Escrow`] payload.
+//!   Any subsequent write rewrites the escrow into the compact layout and removes the
+//!   legacy record.
 
 use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, Vec};
+
+#[cfg(test)]
+use soroban_sdk::xdr::ToXdr;
 
 use crate::types::{DisputeVote, EscrowEntry, FeeConfig, Role, StealthEscrowEntry};
 
@@ -47,6 +55,7 @@ use crate::types::{DisputeVote, EscrowEntry, FeeConfig, Role, StealthEscrowEntry
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum RecordType {
     Escrow,
+    EscrowDispute,
     FeeConfig,
     StealthEscrow,
     EscrowIdMap,
@@ -65,6 +74,10 @@ pub struct TtlPolicy {
 fn get_ttl_policy(record_type: RecordType) -> TtlPolicy {
     match record_type {
         RecordType::Escrow => TtlPolicy {
+            threshold: LEDGER_THRESHOLD,
+            ttl: SIX_MONTHS_IN_LEDGERS,
+        },
+        RecordType::EscrowDispute => TtlPolicy {
             threshold: LEDGER_THRESHOLD,
             ttl: SIX_MONTHS_IN_LEDGERS,
         },
@@ -123,8 +136,13 @@ pub enum PauseFlag {
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
-    /// Escrow entry keyed by commitment hash (`Bytes`, typically 32 bytes).
+    /// Legacy escrow entry keyed by commitment hash (`Bytes`, typically 32 bytes).
+    /// Kept for backward-compatible reads after the storage compaction pass.
     Escrow(Bytes),
+    /// Compact escrow payload used for new and rewritten records.
+    EscrowCore(Bytes),
+    /// Optional dispute-only metadata for escrows that actually use arbiters.
+    EscrowDispute(Bytes),
     /// Global escrow counter (singleton).
     EscrowCounter,
     /// Current contract schema version (singleton).
@@ -179,6 +197,148 @@ pub enum DataKey {
     FeeCollector(u32),
     /// Tracks arbiter votes for disputed escrows. Keyed by (commitment, arbiter).
     DisputeVote(Bytes, Address),
+}
+
+/// Compact escrow record stored on the hot path.
+///
+/// Dispute metadata is intentionally split into a separate record so the common
+/// no-arbiter escrow avoids paying storage rent for empty optional fields.
+#[contracttype]
+#[derive(Clone)]
+struct CompactEscrowEntry {
+    token: Address,
+    amount_due: i128,
+    amount_paid: i128,
+    owner: Address,
+    status: crate::types::EscrowStatus,
+    created_at: u64,
+    expires_at: u64,
+}
+
+impl CompactEscrowEntry {
+    fn from_public(entry: &EscrowEntry) -> Self {
+        Self {
+            token: entry.token.clone(),
+            amount_due: entry.amount_due,
+            amount_paid: entry.amount_paid,
+            owner: entry.owner.clone(),
+            status: entry.status,
+            created_at: entry.created_at,
+            expires_at: entry.expires_at,
+        }
+    }
+
+    fn into_public(self, dispute: EscrowDisputeConfig) -> EscrowEntry {
+        EscrowEntry {
+            token: self.token,
+            amount_due: self.amount_due,
+            amount_paid: self.amount_paid,
+            owner: self.owner,
+            status: self.status,
+            created_at: self.created_at,
+            expires_at: self.expires_at,
+            arbiter: dispute.arbiter,
+            arbiters: dispute.arbiters,
+            arbiter_threshold: dispute.arbiter_threshold,
+        }
+    }
+}
+
+/// Dispute-only escrow metadata stored separately from the hot-path core record.
+#[contracttype]
+#[derive(Clone)]
+struct EscrowDisputeConfig {
+    arbiter: Option<Address>,
+    arbiters: Vec<Address>,
+    arbiter_threshold: u32,
+}
+
+impl EscrowDisputeConfig {
+    fn empty(env: &Env) -> Self {
+        Self {
+            arbiter: None,
+            arbiters: Vec::new(env),
+            arbiter_threshold: 0,
+        }
+    }
+
+    fn from_public(env: &Env, entry: &EscrowEntry) -> Self {
+        Self {
+            arbiter: entry.arbiter.clone(),
+            arbiters: if entry.arbiters.is_empty() {
+                Vec::new(env)
+            } else {
+                entry.arbiters.clone()
+            },
+            arbiter_threshold: entry.arbiter_threshold,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.arbiter.is_none() && self.arbiters.is_empty() && self.arbiter_threshold == 0
+    }
+}
+
+fn legacy_escrow_key(commitment: &Bytes) -> DataKey {
+    DataKey::Escrow(commitment.clone())
+}
+
+fn compact_escrow_key(commitment: &Bytes) -> DataKey {
+    DataKey::EscrowCore(commitment.clone())
+}
+
+fn escrow_dispute_key(commitment: &Bytes) -> DataKey {
+    DataKey::EscrowDispute(commitment.clone())
+}
+
+fn get_escrow_dispute_config(env: &Env, commitment: &Bytes) -> EscrowDisputeConfig {
+    let key = escrow_dispute_key(commitment);
+    let dispute = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| EscrowDisputeConfig::empty(env));
+
+    if !dispute.is_empty() {
+        set_or_extend_ttl(env, &key, RecordType::EscrowDispute);
+    }
+
+    dispute
+}
+
+fn put_escrow_dispute_config(env: &Env, commitment: &Bytes, entry: &EscrowEntry) {
+    let key = escrow_dispute_key(commitment);
+    let dispute = EscrowDisputeConfig::from_public(env, entry);
+
+    if dispute.is_empty() {
+        env.storage().persistent().remove(&key);
+        return;
+    }
+
+    env.storage().persistent().set(&key, &dispute);
+    set_or_extend_ttl(env, &key, RecordType::EscrowDispute);
+}
+
+fn extend_escrow_compaction_ttl(env: &Env, commitment: &Bytes) -> bool {
+    let core_key = compact_escrow_key(commitment);
+    if env.storage().persistent().has(&core_key) {
+        set_or_extend_ttl(env, &core_key, RecordType::Escrow);
+
+        let dispute_key = escrow_dispute_key(commitment);
+        if env.storage().persistent().has(&dispute_key) {
+            set_or_extend_ttl(env, &dispute_key, RecordType::EscrowDispute);
+        }
+
+        return true;
+    }
+
+    let legacy_key = legacy_escrow_key(commitment);
+    if env.storage().persistent().has(&legacy_key) {
+        set_or_extend_ttl(env, &legacy_key, RecordType::Escrow);
+        return true;
+    }
+
+    false
 }
 
 // -----------------------------------------------------------------------------
@@ -306,34 +466,94 @@ pub fn assert_post_upgrade_invariants(env: &Env) -> Result<(), &'static str> {
 /// **Contract**: Overwrites any existing entry for the same commitment.
 /// The commitment should be the 32-byte `SHA256(owner || amount || salt)` hash.
 pub fn put_escrow(env: &Env, commitment: &Bytes, entry: &EscrowEntry) {
-    let key = DataKey::Escrow(commitment.clone());
-    env.storage().persistent().set(&key, entry);
-    set_or_extend_ttl(env, &key, RecordType::Escrow);
+    let compact_key = compact_escrow_key(commitment);
+    let compact_entry = CompactEscrowEntry::from_public(entry);
+
+    env.storage().persistent().set(&compact_key, &compact_entry);
+    set_or_extend_ttl(env, &compact_key, RecordType::Escrow);
+    put_escrow_dispute_config(env, commitment, entry);
+
+    // Lazy migration: once an escrow is rewritten, retire the legacy payload.
+    env.storage()
+        .persistent()
+        .remove(&legacy_escrow_key(commitment));
 }
 
 /// Remove an escrow entry from storage and reclaim the storage deposit.
 pub fn remove_escrow(env: &Env, commitment: &Bytes) {
-    let key = DataKey::Escrow(commitment.clone());
-    env.storage().persistent().remove(&key);
+    env.storage()
+        .persistent()
+        .remove(&compact_escrow_key(commitment));
+    env.storage()
+        .persistent()
+        .remove(&escrow_dispute_key(commitment));
+    env.storage()
+        .persistent()
+        .remove(&legacy_escrow_key(commitment));
 }
 
 /// Get an escrow entry from storage.
 ///
 /// **Contract**: Returns `None` if no escrow exists for the commitment.
 pub fn get_escrow(env: &Env, commitment: &Bytes) -> Option<EscrowEntry> {
-    let key = DataKey::Escrow(commitment.clone());
-    let result = env.storage().persistent().get(&key);
-    if result.is_some() {
-        set_or_extend_ttl(env, &key, RecordType::Escrow);
+    let compact_key = compact_escrow_key(commitment);
+    let compact_result: Option<CompactEscrowEntry> = env.storage().persistent().get(&compact_key);
+    if let Some(compact_entry) = compact_result {
+        set_or_extend_ttl(env, &compact_key, RecordType::Escrow);
+        let dispute = get_escrow_dispute_config(env, commitment);
+        return Some(compact_entry.into_public(dispute));
     }
-    result
+
+    let legacy_key = legacy_escrow_key(commitment);
+    let legacy_result: Option<EscrowEntry> = env.storage().persistent().get(&legacy_key);
+    if legacy_result.is_some() {
+        set_or_extend_ttl(env, &legacy_key, RecordType::Escrow);
+    }
+    legacy_result
 }
 
 /// Check if an escrow entry exists in storage.
 #[allow(dead_code)]
 pub fn has_escrow(env: &Env, commitment: &Bytes) -> bool {
-    let key = DataKey::Escrow(commitment.clone());
-    env.storage().persistent().has(&key)
+    env.storage()
+        .persistent()
+        .has(&compact_escrow_key(commitment))
+        || env
+            .storage()
+            .persistent()
+            .has(&legacy_escrow_key(commitment))
+}
+
+/// Extend the TTL of whichever escrow representation is currently stored.
+pub fn extend_escrow_storage_ttl(env: &Env, commitment: &Bytes) -> bool {
+    extend_escrow_compaction_ttl(env, commitment)
+}
+
+#[cfg(test)]
+pub(crate) fn legacy_escrow_storage_footprint_bytes(
+    env: &Env,
+    commitment: &Bytes,
+    entry: &EscrowEntry,
+) -> usize {
+    (legacy_escrow_key(commitment).to_xdr(env).len() + entry.to_xdr(env).len()) as usize
+}
+
+#[cfg(test)]
+pub(crate) fn compact_escrow_storage_footprint_bytes(
+    env: &Env,
+    commitment: &Bytes,
+    entry: &EscrowEntry,
+) -> usize {
+    let compact_key = compact_escrow_key(commitment);
+    let compact_entry = CompactEscrowEntry::from_public(entry);
+    let mut total = compact_key.to_xdr(env).len() + compact_entry.to_xdr(env).len();
+
+    let dispute = EscrowDisputeConfig::from_public(env, entry);
+    if !dispute.is_empty() {
+        total += escrow_dispute_key(commitment).to_xdr(env).len() + dispute.to_xdr(env).len();
+    }
+
+    total as usize
 }
 
 /// Get the next escrow counter value.

--- a/app/contract/contracts/quickex/src/storage_test.rs
+++ b/app/contract/contracts/quickex/src/storage_test.rs
@@ -102,6 +102,21 @@ use crate::{
     types::{EscrowEntry, EscrowStatus},
 };
 
+fn make_entry(env: &Env, amount: i128) -> EscrowEntry {
+    EscrowEntry {
+        token: Address::generate(env),
+        amount_due: amount,
+        amount_paid: amount,
+        owner: Address::generate(env),
+        status: EscrowStatus::Pending,
+        created_at: env.ledger().timestamp(),
+        expires_at: 0,
+        arbiter: None,
+        arbiters: Vec::new(env),
+        arbiter_threshold: 0,
+    }
+}
+
 #[test]
 fn test_escrow_storage() {
     let env = Env::default();
@@ -146,6 +161,99 @@ fn test_escrow_storage() {
         let non_existent_commitment: Bytes = Bytes::from_array(&env, &[2u8; 32]);
         assert!(!has_escrow(&env, &non_existent_commitment));
         assert!(get_escrow(&env, &non_existent_commitment).is_none());
+    });
+}
+
+#[test]
+fn test_common_escrow_is_compacted_and_smaller_than_legacy_layout() {
+    let env = Env::default();
+    let contract_id = env.register(crate::QuickexContract, ());
+    env.as_contract(&contract_id, || {
+        let commitment: Bytes = Bytes::from_array(&env, &[6u8; 32]);
+        let entry = make_entry(&env, 2_500);
+
+        put_escrow(&env, &commitment, &entry);
+
+        assert!(env
+            .storage()
+            .persistent()
+            .has(&DataKey::EscrowCore(commitment.clone())));
+        assert!(!env
+            .storage()
+            .persistent()
+            .has(&DataKey::Escrow(commitment.clone())));
+        assert!(!env
+            .storage()
+            .persistent()
+            .has(&DataKey::EscrowDispute(commitment.clone())));
+
+        let compact_bytes = compact_escrow_storage_footprint_bytes(&env, &commitment, &entry);
+        let legacy_bytes = legacy_escrow_storage_footprint_bytes(&env, &commitment, &entry);
+        assert!(
+            compact_bytes < legacy_bytes,
+            "expected compact footprint {compact_bytes} to be smaller than legacy {legacy_bytes}"
+        );
+    });
+}
+
+#[test]
+fn test_arbiter_escrow_round_trips_via_separate_dispute_record() {
+    let env = Env::default();
+    let contract_id = env.register(crate::QuickexContract, ());
+    env.as_contract(&contract_id, || {
+        let commitment: Bytes = Bytes::from_array(&env, &[7u8; 32]);
+        let arbiter = Address::generate(&env);
+        let mut entry = make_entry(&env, 5_000);
+        entry.arbiter = Some(arbiter.clone());
+
+        put_escrow(&env, &commitment, &entry);
+
+        assert!(env
+            .storage()
+            .persistent()
+            .has(&DataKey::EscrowCore(commitment.clone())));
+        assert!(env
+            .storage()
+            .persistent()
+            .has(&DataKey::EscrowDispute(commitment.clone())));
+
+        let stored = get_escrow(&env, &commitment).unwrap();
+        assert_eq!(stored.arbiter, Some(arbiter));
+        assert!(stored.arbiters.is_empty());
+        assert_eq!(stored.arbiter_threshold, 0);
+    });
+}
+
+#[test]
+fn test_legacy_escrow_can_be_rewritten_to_compact_storage() {
+    let env = Env::default();
+    let contract_id = env.register(crate::QuickexContract, ());
+    env.as_contract(&contract_id, || {
+        let commitment: Bytes = Bytes::from_array(&env, &[8u8; 32]);
+        let entry = make_entry(&env, 7_500);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(commitment.clone()), &entry);
+
+        let mut updated = get_escrow(&env, &commitment).unwrap();
+        assert_eq!(updated.amount_due, entry.amount_due);
+        updated.status = EscrowStatus::Spent;
+
+        put_escrow(&env, &commitment, &updated);
+
+        assert!(env
+            .storage()
+            .persistent()
+            .has(&DataKey::EscrowCore(commitment.clone())));
+        assert!(!env
+            .storage()
+            .persistent()
+            .has(&DataKey::Escrow(commitment.clone())));
+        assert_eq!(
+            get_escrow(&env, &commitment).unwrap().status,
+            EscrowStatus::Spent
+        );
     });
 }
 

--- a/app/contract/contracts/quickex/test_snapshots/storage_test/test_arbiter_escrow_round_trips_via_separate_dispute_record.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/storage_test/test_arbiter_escrow_round_trips_via_separate_dispute_record.1.json
@@ -1,0 +1,253 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowCore"
+                },
+                {
+                  "bytes": "0707070707070707070707070707070707070707070707070707070707070707"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowCore"
+                    },
+                    {
+                      "bytes": "0707070707070707070707070707070707070707070707070707070707070707"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_due"
+                      },
+                      "val": {
+                        "i128": "5000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_paid"
+                      },
+                      "val": {
+                        "i128": "5000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Pending"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowDispute"
+                },
+                {
+                  "bytes": "0707070707070707070707070707070707070707070707070707070707070707"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowDispute"
+                    },
+                    {
+                      "bytes": "0707070707070707070707070707070707070707070707070707070707070707"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "arbiter"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "arbiter_threshold"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "arbiters"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/storage_test/test_common_escrow_is_compacted_and_smaller_than_legacy_layout.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/storage_test/test_common_escrow_is_compacted_and_smaller_than_legacy_layout.1.json
@@ -1,0 +1,183 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowCore"
+                },
+                {
+                  "bytes": "0606060606060606060606060606060606060606060606060606060606060606"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowCore"
+                    },
+                    {
+                      "bytes": "0606060606060606060606060606060606060606060606060606060606060606"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_due"
+                      },
+                      "val": {
+                        "i128": "2500"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_paid"
+                      },
+                      "val": {
+                        "i128": "2500"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Pending"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/app/contract/contracts/quickex/test_snapshots/storage_test/test_legacy_escrow_can_be_rewritten_to_compact_storage.1.json
+++ b/app/contract/contracts/quickex/test_snapshots/storage_test/test_legacy_escrow_can_be_rewritten_to_compact_storage.1.json
@@ -1,0 +1,183 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EscrowCore"
+                },
+                {
+                  "bytes": "0808080808080808080808080808080808080808080808080808080808080808"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EscrowCore"
+                    },
+                    {
+                      "bytes": "0808080808080808080808080808080808080808080808080808080808080808"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_due"
+                      },
+                      "val": {
+                        "i128": "7500"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_paid"
+                      },
+                      "val": {
+                        "i128": "7500"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Spent"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          3110400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
Closes #567

---

## Summary
- compacted common escrow storage by moving dispute-only metadata into a sidecar record
- preserved behavior with lazy fallback from legacy `DataKey::Escrow`
- added storage footprint benchmarks and regression coverage for compact and legacy paths

## What Changed
- added `DataKey::EscrowCore` and `DataKey::EscrowDispute`
- updated escrow storage helpers to write compact core records and only persist dispute config when needed
- kept legacy escrow reads working and rewrite them into