### PR TITLE
feat(links): harden expiry processing, add audit + notifications

### DIFF
--- a/app/backend/src/events/notification.events.ts
+++ b/app/backend/src/events/notification.events.ts
@@ -1,5 +1,6 @@
 export enum NotificationEvent {
   PaymentReceived = 'payment.received',
+  PaymentLinkExpired = 'payment.link.expired',
   UsernameClaimed = 'username.claimed',
   RecurringLinkCreated = 'recurring.link.created',
   RecurringLinkUpdated = 'recurring.link.updated',

--- a/app/backend/src/links/__tests__/payment-link-expiry.service.unit.spec.ts
+++ b/app/backend/src/links/__tests__/payment-link-expiry.service.unit.spec.ts
@@ -1,0 +1,75 @@
+import { Test } from '@nestjs/testing';
+import { PaymentLinkExpiryService } from '../payment-link-expiry.service';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { AuditService } from '../../audit/audit.service';
+
+describe('PaymentLinkExpiryService', () => {
+  let svc: PaymentLinkExpiryService;
+  let mockSupabase: any;
+  let mockAudit: any;
+  let events: EventEmitter2;
+
+  beforeEach(async () => {
+    mockSupabase = {
+      getClient: jest.fn(),
+    };
+
+    // Minimal chainable builder used by service
+    const builder = {
+      update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+      select: jest.fn().mockResolvedValue({ data: [], error: null }),
+      from: jest.fn().mockReturnThis(),
+      insert: jest.fn().mockResolvedValue({ data: [], error: null }),
+    };
+
+    mockSupabase.getClient.mockReturnValue(builder);
+
+    mockAudit = { log: jest.fn().mockResolvedValue(undefined) };
+
+    events = new EventEmitter2();
+
+    const module = await Test.createTestingModule({
+      providers: [
+        PaymentLinkExpiryService,
+        { provide: SupabaseService, useValue: mockSupabase },
+        { provide: EventEmitter2, useValue: events },
+        { provide: AuditService, useValue: mockAudit },
+      ],
+    }).compile();
+
+    svc = module.get(PaymentLinkExpiryService);
+  });
+
+  it('marks expired links and writes audit + emits event', async () => {
+    const updatedRow = {
+      id: '1111-2222',
+      owner_public_key: 'GABCDEFG',
+      destination_public_key: 'GDEST',
+      expires_at: new Date().toISOString(),
+    };
+
+    const client = mockSupabase.getClient();
+    client.select.mockResolvedValue({ data: [updatedRow], error: null });
+    client.insert.mockResolvedValue({ data: [{ id: 'audit1' }], error: null });
+
+    const spyEmit = jest.spyOn(events, 'emit');
+
+    const count = await svc.runExpirySweep('run-1');
+    expect(count).toBe(1);
+    expect(mockAudit.log).toHaveBeenCalledWith('system:expiry-worker', 'payment_link.expired', String(updatedRow.id), expect.any(Object));
+    expect(spyEmit).toHaveBeenCalledWith('payment.link.expired', expect.objectContaining({ linkId: String(updatedRow.id) }));
+  });
+
+  it('is idempotent when there are no open expired links', async () => {
+    const client = mockSupabase.getClient();
+    client.select.mockResolvedValue({ data: [], error: null });
+
+    const count = await svc.runExpirySweep('run-2');
+    expect(count).toBe(0);
+    expect(mockAudit.log).not.toHaveBeenCalled();
+  });
+});

--- a/app/backend/src/links/__tests__/payment-link-expiry.service.unit.spec.ts
+++ b/app/backend/src/links/__tests__/payment-link-expiry.service.unit.spec.ts
@@ -6,8 +6,8 @@ import { AuditService } from '../../audit/audit.service';
 
 describe('PaymentLinkExpiryService', () => {
   let svc: PaymentLinkExpiryService;
-  let mockSupabase: any;
-  let mockAudit: any;
+  let mockSupabase: { getClient: jest.Mock };
+  let mockAudit: { log: jest.Mock };
   let events: EventEmitter2;
 
   beforeEach(async () => {

--- a/app/backend/src/links/links.module.ts
+++ b/app/backend/src/links/links.module.ts
@@ -10,6 +10,7 @@ import { RecurringPaymentsRepository } from "./recurring-payments.repository";
 import { RecurringPaymentProcessor } from "../stellar/recurring-payment-processor";
 import { PaymentLinkController } from "./payment-link.controller";
 import { PaymentLinkService } from "./payment-link.service";
+import { PaymentLinkExpiryService } from './payment-link-expiry.service';
 import { SupabaseModule } from "../supabase/supabase.module";
 import { StellarModule } from "../stellar/stellar.module";
 import { ApiKeysModule } from "../api-keys/api-keys.module";
@@ -28,6 +29,7 @@ import { AuditModule } from "../audit/audit.module";
   ],
   providers: [
     LinksService,
+    PaymentLinkExpiryService,
     BulkPaymentLinksService,
     RecurringPaymentsService,
     RecurringPaymentsScheduler,
@@ -37,6 +39,7 @@ import { AuditModule } from "../audit/audit.module";
   ],
   exports: [
     LinksService,
+    PaymentLinkExpiryService,
     RecurringPaymentsService,
     BulkPaymentLinksService,
     RecurringPaymentsRepository,

--- a/app/backend/src/links/payment-link-expiry.service.ts
+++ b/app/backend/src/links/payment-link-expiry.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { v4 as uuidv4 } from 'uuid';
+
+import { SupabaseService } from '../supabase/supabase.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { AuditService } from '../audit/audit.service';
+
+@Injectable()
+export class PaymentLinkExpiryService {
+  private readonly logger = new Logger(PaymentLinkExpiryService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly auditService: AuditService,
+  ) {}
+
+  // Run every minute to sweep expired open links. Idempotent by design.
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'payment-link-expiry-sweep', timeZone: 'UTC' })
+  async handleCron(): Promise<void> {
+    const runId = uuidv4();
+    try {
+      const count = await this.runExpirySweep(runId);
+      if (count > 0) this.logger.log(`Expiry sweep ${runId}: expired ${count} link(s)`);
+    } catch (err) {
+      this.logger.error(`Expiry sweep ${runId} failed: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Sweep open payment_links whose `expires_at` <= now and mark them expired.
+   * The update is constrained to rows with status='open' so it is safe to
+   * run concurrently or replayed — idempotent and replay-safe.
+   */
+  async runExpirySweep(runId: string): Promise<number> {
+    const client = this.supabase.getClient();
+    const nowIso = new Date().toISOString();
+    try {
+      // Update matched rows and return their representation so we can audit and emit events.
+      const { data, error } = await client
+        .from('payment_links')
+        .update({
+          status: 'expired',
+          expiry_processed_at: nowIso,
+          expiry_processed_by: 'expiry-worker',
+          expiry_note: `expired by sweep ${runId}`,
+        })
+        .eq('status', 'open')
+        .not('expires_at', 'is', null)
+        .lte('expires_at', nowIso)
+        .select('id,owner_public_key,destination_public_key,amount,asset_code,memo,expires_at,matched_tx_hash,matched_at');
+
+      if (error) {
+        this.logger.error(`Failed to mark expired links: ${error.message}`);
+        return 0;
+      }
+
+      const updated = (data ?? []) as Array<Record<string, unknown>>;
+      if (updated.length === 0) return 0;
+
+      // For each updated link write an audit row and emit a notification event
+      for (const row of updated) {
+        const linkId = String(row.id);
+        const expiresAt = row.expires_at ? String(row.expires_at) : null;
+
+        // Persist to expiry audit table
+        try {
+          await client.from('payment_link_expiry_audit').insert({
+            link_id: linkId,
+            previous_status: 'open',
+            new_status: 'expired',
+            expires_at: expiresAt,
+            processed_at: nowIso,
+            processed_by: 'expiry-worker',
+            run_id: runId,
+            note: `sweep`,
+          });
+        } catch (err) {
+          this.logger.warn(`Failed to record expiry audit for ${linkId}: ${(err as Error).message}`);
+        }
+
+        // Emit an audit log for operators
+        await this.auditService.log('system:expiry-worker', 'payment_link.expired', linkId, {
+          runId,
+          expiresAt,
+        });
+
+        // Notify downstream notification service via event-emitter so user gets informed
+        this.eventEmitter.emit('payment.link.expired', {
+          linkId,
+          expiresAt,
+          ownerPublicKey: row.owner_public_key ?? null,
+          destinationPublicKey: row.destination_public_key ?? null,
+        });
+      }
+
+      return updated.length;
+    } catch (err) {
+      this.logger.error(`Expiry sweep failed: ${(err as Error).message}`);
+      return 0;
+    }
+  }
+}

--- a/app/backend/src/notifications/notification.service.ts
+++ b/app/backend/src/notifications/notification.service.ts
@@ -196,6 +196,24 @@ export class NotificationService implements OnModuleInit {
     await this.dispatch(payload);
   }
 
+  @OnEvent("payment.link.expired", { async: true })
+  async onPaymentLinkExpired(event: { linkId: string; expiresAt?: string | null; ownerPublicKey?: string | null }): Promise<void> {
+    if (!event.ownerPublicKey) return;
+    const payload = {
+      eventType: 'payment.link.expired' as const,
+      eventId: `link:${event.linkId}:expired:${event.expiresAt ?? ''}`,
+      recipientPublicKey: event.ownerPublicKey,
+      title: 'Payment Link Expired',
+      body: 'A payment link you created has expired.',
+      occurredAt: new Date().toISOString(),
+      linkId: event.linkId,
+      expiredAt: event.expiresAt ?? null,
+      metadata: { linkId: event.linkId, expiredAt: event.expiresAt ?? null },
+    } as unknown as any;
+
+    await this.dispatch(payload);
+  }
+
   @OnEvent(NotificationEvent.UsernameClaimed, { async: true })
   async onUsernameClaimed(event: UsernameClaimedEvent): Promise<void> {
     const payload: UsernameClaimedPayload = {

--- a/app/backend/src/notifications/notification.service.ts
+++ b/app/backend/src/notifications/notification.service.ts
@@ -19,6 +19,7 @@ import type {
   PaymentReceivedPayload,
   UsernameClaimedPayload,
   AutoReconciliationSucceededNotificationPayload,
+  PaymentLinkExpiredPayload,
 } from "./types/notification.types";
 
 import {
@@ -199,8 +200,8 @@ export class NotificationService implements OnModuleInit {
   @OnEvent("payment.link.expired", { async: true })
   async onPaymentLinkExpired(event: { linkId: string; expiresAt?: string | null; ownerPublicKey?: string | null }): Promise<void> {
     if (!event.ownerPublicKey) return;
-    const payload = {
-      eventType: 'payment.link.expired' as const,
+    const payload: PaymentLinkExpiredPayload = {
+      eventType: 'payment.link.expired',
       eventId: `link:${event.linkId}:expired:${event.expiresAt ?? ''}`,
       recipientPublicKey: event.ownerPublicKey,
       title: 'Payment Link Expired',
@@ -209,7 +210,7 @@ export class NotificationService implements OnModuleInit {
       linkId: event.linkId,
       expiredAt: event.expiresAt ?? null,
       metadata: { linkId: event.linkId, expiredAt: event.expiresAt ?? null },
-    } as unknown as any;
+    };
 
     await this.dispatch(payload);
   }

--- a/app/backend/src/notifications/types/notification.types.ts
+++ b/app/backend/src/notifications/types/notification.types.ts
@@ -29,6 +29,15 @@ export type NotificationEventType =
   | "recurring.link.resumed"
   | "recurring.link.completed"
   | "auto_reconciliation.succeeded";
+  | "payment.link.expired";
+
+export type PaymentLinkExpiredEvent = "payment.link.expired";
+
+export interface PaymentLinkExpiredPayload extends BaseNotificationPayload {
+  eventType: PaymentLinkExpiredEvent;
+  linkId: string;
+  expiredAt: string | null;
+}
 
 export interface BaseNotificationPayload {
   /** The event kind — used to match against user preference filters. */
@@ -152,6 +161,7 @@ export type NotificationPayload =
   | RecurringPaymentFailedPayload
   | RecurringLinkStatusPayload
   | AutoReconciliationSucceededNotificationPayload;
+  | PaymentLinkExpiredPayload;
 
 // ---------------------------------------------------------------------------
 // User preferences

--- a/app/backend/src/notifications/types/notification.types.ts
+++ b/app/backend/src/notifications/types/notification.types.ts
@@ -28,7 +28,7 @@ export type NotificationEventType =
   | "recurring.link.paused"
   | "recurring.link.resumed"
   | "recurring.link.completed"
-  | "auto_reconciliation.succeeded";
+  | "auto_reconciliation.succeeded"
   | "payment.link.expired";
 
 export type PaymentLinkExpiredEvent = "payment.link.expired";
@@ -160,7 +160,7 @@ export type NotificationPayload =
   | RecurringPaymentExecutedPayload
   | RecurringPaymentFailedPayload
   | RecurringLinkStatusPayload
-  | AutoReconciliationSucceededNotificationPayload;
+  | AutoReconciliationSucceededNotificationPayload
   | PaymentLinkExpiredPayload;
 
 // ---------------------------------------------------------------------------

--- a/app/backend/supabase/migrations/20260629000000_add_payment_link_expiry_hardening.sql
+++ b/app/backend/supabase/migrations/20260629000000_add_payment_link_expiry_hardening.sql
@@ -1,0 +1,21 @@
+-- Add expiry processing columns and audit table for payment_links
+
+ALTER TABLE IF EXISTS payment_links
+  ADD COLUMN IF NOT EXISTS expiry_processed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS expiry_processed_by TEXT,
+  ADD COLUMN IF NOT EXISTS expiry_note TEXT;
+
+CREATE TABLE IF NOT EXISTS payment_link_expiry_audit (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  link_id UUID NOT NULL REFERENCES payment_links(id) ON DELETE CASCADE,
+  previous_status TEXT NOT NULL,
+  new_status TEXT NOT NULL,
+  expires_at TIMESTAMPTZ,
+  processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  processed_by TEXT,
+  run_id TEXT,
+  note TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_payment_link_expiry_audit_processed
+  ON payment_link_expiry_audit (processed_at DESC);


### PR DESCRIPTION
feat(links): harden expiry processing, add audit + notifications

- Summary: Add an idempotent expiry sweep for payment links that reliably transitions open links to `expired` even with delayed jobs or event replays. Record detailed expiry audit rows, emit admin audit events, and notify link owners.

What changed:
  - Migration: 20260629000000_add_payment_link_expiry_hardening.sql
  - Service (expiry sweep): payment-link-expiry.service.ts
  - Module registration: links.module.ts
  - Notification plumbing: notification.service.ts, notification.events.ts, notification.types.ts
  - Tests: payment-link-expiry.service.unit.spec.ts

- **Behavior / rationale:**
  - The sweep updates only rows where `status = 'open'` and `expires_at <= NOW()`, so repeated runs, delayed workers, or replayed events are safe and idempotent.
  - Each expiry writes a row to `payment_link_expiry_audit`, logs an admin audit via `AuditService.log`, and emits a `payment.link.expired` event targeted to the link owner.
  - Auto-match and other writers already guard with `.eq('status', 'open')`, preventing late payments from silently overwriting an expired state; the expiry sweep mirrors that pattern for determinism.

- **Acceptance criteria mapping:**
  - Deterministic & replay-safe: ensured by status-guarded update and audit trail.
  - Late payments do not silently overwrite expired state: update only affects `open` rows; auto-match also requires `open`.
  - Operators can inspect why/when a link expired: `payment_link_expiry_audit` + admin audit logs.

- **How to run locally**
  - Apply DB migration to your Postgres/Supabase:
    ```bash
    # (run in your DB migration tooling / psql)
    psql $DATABASE_URL -f app/backend/supabase/migrations/20260629000000_add_payment_link_expiry_hardening.sql
    ```
  - Run backend tests:
    ```bash
    pnpm --filter app/backend install
    pnpm --filter app/backend test
    ```
  - Run the expiry sweep manually (example from Node REPL or call service via admin endpoint if you add one). The service also runs every minute via Cron.
closes #548 