### PR TITLE
feat: implement privacy-aware feedback submission system with automat…

### DIFF
--- a/app/mobile/__tests__/feedback-redaction.test.ts
+++ b/app/mobile/__tests__/feedback-redaction.test.ts
@@ -1,0 +1,68 @@
+import {
+  maskStellarPublicKey,
+  redactContext,
+  redactFeedbackText,
+} from '../utils/feedback-redaction';
+
+// Valid-shaped Stellar keys (56 chars, base32 alphabet A-Z2-7).
+const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX';
+const SECRET_KEY = 'SABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX';
+
+describe('feedback redaction', () => {
+  describe('redactFeedbackText', () => {
+    it('fully removes Stellar secret seeds', () => {
+      const result = redactFeedbackText(`my seed is ${SECRET_KEY} keep it safe`);
+      expect(result).toBe('my seed is [REDACTED_SECRET_KEY] keep it safe');
+      expect(result).not.toContain(SECRET_KEY);
+    });
+
+    it('masks Stellar public keys', () => {
+      const result = redactFeedbackText(`paid ${PUBLIC_KEY} today`);
+      expect(result).toBe(`paid ${maskStellarPublicKey(PUBLIC_KEY)} today`);
+      expect(result).not.toContain(PUBLIC_KEY);
+    });
+
+    it('still redacts standard PII (email)', () => {
+      expect(redactFeedbackText('reach me at a@b.com')).toBe('reach me at [EMAIL]');
+    });
+
+    it('handles multiple sensitive values in one string', () => {
+      const input = `from ${PUBLIC_KEY} using ${SECRET_KEY} email x@y.com`;
+      const result = redactFeedbackText(input);
+      expect(result).toContain(maskStellarPublicKey(PUBLIC_KEY));
+      expect(result).toContain('[REDACTED_SECRET_KEY]');
+      expect(result).toContain('[EMAIL]');
+      expect(result).not.toContain(SECRET_KEY);
+    });
+
+    it('passes through empty input unchanged', () => {
+      expect(redactFeedbackText('')).toBe('');
+    });
+  });
+
+  describe('maskStellarPublicKey', () => {
+    it('keeps a prefix and suffix', () => {
+      expect(maskStellarPublicKey(PUBLIC_KEY)).toBe('GABC…UVWX');
+    });
+
+    it('leaves short strings untouched', () => {
+      expect(maskStellarPublicKey('GABC')).toBe('GABC');
+    });
+  });
+
+  describe('redactContext', () => {
+    it('recursively scrubs string values in nested objects', () => {
+      const result = redactContext({
+        note: `seed ${SECRET_KEY}`,
+        nested: { addresses: [PUBLIC_KEY, 'plain text'] },
+        count: 3,
+      });
+
+      expect(result.note).toBe('seed [REDACTED_SECRET_KEY]');
+      expect(result.nested.addresses[0]).toBe(maskStellarPublicKey(PUBLIC_KEY));
+      expect(result.nested.addresses[1]).toBe('plain text');
+      // Non-string values are preserved as-is.
+      expect(result.count).toBe(3);
+    });
+  });
+});

--- a/app/mobile/__tests__/feedback-service.test.ts
+++ b/app/mobile/__tests__/feedback-service.test.ts
@@ -1,0 +1,115 @@
+import {
+  buildFeedbackMetadata,
+  buildFeedbackPayload,
+  formatFeedbackForExport,
+  submitFeedback,
+  type FeedbackContext,
+  type FeedbackInput,
+} from '../services/feedback';
+
+const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX';
+const SECRET_KEY = 'SABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX';
+
+const context: FeedbackContext = {
+  environmentId: 'testnet',
+  environmentLabel: 'Shared Testnet',
+  apiUrl: 'https://testnet-api.quickex.to',
+  backendVersion: '2.1.0',
+  walletPublicKey: PUBLIC_KEY,
+  platform: 'ios 17',
+};
+
+const input: FeedbackInput = {
+  category: 'bug',
+  title: '  Scan fails  ',
+  description: `Crashed while paying ${PUBLIC_KEY} with seed ${SECRET_KEY}`,
+  attachments: { logs: `error for x@y.com on ${SECRET_KEY}` },
+};
+
+describe('feedback service', () => {
+  describe('buildFeedbackMetadata', () => {
+    it('captures environment and masks the wallet key', () => {
+      const meta = buildFeedbackMetadata(context);
+      expect(meta.environmentId).toBe('testnet');
+      expect(meta.apiUrl).toBe(context.apiUrl);
+      expect(meta.backendVersion).toBe('2.1.0');
+      expect(meta.walletPublicKeyMasked).toBe('GABC…UVWX');
+      expect(meta.walletPublicKeyMasked).not.toContain(PUBLIC_KEY);
+      expect(meta.capturedAt).toBeTruthy();
+    });
+
+    it('omits wallet field when not connected', () => {
+      const meta = buildFeedbackMetadata({ ...context, walletPublicKey: undefined });
+      expect(meta.walletPublicKeyMasked).toBeUndefined();
+    });
+  });
+
+  describe('buildFeedbackPayload', () => {
+    it('trims and redacts contributor input', () => {
+      const payload = buildFeedbackPayload(input, context);
+      expect(payload.title).toBe('Scan fails');
+      expect(payload.description).toContain('GABC…UVWX');
+      expect(payload.description).toContain('[REDACTED_SECRET_KEY]');
+      expect(payload.description).not.toContain(SECRET_KEY);
+      expect(payload.logs).toContain('[EMAIL]');
+      expect(payload.logs).not.toContain(SECRET_KEY);
+      expect(payload.redacted).toBe(true);
+    });
+  });
+
+  describe('submitFeedback', () => {
+    it('posts the redacted payload and reports submitted on success', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+      const result = await submitFeedback(input, context, { fetchImpl: fetchImpl as any });
+
+      expect(result.status).toBe('submitted');
+      expect(fetchImpl).toHaveBeenCalledWith(
+        'https://testnet-api.quickex.to/feedback',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      // Body must not leak the secret key.
+      const body = (fetchImpl.mock.calls[0][1] as any).body as string;
+      expect(body).not.toContain(SECRET_KEY);
+    });
+
+    it('falls back to export on HTTP error', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+      const result = await submitFeedback(input, context, { fetchImpl: fetchImpl as any });
+      expect(result.status).toBe('exported');
+      if (result.status === 'exported') {
+        expect(result.reason).toContain('503');
+      }
+    });
+
+    it('falls back to export on network failure', async () => {
+      const fetchImpl = jest.fn().mockRejectedValue(new Error('offline'));
+      const result = await submitFeedback(input, context, { fetchImpl: fetchImpl as any });
+      expect(result.status).toBe('exported');
+      if (result.status === 'exported') {
+        expect(result.reason).toContain('offline');
+      }
+    });
+
+    it('exports without calling fetch when no API is configured', async () => {
+      const fetchImpl = jest.fn();
+      const result = await submitFeedback(
+        input,
+        { ...context, apiUrl: '' },
+        { fetchImpl: fetchImpl as any },
+      );
+      expect(fetchImpl).not.toHaveBeenCalled();
+      expect(result.status).toBe('exported');
+    });
+  });
+
+  describe('formatFeedbackForExport', () => {
+    it('produces readable text without leaking secrets', () => {
+      const payload = buildFeedbackPayload(input, context);
+      const text = formatFeedbackForExport(payload);
+      expect(text).toContain('QuickEx Feedback');
+      expect(text).toContain('Scan fails');
+      expect(text).toContain('Shared Testnet');
+      expect(text).not.toContain(SECRET_KEY);
+    });
+  });
+});

--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -251,6 +251,7 @@ function AppShell() {
         <Stack.Screen name="contacts" />
         <Stack.Screen name="add-contact" />
         <Stack.Screen name="edit-contact" />
+        <Stack.Screen name="feedback" />
       </Stack>
       {isReady && settings.biometricLockEnabled ? (
         <AppLockOverlay

--- a/app/mobile/app/feedback.tsx
+++ b/app/mobile/app/feedback.tsx
@@ -1,0 +1,441 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Platform,
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+
+import { useTheme } from '../src/theme/ThemeContext';
+import { useEnvironment } from '../contexts/EnvironmentContext';
+import { useWallet } from '../hooks/useWallet';
+import { getOfflineQueue } from '../services/offline-queue';
+import { copyToClipboard } from '../src/utils/clipboard';
+import {
+  buildFeedbackMetadata,
+  formatFeedbackForExport,
+  submitFeedback,
+  type FeedbackCategory,
+  type FeedbackContext,
+} from '../services/feedback';
+
+const CATEGORIES: { value: FeedbackCategory; label: string }[] = [
+  { value: 'bug', label: 'Bug' },
+  { value: 'idea', label: 'Idea' },
+  { value: 'question', label: 'Question' },
+  { value: 'other', label: 'Other' },
+];
+
+export default function FeedbackScreen() {
+  const { theme } = useTheme();
+  const router = useRouter();
+  const { currentId, current, metadata } = useEnvironment();
+  const { wallet } = useWallet();
+
+  const [category, setCategory] = useState<FeedbackCategory>('bug');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [attachLogs, setAttachLogs] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Screenshot attachment is a capture hook awaiting a bundled image picker;
+  // until then no URIs are collected. Kept as a stable reference so the submit
+  // path and preview already account for attachments.
+  const screenshots = useMemo<string[]>(() => [], []);
+
+  // Captured automatically — the contributor never types this. Memoised on the
+  // values it derives from so the preview stays in sync as the environment or
+  // wallet changes.
+  const context = useMemo<FeedbackContext>(
+    () => ({
+      environmentId: currentId,
+      environmentLabel: current.label,
+      apiUrl: current.apiUrl,
+      backendVersion: metadata?.appVersion,
+      walletPublicKey: wallet.connected ? wallet.publicKey : undefined,
+      platform: `${Platform.OS} ${Platform.Version ?? ''}`.trim(),
+    }),
+    [currentId, current, metadata, wallet],
+  );
+
+  const previewMetadata = useMemo(
+    () => buildFeedbackMetadata(context),
+    [context],
+  );
+
+  const canSubmit = title.trim().length > 0 && !submitting;
+
+  // Optional log-export hook: pulls the offline queue as a redactable log dump.
+  const collectLogs = useCallback(async (): Promise<string | undefined> => {
+    if (!attachLogs) return undefined;
+    try {
+      const queue = await getOfflineQueue();
+      return JSON.stringify(queue, null, 2);
+    } catch {
+      return undefined;
+    }
+  }, [attachLogs]);
+
+  // Optional screenshot-attach hook. A native image picker isn't bundled in
+  // this build, so attachment is gated behind availability; contributors can
+  // still share exported context out-of-band. This keeps the capture surface
+  // in place for when a picker is added.
+  const handleAttachScreenshot = useCallback(() => {
+    Alert.alert(
+      'Attach Screenshot',
+      'Screenshot capture is not available in this build. Use your device screenshot tool and attach it when sharing the exported feedback.',
+    );
+  }, []);
+
+  const exportPayload = useCallback(
+    async (text: string) => {
+      try {
+        await Share.share({ message: text }, { dialogTitle: 'Share Feedback' });
+      } catch {
+        // Fall back to clipboard if the share sheet is unavailable.
+        const copied = await copyToClipboard(text);
+        Alert.alert(
+          copied ? 'Copied' : 'Export Failed',
+          copied
+            ? 'Feedback copied to clipboard.'
+            : 'Could not export feedback.',
+        );
+      }
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      const logs = await collectLogs();
+      const result = await submitFeedback(
+        {
+          category,
+          title,
+          description,
+          attachments: { screenshots, logs },
+        },
+        context,
+      );
+
+      if (result.status === 'submitted') {
+        Alert.alert('Thanks!', 'Your feedback was sent.', [
+          { text: 'OK', onPress: () => router.back() },
+        ]);
+        return;
+      }
+
+      // Couldn't reach the backend — offer the structured export instead.
+      Alert.alert(
+        'Saved for Export',
+        `Couldn't reach the backend (${result.reason}). Share your feedback as a structured report instead?`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Share',
+            onPress: () => exportPayload(formatFeedbackForExport(result.payload)),
+          },
+        ],
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    canSubmit,
+    collectLogs,
+    category,
+    title,
+    description,
+    screenshots,
+    context,
+    router,
+    exportPayload,
+  ]);
+
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: theme.background }]}
+      edges={['top', 'bottom']}
+    >
+      <ScrollView
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={[styles.title, { color: theme.textPrimary }]}>
+          Send Feedback
+        </Text>
+        <Text style={[styles.subtitle, { color: theme.textSecondary }]}>
+          Report an issue or share an idea while testing. Build and environment
+          details are attached automatically and sensitive values are redacted.
+        </Text>
+
+        <Text style={[styles.label, { color: theme.textPrimary }]}>Category</Text>
+        <View style={styles.categoryRow}>
+          {CATEGORIES.map((option) => {
+            const active = option.value === category;
+            return (
+              <Pressable
+                key={option.value}
+                testID={`category-${option.value}`}
+                onPress={() => setCategory(option.value)}
+                style={[
+                  styles.categoryChip,
+                  {
+                    backgroundColor: active
+                      ? theme.chipActiveBg
+                      : theme.surface,
+                    borderColor: active
+                      ? theme.buttonPrimaryBg
+                      : theme.border,
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.categoryText,
+                    {
+                      color: active ? theme.chipActiveText : theme.textSecondary,
+                    },
+                  ]}
+                >
+                  {option.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <Text style={[styles.label, { color: theme.textPrimary }]}>Title</Text>
+        <TextInput
+          testID="feedback-title"
+          style={[
+            styles.input,
+            {
+              backgroundColor: theme.surface,
+              color: theme.textPrimary,
+              borderColor: theme.border,
+            },
+          ]}
+          placeholder="Short summary"
+          placeholderTextColor={theme.textSecondary}
+          value={title}
+          onChangeText={setTitle}
+          returnKeyType="next"
+        />
+
+        <Text style={[styles.label, { color: theme.textPrimary }]}>
+          Description
+        </Text>
+        <TextInput
+          testID="feedback-description"
+          style={[
+            styles.input,
+            styles.textArea,
+            {
+              backgroundColor: theme.surface,
+              color: theme.textPrimary,
+              borderColor: theme.border,
+            },
+          ]}
+          placeholder="What happened? What did you expect?"
+          placeholderTextColor={theme.textSecondary}
+          value={description}
+          onChangeText={setDescription}
+          multiline
+          textAlignVertical="top"
+        />
+
+        <View
+          style={[
+            styles.optionRow,
+            { backgroundColor: theme.surface, borderColor: theme.border },
+          ]}
+        >
+          <View style={styles.optionCopy}>
+            <Text style={[styles.label, { color: theme.textPrimary }]}>
+              Attach diagnostic logs
+            </Text>
+            <Text style={[styles.helper, { color: theme.textMuted }]}>
+              Includes the offline action queue. Redacted before sending.
+            </Text>
+          </View>
+          <Switch value={attachLogs} onValueChange={setAttachLogs} />
+        </View>
+
+        <Pressable
+          style={[
+            styles.secondaryButton,
+            { backgroundColor: theme.surface, borderColor: theme.border },
+          ]}
+          onPress={handleAttachScreenshot}
+        >
+          <Text style={[styles.secondaryButtonText, { color: theme.textPrimary }]}>
+            {screenshots.length > 0
+              ? `Screenshots attached (${screenshots.length})`
+              : 'Attach screenshot'}
+          </Text>
+        </Pressable>
+
+        <View
+          style={[
+            styles.metadataCard,
+            {
+              backgroundColor: theme.surfaceElevated,
+              borderColor: theme.borderLight,
+            },
+          ]}
+        >
+          <Text style={[styles.metadataTitle, { color: theme.textSecondary }]}>
+            Attached automatically
+          </Text>
+          <MetadataRow theme={theme} label="App version" value={previewMetadata.buildMetadata} />
+          <MetadataRow
+            theme={theme}
+            label="Environment"
+            value={`${context.environmentLabel} (${previewMetadata.network})`}
+          />
+          <MetadataRow theme={theme} label="API" value={previewMetadata.apiUrl} />
+          {previewMetadata.backendVersion ? (
+            <MetadataRow
+              theme={theme}
+              label="Backend"
+              value={previewMetadata.backendVersion}
+            />
+          ) : null}
+          {previewMetadata.walletPublicKeyMasked ? (
+            <MetadataRow
+              theme={theme}
+              label="Wallet"
+              value={previewMetadata.walletPublicKeyMasked}
+            />
+          ) : null}
+          <MetadataRow theme={theme} label="Platform" value={previewMetadata.platform} />
+        </View>
+
+        <Pressable
+          testID="feedback-submit"
+          disabled={!canSubmit}
+          style={[
+            styles.submitButton,
+            {
+              backgroundColor: canSubmit ? theme.buttonPrimaryBg : theme.border,
+            },
+          ]}
+          onPress={handleSubmit}
+        >
+          {submitting ? (
+            <ActivityIndicator color={theme.buttonPrimaryText} />
+          ) : (
+            <Text
+              style={[styles.submitText, { color: theme.buttonPrimaryText }]}
+            >
+              Send Feedback
+            </Text>
+          )}
+        </Pressable>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function MetadataRow({
+  theme,
+  label,
+  value,
+}: {
+  theme: ReturnType<typeof useTheme>['theme'];
+  label: string;
+  value: string;
+}) {
+  return (
+    <View style={styles.metadataRow}>
+      <Text style={[styles.metadataLabel, { color: theme.textMuted }]}>
+        {label}
+      </Text>
+      <Text
+        style={[styles.metadataValue, { color: theme.textPrimary }]}
+        numberOfLines={1}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 24, gap: 14 },
+  title: { fontSize: 28, fontWeight: '800' },
+  subtitle: { fontSize: 15, lineHeight: 21 },
+  label: { fontSize: 15, fontWeight: '700' },
+  helper: { fontSize: 13, lineHeight: 18 },
+  categoryRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  categoryChip: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  categoryText: { fontSize: 14, fontWeight: '600' },
+  input: {
+    borderRadius: 14,
+    borderWidth: 1,
+    padding: 14,
+    fontSize: 16,
+  },
+  textArea: { minHeight: 120 },
+  optionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 14,
+    gap: 12,
+  },
+  optionCopy: { flex: 1, gap: 4 },
+  secondaryButton: {
+    borderWidth: 1,
+    borderRadius: 14,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  secondaryButtonText: { fontSize: 15, fontWeight: '600' },
+  metadataCard: {
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 14,
+    gap: 10,
+  },
+  metadataTitle: {
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  metadataRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  metadataLabel: { fontSize: 13, fontWeight: '600' },
+  metadataValue: { fontSize: 13, flexShrink: 1, fontFamily: 'Courier New' },
+  submitButton: {
+    borderRadius: 16,
+    paddingVertical: 16,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  submitText: { fontSize: 16, fontWeight: '700' },
+});

--- a/app/mobile/app/settings.tsx
+++ b/app/mobile/app/settings.tsx
@@ -382,8 +382,34 @@ export default function SettingsScreen() {
           ) : null}
         </View>
 
+        <View
+          style={[
+            styles.card,
+            { backgroundColor: theme.surface, borderColor: theme.border },
+          ]}
+        >
+          <Text style={[styles.cardTitle, { color: theme.textPrimary }]}>
+            Feedback
+          </Text>
+
+          <Link href="/feedback" asChild>
+            <Pressable style={styles.row}>
+              <View style={styles.rowCopy}>
+                <Text style={[styles.label, { color: theme.textPrimary }]}>
+                  Send Feedback
+                </Text>
+                <Text style={[styles.helper, { color: theme.textMuted }]}>
+                  Report an issue or idea. Build and environment details are
+                  attached automatically.
+                </Text>
+              </View>
+              <Text style={[styles.helper, { color: theme.textMuted }]}>→</Text>
+            </Pressable>
+          </Link>
+        </View>
+
         <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: theme.textPrimary }]}> 
+          <Text style={[styles.sectionTitle, { color: theme.textPrimary }]}>
             Onboarding
           </Text>
           <OnboardingResetButton />

--- a/app/mobile/services/feedback.ts
+++ b/app/mobile/services/feedback.ts
@@ -1,0 +1,214 @@
+/**
+ * Feedback service
+ *
+ * Builds a structured feedback payload from a contributor's form input plus
+ * automatically-captured environment/build/backend metadata, redacts any
+ * sensitive values, and routes the submission to the backend feedback API.
+ *
+ * When the API is unreachable (or no API base URL is configured), the same
+ * redacted payload is returned to the caller as a structured export so it can
+ * be shared/copied out of the app instead of being silently dropped.
+ */
+import {
+  APP_VERSION,
+  BUILD_METADATA,
+  BUILD_NUMBER,
+  BUILD_TAG,
+  APP_ENVIRONMENT,
+  STELLAR_NETWORK,
+} from '../src/config/build';
+import { redactContext, redactFeedbackText } from '../utils/feedback-redaction';
+
+export type FeedbackCategory = 'bug' | 'idea' | 'question' | 'other';
+
+/** Optional attachment hooks resolved lazily so the screen controls capture. */
+export interface FeedbackAttachments {
+  /** URIs of screenshots the contributor chose to attach. */
+  screenshots?: string[];
+  /** Free-form log export (e.g. offline queue dump, recent errors). */
+  logs?: string;
+}
+
+export interface FeedbackInput {
+  category: FeedbackCategory;
+  /** Short one-line summary. */
+  title: string;
+  /** Detailed description of the issue / idea. */
+  description: string;
+  attachments?: FeedbackAttachments;
+}
+
+/** Metadata captured automatically — the contributor never types this. */
+export interface FeedbackMetadata {
+  appVersion: string;
+  buildNumber: string;
+  buildMetadata: string;
+  buildTag: string;
+  environment: string;
+  environmentId: string;
+  apiUrl: string;
+  network: string;
+  /** Backend version reported by the active environment, if known. */
+  backendVersion?: string;
+  /** Masked wallet public key, if a wallet is connected. */
+  walletPublicKeyMasked?: string;
+  platform: string;
+  capturedAt: string;
+}
+
+export interface FeedbackPayload {
+  category: FeedbackCategory;
+  title: string;
+  description: string;
+  screenshots: string[];
+  logs?: string;
+  metadata: FeedbackMetadata;
+  /** Marks that all free-text/context fields have been run through redaction. */
+  redacted: true;
+}
+
+export interface FeedbackContext {
+  environmentId: string;
+  environmentLabel: string;
+  apiUrl: string;
+  backendVersion?: string;
+  walletPublicKey?: string;
+  platform: string;
+}
+
+export type FeedbackResult =
+  | { status: 'submitted'; payload: FeedbackPayload }
+  | { status: 'exported'; payload: FeedbackPayload; reason: string };
+
+/**
+ * Assemble build/environment/backend metadata for a feedback submission.
+ * Wallet public keys are masked here so the full address is never attached.
+ */
+export function buildFeedbackMetadata(context: FeedbackContext): FeedbackMetadata {
+  return {
+    appVersion: APP_VERSION,
+    buildNumber: BUILD_NUMBER,
+    buildMetadata: BUILD_METADATA,
+    buildTag: BUILD_TAG,
+    environment: APP_ENVIRONMENT,
+    environmentId: context.environmentId,
+    apiUrl: context.apiUrl,
+    network: STELLAR_NETWORK,
+    backendVersion: context.backendVersion,
+    walletPublicKeyMasked: context.walletPublicKey
+      ? redactFeedbackText(context.walletPublicKey)
+      : undefined,
+    platform: context.platform,
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Build a fully-redacted, structured feedback payload from raw form input and
+ * captured context. Every contributor-supplied string is scrubbed; metadata is
+ * attached automatically.
+ */
+export function buildFeedbackPayload(
+  input: FeedbackInput,
+  context: FeedbackContext,
+): FeedbackPayload {
+  const attachments = input.attachments ?? {};
+
+  return {
+    category: input.category,
+    title: redactFeedbackText(input.title.trim()),
+    description: redactFeedbackText(input.description.trim()),
+    // Screenshot URIs are local file paths — keep them but redact defensively
+    // in case a path embeds a key or address.
+    screenshots: redactContext(attachments.screenshots ?? []),
+    logs: attachments.logs ? redactFeedbackText(attachments.logs) : undefined,
+    metadata: buildFeedbackMetadata(context),
+    redacted: true,
+  };
+}
+
+/**
+ * Submit feedback. Posts the redacted payload to `${apiUrl}/feedback`; on any
+ * network/HTTP failure it falls back to returning the payload as a structured
+ * export so the contributor can copy/share it instead of losing their report.
+ */
+export async function submitFeedback(
+  input: FeedbackInput,
+  context: FeedbackContext,
+  options?: { fetchImpl?: typeof fetch; signal?: AbortSignal },
+): Promise<FeedbackResult> {
+  const payload = buildFeedbackPayload(input, context);
+  const doFetch = options?.fetchImpl ?? fetch;
+
+  if (!context.apiUrl) {
+    return {
+      status: 'exported',
+      payload,
+      reason: 'No backend configured for this environment.',
+    };
+  }
+
+  try {
+    const response = await doFetch(`${context.apiUrl}/feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: options?.signal,
+    });
+
+    if (!response.ok) {
+      return {
+        status: 'exported',
+        payload,
+        reason: `Backend returned status ${response.status}.`,
+      };
+    }
+
+    return { status: 'submitted', payload };
+  } catch (error) {
+    return {
+      status: 'exported',
+      payload,
+      reason: error instanceof Error ? error.message : 'Failed to reach backend.',
+    };
+  }
+}
+
+/**
+ * Render a feedback payload as human-readable text for clipboard/share export.
+ */
+export function formatFeedbackForExport(payload: FeedbackPayload): string {
+  const m = payload.metadata;
+  const lines = [
+    '=== QuickEx Feedback ===',
+    `Category: ${payload.category}`,
+    `Title: ${payload.title}`,
+    '',
+    'Description:',
+    payload.description || '(none)',
+    '',
+    '--- Environment ---',
+    `App Version: ${m.appVersion}`,
+    `Build: ${m.buildMetadata}`,
+    `Build Number: ${m.buildNumber}`,
+    m.buildTag ? `Build Tag: ${m.buildTag}` : null,
+    `Environment: ${m.environment} (${m.environmentId})`,
+    `API: ${m.apiUrl}`,
+    `Network: ${m.network}`,
+    m.backendVersion ? `Backend Version: ${m.backendVersion}` : null,
+    m.walletPublicKeyMasked ? `Wallet: ${m.walletPublicKeyMasked}` : null,
+    `Platform: ${m.platform}`,
+    `Captured: ${m.capturedAt}`,
+  ];
+
+  if (payload.screenshots.length > 0) {
+    lines.push('', `Screenshots: ${payload.screenshots.length} attached`);
+  }
+  if (payload.logs) {
+    lines.push('', '--- Logs ---', payload.logs);
+  }
+
+  lines.push('', '(Sensitive values redacted before export.)', '========================');
+
+  return lines.filter((line) => line !== null).join('\n');
+}

--- a/app/mobile/utils/feedback-redaction.ts
+++ b/app/mobile/utils/feedback-redaction.ts
@@ -1,0 +1,70 @@
+import { scrubPii } from './piiScrubber';
+
+/**
+ * Privacy-safe redaction for feedback context.
+ *
+ * Feedback submissions can carry attached context (free-text descriptions,
+ * exported logs, copied error payloads) that may contain sensitive values.
+ * QuickEx is a Stellar wallet, so the highest-risk leak is a secret seed or a
+ * raw account public key — neither of which the generic {@link scrubPii}
+ * handles. This module layers Stellar-aware redaction on top of the existing
+ * PII scrubber so a single call covers emails/phones/cards *and* wallet keys.
+ */
+
+// Stellar secret seeds start with `S` and are 56 base32 chars. These must never
+// leave the device — redact aggressively.
+const STELLAR_SECRET = /\bS[A-Z2-7]{55}\b/g;
+
+// Stellar public keys start with `G` and are 56 base32 chars. Not secret, but
+// they identify a user's account, so we partially mask rather than drop them —
+// keeping a prefix/suffix lets contributors correlate reports without exposing
+// the full address.
+const STELLAR_PUBLIC_KEY = /\bG[A-Z2-7]{55}\b/g;
+
+/**
+ * Mask a Stellar public key to `GABC…WXYZ`, preserving enough to correlate
+ * reports while removing the full identifier.
+ */
+export function maskStellarPublicKey(key: string): string {
+  if (key.length < 12) return key;
+  return `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+/**
+ * Redact sensitive values from a single string: standard PII plus Stellar
+ * secret seeds (fully removed) and public keys (masked).
+ */
+export function redactFeedbackText(text: string): string {
+  if (!text) return text;
+
+  let redacted = text.replace(STELLAR_SECRET, '[REDACTED_SECRET_KEY]');
+  redacted = redacted.replace(STELLAR_PUBLIC_KEY, (match) =>
+    maskStellarPublicKey(match),
+  );
+
+  // Run the shared PII scrubber last so its replacement tokens (e.g. [EMAIL])
+  // are never themselves matched by the Stellar patterns above.
+  return scrubPii(redacted);
+}
+
+/**
+ * Recursively redact every string value in a context object. Keys are left
+ * intact; only values are scrubbed. Useful for sanitising structured metadata
+ * before it is attached to a feedback payload.
+ */
+export function redactContext<T>(value: T): T {
+  if (typeof value === 'string') {
+    return redactFeedbackText(value) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactContext(item)) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = redactContext(val);
+    }
+    return out as T;
+  }
+  return value;
+}


### PR DESCRIPTION
I built the in-app feedback feature on feat/mobile-feedback-capture, matching the existing Expo/expo-router conventions (useTheme tokens, useEnvironment, useWallet, SafeAreaView screens).
Closes #588 
What I added
[utils/feedback-redaction.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/app/mobile/utils/feedback-redaction.ts) — Stellar-aware redaction layered on the existing scrubPii:

Secret seeds (S…, 56 base32) → fully removed as [REDACTED_SECRET_KEY]
Public keys (G…) → masked to GABC…WXYZ (correlatable, not exposed)
redactContext() recursively scrubs every string in a structured object
This is the key privacy decision: in a wallet app the real leak risk is a seed/address, which the generic PII scrubber doesn't cover.
[services/feedback.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/app/mobile/services/feedback.ts) — payload assembly + routing:

buildFeedbackMetadata() auto-attaches app version, build number/tag, environment + API URL, network, backend version, masked wallet key, platform, timestamp
buildFeedbackPayload() trims + redacts all contributor text and marks redacted: true
submitFeedback() POSTs to ${apiUrl}/feedback; on HTTP error, network failure, or no configured API it falls back to a structured export so reports are never lost
formatFeedbackForExport() renders shareable text
[app/feedback.tsx](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/app/mobile/app/feedback.tsx) — the screen: category chips, title/description, a diagnostic-logs toggle (exports the offline queue, redacted), a screenshot-attach hook, a live "attached automatically" metadata preview, and submit-with-export-fallback via the native Share sheet.

Wiring: registered the route in [_layout.tsx](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/app/mobile/app/_layout.tsx) and added a "Send Feedback" card in [settings.tsx](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/app/mobile/app/settings.tsx).

Tests: [feedback-redaction.test.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/app/mobile/__tests__/feedback-redaction.test.ts) and [feedback-service.test.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/app/mobile/__tests__/feedback-service.test.ts) cover redaction (incl. asserting secrets never appear in the POST body), metadata masking, and all four submit outcomes.