### PR TITLE
feat(backend): oracle failure test harness for pricing regressions

### DIFF
--- a/app/backend/src/stellar/__tests__/oracle-failure.harness.unit.spec.ts
+++ b/app/backend/src/stellar/__tests__/oracle-failure.harness.unit.spec.ts
@@ -1,0 +1,646 @@
+/**
+ * oracle-failure.harness.unit.spec.ts
+ *
+ * Dedicated test harness for oracle outages, stale data, and malformed
+ * responses so pricing-related regressions are caught before deploys.
+ *
+ * Test surface:
+ *  1. PathPreviewService – direct oracle interactions (fetch wiring)
+ *  2. QuoteService        – downstream effects of oracle failures on fee/pricing
+ *  3. Parameterised suite – all ORACLE_SCENARIOS exercised in one table
+ *  4. Staleness detection – isStaleAmount() utility
+ *  5. Harness self-tests  – fixtures and helpers are internally consistent
+ */
+
+import {
+  BadRequestException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+
+import { PathPreviewService } from '../path-preview.service';
+import { QuoteService } from '../quote.service';
+
+// ---------------------------------------------------------------------------
+// Harness imports
+// ---------------------------------------------------------------------------
+
+import {
+  ORACLE_SCENARIOS,
+  HEALTHY_HORIZON_RESPONSE,
+  HEALTHY_MULTIHOP_HORIZON_RESPONSE,
+  STALE_HORIZON_RESPONSE,
+  STALE_AMOUNT_THRESHOLD,
+  INVALID_HORIZON_RESPONSE_NO_EMBEDDED,
+  INVALID_HORIZON_RESPONSE_RECORDS_NOT_ARRAY,
+  EMPTY_PATHS_HORIZON_RESPONSE,
+  INVALID_RECORD_NAN_AMOUNT,
+  INVALID_RECORD_NEGATIVE_AMOUNT,
+  HTTP_503_RESPONSE,
+  HTTP_429_RESPONSE,
+  HTTP_500_RESPONSE,
+  NETWORK_TIMEOUT_ERROR,
+  NETWORK_CONNECTION_REFUSED_ERROR,
+  USDC_ISSUER,
+  makeOkFetchResponse,
+  HEALTHY_PATH_RECORD,
+  PARTIAL_DATA_HORIZON_RESPONSE,
+} from './oracle-harness.fixtures';
+
+import {
+  makePathPreviewService,
+  makeQuoteService,
+  wireFetchForState,
+  isStaleAmount,
+  oracleScenariosTable,
+  HARNESS_STRICT_RECEIVE_REQUEST,
+  HARNESS_STRICT_SEND_REQUEST,
+  HARNESS_QUOTE_REQUEST,
+  makeAppConfigStub,
+} from './oracle-harness.helpers';
+
+// ---------------------------------------------------------------------------
+// Shared test state
+// ---------------------------------------------------------------------------
+
+let service: PathPreviewService;
+let fetchSpy: jest.SpyInstance;
+
+beforeEach(async () => {
+  service = await makePathPreviewService();
+  fetchSpy = jest.spyOn(global, 'fetch');
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ===========================================================================
+// 1. PathPreviewService – HTTP-level oracle failures
+// ===========================================================================
+
+describe('PathPreviewService – oracle HTTP failures (strict-receive)', () => {
+  it('throws ServiceUnavailableException on HTTP 503', async () => {
+    fetchSpy.mockResolvedValueOnce(HTTP_503_RESPONSE);
+
+    await expect(
+      service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST),
+    ).rejects.toThrow(ServiceUnavailableException);
+  });
+
+  it('throws ServiceUnavailableException on HTTP 429', async () => {
+    fetchSpy.mockResolvedValueOnce(HTTP_429_RESPONSE);
+
+    await expect(
+      service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST),
+    ).rejects.toThrow(ServiceUnavailableException);
+  });
+
+  it('throws ServiceUnavailableException on HTTP 500', async () => {
+    fetchSpy.mockResolvedValueOnce(HTTP_500_RESPONSE);
+
+    await expect(
+      service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST),
+    ).rejects.toThrow(ServiceUnavailableException);
+  });
+
+  it('throws ServiceUnavailableException on network timeout', async () => {
+    fetchSpy.mockRejectedValueOnce(NETWORK_TIMEOUT_ERROR);
+
+    await expect(
+      service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST),
+    ).rejects.toThrow(ServiceUnavailableException);
+  });
+
+  it('throws ServiceUnavailableException on connection refused', async () => {
+    fetchSpy.mockRejectedValueOnce(NETWORK_CONNECTION_REFUSED_ERROR);
+
+    await expect(
+      service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST),
+    ).rejects.toThrow(ServiceUnavailableException);
+  });
+
+  it('does not leak the raw network error message to callers', async () => {
+    fetchSpy.mockRejectedValueOnce(NETWORK_TIMEOUT_ERROR);
+
+    try {
+      await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+      fail('Expected ServiceUnavailableException');
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(ServiceUnavailableException);
+      // The raw error should not be forwarded in the exception message
+      const msg = JSON.stringify((err as ServiceUnavailableException).getResponse());
+      expect(msg).not.toContain('Network timeout');
+    }
+  });
+});
+
+// ===========================================================================
+// 2. PathPreviewService – oracle outage on strict-send endpoint
+// ===========================================================================
+
+describe('PathPreviewService – oracle HTTP failures (strict-send)', () => {
+  it('throws ServiceUnavailableException on HTTP 503', async () => {
+    fetchSpy.mockResolvedValueOnce(HTTP_503_RESPONSE);
+
+    await expect(
+      service.strictSendPaths(HARNESS_STRICT_SEND_REQUEST),
+    ).rejects.toThrow(ServiceUnavailableException);
+  });
+
+  it('throws ServiceUnavailableException on network error', async () => {
+    fetchSpy.mockRejectedValueOnce(NETWORK_TIMEOUT_ERROR);
+
+    await expect(
+      service.strictSendPaths(HARNESS_STRICT_SEND_REQUEST),
+    ).rejects.toThrow(ServiceUnavailableException);
+  });
+
+  it('returns empty paths (not an exception) when oracle is reachable but has no records', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse(EMPTY_PATHS_HORIZON_RESPONSE),
+    );
+
+    const result = await service.strictSendPaths(HARNESS_STRICT_SEND_REQUEST);
+    expect(result.paths).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// 3. PathPreviewService – malformed / stale oracle data
+// ===========================================================================
+
+describe('PathPreviewService – malformed oracle responses (strict-receive)', () => {
+  it('returns empty paths when _embedded is missing entirely', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse(INVALID_HORIZON_RESPONSE_NO_EMBEDDED),
+    );
+
+    const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+    expect(result.paths).toHaveLength(0);
+  });
+
+  it('returns empty paths when records is not an array', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse(INVALID_HORIZON_RESPONSE_RECORDS_NOT_ARRAY),
+    );
+
+    const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+    expect(result.paths).toHaveLength(0);
+  });
+
+  it('includes records with NaN amounts without throwing', async () => {
+    // The service maps records; NaN propagation is handled by consumers (QuoteService)
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse({
+        _embedded: { records: [INVALID_RECORD_NAN_AMOUNT] },
+      }),
+    );
+
+    const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+    expect(result.paths).toHaveLength(1);
+    // rateDescription should degrade gracefully to "—"
+    expect(result.paths[0].rateDescription).toBe('—');
+  });
+
+  it('includes records with negative amounts without throwing', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse({
+        _embedded: { records: [INVALID_RECORD_NEGATIVE_AMOUNT] },
+      }),
+    );
+
+    const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+    expect(result.paths).toHaveLength(1);
+    expect(result.paths[0].sourceAmount).toBe('-100.0000000');
+  });
+
+  it('returns only valid records from a partial-data response', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse(PARTIAL_DATA_HORIZON_RESPONSE),
+    );
+
+    // PathPreviewService maps all three records; consumer (QuoteService) sees the raw amounts
+    const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+    expect(result.paths.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('PathPreviewService – stale oracle data', () => {
+  it('returns stale paths without throwing (caller decides how to handle)', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse(STALE_HORIZON_RESPONSE),
+    );
+
+    const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+    expect(result.paths).toHaveLength(1);
+    // The source amount should match the stale fixture value
+    expect(result.paths[0].sourceAmount).toBe('0.0000001');
+  });
+
+  it('stale amounts are flagged by isStaleAmount()', () => {
+    const stalePath = {
+      sourceAmount: '0.0000001',
+      destinationAmount: '0.0000001',
+    };
+    expect(isStaleAmount(stalePath.sourceAmount)).toBe(true);
+    expect(isStaleAmount(stalePath.destinationAmount)).toBe(true);
+  });
+
+  it('healthy amounts are not flagged as stale', () => {
+    expect(isStaleAmount('100.0000000')).toBe(false);
+    expect(isStaleAmount('10.0000000')).toBe(false);
+    expect(isStaleAmount('0.1000000')).toBe(false);
+  });
+
+  it('STALE_AMOUNT_THRESHOLD is less than the smallest sensible trade amount', () => {
+    expect(STALE_AMOUNT_THRESHOLD).toBeLessThan(0.01);
+    expect(STALE_AMOUNT_THRESHOLD).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// 4. QuoteService – downstream fee/pricing effects of oracle failures
+// ===========================================================================
+
+describe('QuoteService – oracle failure propagation', () => {
+  it('throws ServiceUnavailableException when oracle is down', async () => {
+    const svc = makeQuoteService(null);
+
+    await expect(svc.createQuote(HARNESS_QUOTE_REQUEST)).rejects.toThrow(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('throws BadRequestException (NO_PATH_FOUND) when oracle returns empty paths', async () => {
+    const svc = makeQuoteService([]);
+
+    await expect(svc.createQuote(HARNESS_QUOTE_REQUEST)).rejects.toMatchObject({
+      response: { code: 'NO_PATH_FOUND' },
+    });
+  });
+
+  it('produces a valid quote with correct fee breakdown when oracle is healthy', async () => {
+    const svc = makeQuoteService([
+      {
+        sourceAmount: '100.0000000',
+        sourceAsset: 'XLM',
+        destinationAmount: '10.0000000',
+        destinationAsset: `USDC:${USDC_ISSUER.slice(0, 4)}…${USDC_ISSUER.slice(-4)}`,
+        hopCount: 0,
+        pathHops: [],
+        rateDescription: '0.100000 (dest/source in smallest units)',
+      },
+    ]);
+
+    const quote = await svc.createQuote(HARNESS_QUOTE_REQUEST);
+
+    expect(quote.quoteId).toMatch(/^qx_[a-f0-9]{24}$/);
+    expect(quote.paths).toHaveLength(1);
+    expect(quote.paths[0].feeBreakdown).toEqual({
+      networkFee: '0.0000100',
+      platformFee: '0.1000000', // 1% of 10.0
+      totalFee: '0.1000000',
+    });
+  });
+
+  it('fee breakdown is zero-safe when destination amount cannot be parsed', async () => {
+    // Oracle returns a NaN amount – QuoteService should not throw
+    const svc = makeQuoteService([
+      {
+        sourceAmount: 'not-a-number',
+        sourceAsset: 'XLM',
+        destinationAmount: 'not-a-number',
+        destinationAsset: 'USDC',
+        hopCount: 0,
+        pathHops: [],
+        rateDescription: '—',
+      },
+    ]);
+
+    const quote = await svc.createQuote(HARNESS_QUOTE_REQUEST);
+    // When destNum is NaN, platformFee should fall back to "0.0000000"
+    expect(quote.paths[0].feeBreakdown.platformFee).toBe('0.0000000');
+    expect(quote.paths[0].feeBreakdown.totalFee).toBe('0.0000000');
+  });
+
+  it('slippage calculation is zero-safe when source amount is NaN', async () => {
+    const svc = makeQuoteService([
+      {
+        sourceAmount: 'not-a-number',
+        sourceAsset: 'XLM',
+        destinationAmount: '10.0000000',
+        destinationAsset: 'USDC',
+        hopCount: 0,
+        pathHops: [],
+        rateDescription: '—',
+      },
+    ]);
+
+    const quote = await svc.createQuote(HARNESS_QUOTE_REQUEST);
+    // When srcNum is non-finite, sourceAmountWithSlippage should equal the raw sourceAmount
+    expect(quote.paths[0].sourceAmountWithSlippage).toBe('not-a-number');
+  });
+
+  it('quote expiry is set correctly even during oracle failures that succeed after retry', async () => {
+    const svc = makeQuoteService([
+      {
+        sourceAmount: '100.0000000',
+        sourceAsset: 'XLM',
+        destinationAmount: '10.0000000',
+        destinationAsset: 'USDC',
+        hopCount: 0,
+        pathHops: [],
+        rateDescription: '0.100000',
+      },
+    ]);
+
+    const before = Date.now();
+    const quote = await svc.createQuote({ ...HARNESS_QUOTE_REQUEST, ttlSeconds: 30 });
+    const expiryMs = new Date(quote.expiresAt).getTime();
+
+    expect(expiryMs).toBeGreaterThan(before + 25_000);
+    expect(expiryMs).toBeLessThanOrEqual(before + 35_000);
+  });
+});
+
+// ===========================================================================
+// 5. Successful path – full pipeline smoke test
+// ===========================================================================
+
+describe('PathPreviewService – healthy oracle (smoke)', () => {
+  it('returns the expected paths for a valid strict-receive request', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse(HEALTHY_HORIZON_RESPONSE),
+    );
+
+    const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+
+    expect(result.paths).toHaveLength(1);
+    expect(result.paths[0].sourceAsset).toBe('XLM');
+    expect(result.paths[0].destinationAmount).toBe('10.0000000');
+    expect(result.paths[0].hopCount).toBe(0);
+    expect(result.horizonUrl).toContain('testnet');
+  });
+
+  it('correctly parses multi-hop path records', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse(HEALTHY_MULTIHOP_HORIZON_RESPONSE),
+    );
+
+    const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+
+    expect(result.paths[0].hopCount).toBe(1);
+    expect(result.paths[0].pathHops).toHaveLength(1);
+    expect(result.paths[0].pathHops[0]).toContain('AQUA');
+  });
+
+  it('returns the testnet Horizon URL for testnet config', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse(HEALTHY_HORIZON_RESPONSE),
+    );
+
+    const { horizonUrl } = await service.previewPaths(
+      HARNESS_STRICT_RECEIVE_REQUEST,
+    );
+    expect(horizonUrl).toBe('https://horizon-testnet.stellar.org');
+  });
+
+  it('returns the mainnet Horizon URL when configured for mainnet', async () => {
+    const mainnetService = await makePathPreviewService(true);
+    fetchSpy.mockResolvedValueOnce(
+      makeOkFetchResponse(HEALTHY_HORIZON_RESPONSE),
+    );
+
+    const { horizonUrl } = await mainnetService.previewPaths(
+      HARNESS_STRICT_RECEIVE_REQUEST,
+    );
+    expect(horizonUrl).toBe('https://horizon.stellar.org');
+  });
+});
+
+// ===========================================================================
+// 6. Parameterised harness – all ORACLE_SCENARIOS
+// ===========================================================================
+
+describe('Parameterised oracle harness – PathPreviewService (strict-receive)', () => {
+  describe.each(oracleScenariosTable(ORACLE_SCENARIOS))(
+    '%s',
+    (_label: string, scenario) => {
+      it('satisfies its scenario contract', async () => {
+        wireFetchForState(fetchSpy, scenario.state);
+
+        if (scenario.expectsUnavailable) {
+          await expect(
+            service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST),
+          ).rejects.toThrow(ServiceUnavailableException);
+          return;
+        }
+
+        // For all other states, previewPaths resolves (empty or populated)
+        const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+
+        if (scenario.expectsNoPath || scenario.state === 'invalid_response' || scenario.state === 'empty_paths') {
+          expect(result.paths).toHaveLength(0);
+        } else {
+          // success and stale both return ≥ 1 path
+          expect(result.paths.length).toBeGreaterThanOrEqual(1);
+        }
+      });
+    },
+  );
+});
+
+describe('Parameterised oracle harness – QuoteService', () => {
+  describe.each(oracleScenariosTable(ORACLE_SCENARIOS))(
+    '%s',
+    (_label: string, scenario) => {
+      it('satisfies its scenario contract', async () => {
+        if (scenario.expectsUnavailable) {
+          const svc = makeQuoteService(null);
+          await expect(
+            svc.createQuote(HARNESS_QUOTE_REQUEST),
+          ).rejects.toThrow(ServiceUnavailableException);
+          return;
+        }
+
+        if (scenario.expectsNoPath) {
+          const svc = makeQuoteService([]);
+          await expect(
+            svc.createQuote(HARNESS_QUOTE_REQUEST),
+          ).rejects.toMatchObject({ response: { code: 'NO_PATH_FOUND' } });
+          return;
+        }
+
+        if (scenario.expectsQuote) {
+          // Build a minimal path row appropriate for the scenario
+          const sourceAmount =
+            scenario.state === 'stale' ? '0.0000001' : '100.0000000';
+          const destAmount =
+            scenario.state === 'stale' ? '0.0000001' : '10.0000000';
+
+          const svc = makeQuoteService([
+            {
+              sourceAmount,
+              sourceAsset: 'XLM',
+              destinationAmount: destAmount,
+              destinationAsset: `USDC:GA5Z…KZVN`,
+              hopCount: 0,
+              pathHops: [],
+              rateDescription: '—',
+            },
+          ]);
+
+          const quote = await svc.createQuote(HARNESS_QUOTE_REQUEST);
+          expect(quote.quoteId).toMatch(/^qx_/);
+          expect(new Date(quote.expiresAt).getTime()).toBeGreaterThan(Date.now());
+
+          // Stale scenario: verify staleness can be detected in the result
+          if (scenario.state === 'stale') {
+            const staleDetected = isStaleAmount(quote.paths[0].sourceAmount);
+            expect(staleDetected).toBe(true);
+          }
+        }
+      });
+    },
+  );
+});
+
+// ===========================================================================
+// 7. Harness self-tests – verify fixtures / helpers are internally consistent
+// ===========================================================================
+
+describe('Harness self-tests', () => {
+  describe('ORACLE_SCENARIOS', () => {
+    it('contains all eight expected states', () => {
+      const states = ORACLE_SCENARIOS.map((s) => s.state);
+      expect(states).toContain('success');
+      expect(states).toContain('stale');
+      expect(states).toContain('invalid_response');
+      expect(states).toContain('empty_paths');
+      expect(states).toContain('http_503');
+      expect(states).toContain('http_429');
+      expect(states).toContain('http_500');
+      expect(states).toContain('network_error');
+      expect(states).toHaveLength(8);
+    });
+
+    it('has exactly one success scenario that expects a quote', () => {
+      const successScenarios = ORACLE_SCENARIOS.filter(
+        (s) => s.state === 'success',
+      );
+      expect(successScenarios).toHaveLength(1);
+      expect(successScenarios[0].expectsQuote).toBe(true);
+    });
+
+    it('scenarios are mutually exclusive: each has exactly one truthy expect flag', () => {
+      for (const scenario of ORACLE_SCENARIOS) {
+        const flags = [
+          scenario.expectsQuote,
+          scenario.expectsUnavailable,
+          scenario.expectsNoPath,
+        ];
+        const trueCount = flags.filter(Boolean).length;
+        // Stale is the only scenario where two could be true (quote + stale check),
+        // but in our fixture only expectsQuote is true for stale.
+        expect(trueCount).toBeGreaterThanOrEqual(1);
+      }
+    });
+  });
+
+  describe('isStaleAmount()', () => {
+    it('returns false for empty string', () => {
+      expect(isStaleAmount('')).toBe(false);
+    });
+
+    it('returns false for zero', () => {
+      expect(isStaleAmount('0')).toBe(false);
+    });
+
+    it('returns false for NaN string', () => {
+      expect(isStaleAmount('not-a-number')).toBe(false);
+    });
+
+    it('returns false for negative numbers', () => {
+      expect(isStaleAmount('-100')).toBe(false);
+    });
+
+    it(`returns true for amounts below the threshold (${STALE_AMOUNT_THRESHOLD})`, () => {
+      expect(isStaleAmount('0.0000001')).toBe(true);
+      expect(isStaleAmount('0.0009999')).toBe(true);
+    });
+
+    it('returns false for amounts at or above the threshold', () => {
+      expect(isStaleAmount(STALE_AMOUNT_THRESHOLD.toString())).toBe(false);
+      expect(isStaleAmount('1.0000000')).toBe(false);
+    });
+  });
+
+  describe('makeAppConfigStub()', () => {
+    it('returns testnet stub by default', () => {
+      expect(makeAppConfigStub().isMainnet).toBe(false);
+    });
+
+    it('returns mainnet stub when requested', () => {
+      expect(makeAppConfigStub(true).isMainnet).toBe(true);
+    });
+  });
+
+  describe('makeOkFetchResponse()', () => {
+    it('returns a response with ok=true and the given body', async () => {
+      const body = { _embedded: { records: [] } };
+      const res = makeOkFetchResponse(body);
+      expect(res.ok).toBe(true);
+      const parsed = await res.json();
+      expect(parsed).toEqual(body);
+    });
+  });
+
+  describe('oracleScenariosTable()', () => {
+    it('produces [label, scenario] tuples', () => {
+      const table = oracleScenariosTable(ORACLE_SCENARIOS);
+      expect(table).toHaveLength(ORACLE_SCENARIOS.length);
+      for (const [label, scenario] of table) {
+        expect(typeof label).toBe('string');
+        expect(label).toContain(scenario.state);
+        expect(scenario).toHaveProperty('description');
+      }
+    });
+
+    it('returns an empty array when given an empty scenarios array', () => {
+      expect(oracleScenariosTable([])).toEqual([]);
+    });
+  });
+
+  describe('HEALTHY_PATH_RECORD fixture', () => {
+    it('has the expected USDC issuer', () => {
+      expect(HEALTHY_PATH_RECORD.destination_asset_issuer).toBe(USDC_ISSUER);
+    });
+
+    it('has valid amount strings', () => {
+      expect(Number.isFinite(parseFloat(HEALTHY_PATH_RECORD.source_amount))).toBe(true);
+      expect(Number.isFinite(parseFloat(HEALTHY_PATH_RECORD.destination_amount))).toBe(true);
+    });
+  });
+
+  describe('wireFetchForState()', () => {
+    it('configures fetch to reject for network_error state', async () => {
+      wireFetchForState(fetchSpy, 'network_error');
+      await expect(
+        fetch('https://horizon-testnet.stellar.org/paths/strict-receive?test=1'),
+      ).rejects.toThrow();
+    });
+
+    it('configures fetch to return non-ok for http_503 state', async () => {
+      wireFetchForState(fetchSpy, 'http_503');
+      const res = await fetch('https://any-url.example.com');
+      expect(res.ok).toBe(false);
+      expect(res.status).toBe(503);
+    });
+
+    it('configures fetch to return ok for success state', async () => {
+      wireFetchForState(fetchSpy, 'success');
+      const res = await fetch('https://any-url.example.com');
+      expect(res.ok).toBe(true);
+    });
+  });
+});

--- a/app/backend/src/stellar/__tests__/oracle-failure.harness.unit.spec.ts
+++ b/app/backend/src/stellar/__tests__/oracle-failure.harness.unit.spec.ts
@@ -12,13 +12,9 @@
  *  5. Harness self-tests  – fixtures and helpers are internally consistent
  */
 
-import {
-  BadRequestException,
-  ServiceUnavailableException,
-} from '@nestjs/common';
+import { ServiceUnavailableException } from '@nestjs/common';
 
 import { PathPreviewService } from '../path-preview.service';
-import { QuoteService } from '../quote.service';
 
 // ---------------------------------------------------------------------------
 // Harness imports

--- a/app/backend/src/stellar/__tests__/oracle-harness.fixtures.ts
+++ b/app/backend/src/stellar/__tests__/oracle-harness.fixtures.ts
@@ -1,0 +1,343 @@
+/**
+ * oracle-harness.fixtures.ts
+ *
+ * Reusable fixtures for oracle outage and pricing-regression tests.
+ *
+ * Three canonical oracle states are defined:
+ *   - SUCCESS   – healthy Horizon response with valid path records
+ *   - STALE     – Horizon responds but the data is outdated (old ledger timestamps,
+ *                 amounts that have not moved for longer than the staleness threshold)
+ *   - INVALID   – Horizon responds with a structurally malformed payload that
+ *                 violates the expected schema (missing required fields, wrong types)
+ *
+ * Additional edge-case fixtures cover:
+ *   - EMPTY_PATHS  – valid envelope but zero path records (valid oracle, no liquidity)
+ *   - PARTIAL_DATA – some records are well-formed, others are missing fields
+ *   - NEGATIVE_AMOUNT – negative / nonsensical amount strings
+ *   - NETWORK_ERROR  – raw network-layer rejection (no HTTP response at all)
+ */
+
+import type { PathPreviewRow } from '../path-preview.service';
+
+// ---------------------------------------------------------------------------
+// Canonical Horizon path record shape
+// ---------------------------------------------------------------------------
+
+export interface HorizonPathRecord {
+  source_asset_type: string;
+  source_asset_code?: string;
+  source_asset_issuer?: string;
+  source_amount: string;
+  destination_asset_type: string;
+  destination_asset_code?: string;
+  destination_asset_issuer?: string;
+  destination_amount: string;
+  path?: Array<{
+    asset_type: string;
+    asset_code?: string;
+    asset_issuer?: string;
+  }>;
+}
+
+export interface HorizonPathsEnvelope {
+  _embedded?: { records: HorizonPathRecord[] };
+}
+
+// ---------------------------------------------------------------------------
+// Well-known test values
+// ---------------------------------------------------------------------------
+
+/** Verified USDC issuer on Stellar (matches verified-assets.constant.ts) */
+export const USDC_ISSUER =
+  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+
+/** Verified AQUA issuer on Stellar */
+export const AQUA_ISSUER =
+  'GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA';
+
+/** Horizon testnet base URL */
+export const TESTNET_HORIZON_URL = 'https://horizon-testnet.stellar.org';
+
+// ---------------------------------------------------------------------------
+// SUCCESS – healthy, up-to-date oracle response
+// ---------------------------------------------------------------------------
+
+export const HEALTHY_PATH_RECORD: HorizonPathRecord = {
+  source_asset_type: 'native',
+  source_amount: '100.0000000',
+  destination_asset_type: 'credit_alphanum4',
+  destination_asset_code: 'USDC',
+  destination_asset_issuer: USDC_ISSUER,
+  destination_amount: '10.0000000',
+  path: [],
+};
+
+export const HEALTHY_HORIZON_RESPONSE: HorizonPathsEnvelope = {
+  _embedded: { records: [HEALTHY_PATH_RECORD] },
+};
+
+/** Multi-hop variant – includes an intermediate AQUA hop */
+export const HEALTHY_MULTIHOP_PATH_RECORD: HorizonPathRecord = {
+  source_asset_type: 'native',
+  source_amount: '50.0000000',
+  destination_asset_type: 'credit_alphanum4',
+  destination_asset_code: 'USDC',
+  destination_asset_issuer: USDC_ISSUER,
+  destination_amount: '5.0000000',
+  path: [
+    {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'AQUA',
+      asset_issuer: AQUA_ISSUER,
+    },
+  ],
+};
+
+export const HEALTHY_MULTIHOP_HORIZON_RESPONSE: HorizonPathsEnvelope = {
+  _embedded: { records: [HEALTHY_MULTIHOP_PATH_RECORD] },
+};
+
+/** Resolved path-preview row shape (what PathPreviewService.previewPaths returns) */
+export const HEALTHY_PATH_ROW: PathPreviewRow = {
+  sourceAmount: '100.0000000',
+  sourceAsset: 'XLM',
+  destinationAmount: '10.0000000',
+  destinationAsset: `USDC:${USDC_ISSUER.slice(0, 4)}…${USDC_ISSUER.slice(-4)}`,
+  hopCount: 0,
+  pathHops: [],
+  rateDescription: expect.any(String) as unknown as string,
+};
+
+// ---------------------------------------------------------------------------
+// STALE – oracle still reachable but data is suspiciously old
+//
+// A "stale" oracle has:
+//  • amounts that look like they have not changed over multiple ledgers
+//  • a `last_modified_ledger` far behind the latest ledger
+//  • rateDescription that indicates a degraded (unchanged) ratio
+//
+// For harness purposes we simulate this by injecting a sentinel amount string
+// (OracleHarnessHelpers.isStaleAmount() detects it) and using a very small
+// ledger gap marker embedded in the record.
+// ---------------------------------------------------------------------------
+
+export const STALE_PATH_RECORD: HorizonPathRecord = {
+  source_asset_type: 'native',
+  source_amount: '0.0000001', // suspiciously tiny — staleness indicator
+  destination_asset_type: 'credit_alphanum4',
+  destination_asset_code: 'USDC',
+  destination_asset_issuer: USDC_ISSUER,
+  destination_amount: '0.0000001',
+  path: [],
+};
+
+export const STALE_HORIZON_RESPONSE: HorizonPathsEnvelope = {
+  _embedded: { records: [STALE_PATH_RECORD] },
+};
+
+/** Amount threshold below which we treat an oracle response as stale (in stroops-as-decimal) */
+export const STALE_AMOUNT_THRESHOLD = 0.001;
+
+// ---------------------------------------------------------------------------
+// INVALID – structurally broken Horizon payloads
+// ---------------------------------------------------------------------------
+
+/** Missing destination amount */
+export const INVALID_RECORD_MISSING_DEST_AMOUNT: Partial<HorizonPathRecord> = {
+  source_asset_type: 'native',
+  source_amount: '100.0000000',
+  destination_asset_type: 'credit_alphanum4',
+  destination_asset_code: 'USDC',
+  destination_asset_issuer: USDC_ISSUER,
+  // destination_amount deliberately omitted
+};
+
+/** Amount is a non-numeric string */
+export const INVALID_RECORD_NAN_AMOUNT: HorizonPathRecord = {
+  source_asset_type: 'native',
+  source_amount: 'not-a-number',
+  destination_asset_type: 'credit_alphanum4',
+  destination_asset_code: 'USDC',
+  destination_asset_issuer: USDC_ISSUER,
+  destination_amount: 'also-not-a-number',
+  path: [],
+};
+
+/** Negative amount string */
+export const INVALID_RECORD_NEGATIVE_AMOUNT: HorizonPathRecord = {
+  source_asset_type: 'native',
+  source_amount: '-100.0000000',
+  destination_asset_type: 'credit_alphanum4',
+  destination_asset_code: 'USDC',
+  destination_asset_issuer: USDC_ISSUER,
+  destination_amount: '-10.0000000',
+  path: [],
+};
+
+/** Completely wrong shape – top-level envelope is missing _embedded */
+export const INVALID_HORIZON_RESPONSE_NO_EMBEDDED: object = {
+  status: 200,
+  data: [], // wrong key
+};
+
+/** _embedded present but records is not an array */
+export const INVALID_HORIZON_RESPONSE_RECORDS_NOT_ARRAY: object = {
+  _embedded: {
+    records: 'this-should-be-an-array',
+  },
+};
+
+/** Null body */
+export const INVALID_HORIZON_RESPONSE_NULL: null = null;
+
+// ---------------------------------------------------------------------------
+// EMPTY_PATHS – valid envelope, zero liquidity
+// ---------------------------------------------------------------------------
+
+export const EMPTY_PATHS_HORIZON_RESPONSE: HorizonPathsEnvelope = {
+  _embedded: { records: [] },
+};
+
+// ---------------------------------------------------------------------------
+// PARTIAL_DATA – mix of valid and broken records
+// ---------------------------------------------------------------------------
+
+export const PARTIAL_DATA_HORIZON_RESPONSE: { _embedded: { records: unknown[] } } = {
+  _embedded: {
+    records: [
+      HEALTHY_PATH_RECORD,
+      INVALID_RECORD_MISSING_DEST_AMOUNT,
+      INVALID_RECORD_NAN_AMOUNT,
+    ],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// HTTP-level failure fixtures
+// ---------------------------------------------------------------------------
+
+/** HTTP 503 – oracle temporarily unavailable */
+export const HTTP_503_RESPONSE = {
+  ok: false,
+  status: 503,
+  text: async () => 'Service Unavailable',
+} as unknown as Response;
+
+/** HTTP 429 – rate-limited */
+export const HTTP_429_RESPONSE = {
+  ok: false,
+  status: 429,
+  text: async () => 'Too Many Requests',
+} as unknown as Response;
+
+/** HTTP 500 – internal server error */
+export const HTTP_500_RESPONSE = {
+  ok: false,
+  status: 500,
+  text: async () => 'Internal Server Error',
+} as unknown as Response;
+
+/** HTTP 200 with valid JSON payload (healthy) */
+export function makeOkFetchResponse(
+  body: object,
+): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Network-layer error (no HTTP response at all)
+// ---------------------------------------------------------------------------
+
+export const NETWORK_TIMEOUT_ERROR = new Error('Network timeout');
+export const NETWORK_CONNECTION_REFUSED_ERROR = new Error(
+  'connect ECONNREFUSED 127.0.0.1:80',
+);
+
+// ---------------------------------------------------------------------------
+// Composite oracle state descriptors
+// – These are used by oracle-harness.helpers.ts to drive parameterised tests.
+// ---------------------------------------------------------------------------
+
+export type OracleState =
+  | 'success'
+  | 'stale'
+  | 'invalid_response'
+  | 'empty_paths'
+  | 'http_503'
+  | 'http_429'
+  | 'http_500'
+  | 'network_error';
+
+export interface OracleScenario {
+  state: OracleState;
+  description: string;
+  /** True when the consumer (QuoteService) should be able to produce a quote */
+  expectsQuote: boolean;
+  /** True when the oracle error should surface as ServiceUnavailableException */
+  expectsUnavailable: boolean;
+  /** True when the oracle error should surface as BadRequestException (no path) */
+  expectsNoPath: boolean;
+}
+
+export const ORACLE_SCENARIOS: readonly OracleScenario[] = [
+  {
+    state: 'success',
+    description: 'Oracle healthy – returns valid paths',
+    expectsQuote: true,
+    expectsUnavailable: false,
+    expectsNoPath: false,
+  },
+  {
+    state: 'empty_paths',
+    description: 'Oracle healthy but no liquidity paths available',
+    expectsQuote: false,
+    expectsUnavailable: false,
+    expectsNoPath: true,
+  },
+  {
+    state: 'http_503',
+    description: 'Oracle temporarily unavailable (HTTP 503)',
+    expectsQuote: false,
+    expectsUnavailable: true,
+    expectsNoPath: false,
+  },
+  {
+    state: 'http_429',
+    description: 'Oracle rate-limiting us (HTTP 429)',
+    expectsQuote: false,
+    expectsUnavailable: true,
+    expectsNoPath: false,
+  },
+  {
+    state: 'http_500',
+    description: 'Oracle internal error (HTTP 500)',
+    expectsQuote: false,
+    expectsUnavailable: true,
+    expectsNoPath: false,
+  },
+  {
+    state: 'network_error',
+    description: 'Oracle unreachable – network-level failure',
+    expectsQuote: false,
+    expectsUnavailable: true,
+    expectsNoPath: false,
+  },
+  {
+    state: 'stale',
+    description: 'Oracle responding with stale / degraded data',
+    expectsQuote: true, // service still produces a quote but with degraded amounts
+    expectsUnavailable: false,
+    expectsNoPath: false,
+  },
+  {
+    state: 'invalid_response',
+    description: 'Oracle returns structurally malformed payload',
+    expectsQuote: false,
+    expectsUnavailable: false,
+    expectsNoPath: true, // maps to empty records fallback
+  },
+] as const;

--- a/app/backend/src/stellar/__tests__/oracle-harness.helpers.ts
+++ b/app/backend/src/stellar/__tests__/oracle-harness.helpers.ts
@@ -1,0 +1,326 @@
+/**
+ * oracle-harness.helpers.ts
+ *
+ * Reusable helper utilities for oracle failure harness tests.
+ *
+ * Provides:
+ *  - makeFetchMockForState()   Wire up a jest fetch spy for a given OracleState
+ *  - makePathPreviewService()  Instantiate PathPreviewService with an AppConfigService stub
+ *  - makeQuoteService()        Instantiate QuoteService with an optional PathPreviewService stub
+ *  - isStaleAmount()           Detect suspiciously small oracle amounts
+ *  - assertOracleFailure()     Assert the correct NestJS exception is thrown per scenario
+ *  - runOracleScenario()       Execute a full oracle scenario against PathPreviewService
+ *  - runQuoteScenario()        Execute a full oracle scenario against QuoteService
+ */
+
+import {
+  BadRequestException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+
+import { PathPreviewService } from '../path-preview.service';
+import { QuoteService } from '../quote.service';
+import { AppConfigService } from '../../config/app-config.service';
+
+import {
+  type OracleState,
+  type OracleScenario,
+  STALE_AMOUNT_THRESHOLD,
+  HEALTHY_HORIZON_RESPONSE,
+  STALE_HORIZON_RESPONSE,
+  INVALID_HORIZON_RESPONSE_NO_EMBEDDED,
+  EMPTY_PATHS_HORIZON_RESPONSE,
+  HTTP_503_RESPONSE,
+  HTTP_429_RESPONSE,
+  HTTP_500_RESPONSE,
+  NETWORK_TIMEOUT_ERROR,
+  USDC_ISSUER,
+  makeOkFetchResponse,
+} from './oracle-harness.fixtures';
+
+// ---------------------------------------------------------------------------
+// Standard request DTOs shared across harness tests
+// ---------------------------------------------------------------------------
+
+/** A canonical strict-receive request (XLM → USDC). */
+export const HARNESS_STRICT_RECEIVE_REQUEST = {
+  destinationAmount: '10',
+  destinationAsset: {
+    code: 'USDC',
+    issuer: USDC_ISSUER,
+  },
+  sourceAssets: [{ code: 'XLM' }],
+};
+
+/** A canonical strict-send request (XLM → USDC). */
+export const HARNESS_STRICT_SEND_REQUEST = {
+  sourceAmount: '100',
+  sourceAsset: { code: 'XLM' },
+  destinationAssets: [
+    {
+      code: 'USDC',
+      issuer: USDC_ISSUER,
+    },
+  ],
+};
+
+/** A canonical QuoteService DTO. */
+export const HARNESS_QUOTE_REQUEST = {
+  destinationAmount: '10',
+  destinationAsset: { code: 'USDC', issuer: USDC_ISSUER },
+  sourceAssets: [{ code: 'XLM' }],
+};
+
+// ---------------------------------------------------------------------------
+// AppConfigService stub
+// ---------------------------------------------------------------------------
+
+/** Returns a minimal AppConfigService stub pointing at testnet. */
+export function makeAppConfigStub(mainnet = false): Pick<AppConfigService, 'isMainnet'> {
+  return { isMainnet: mainnet };
+}
+
+// ---------------------------------------------------------------------------
+// PathPreviewService factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a PathPreviewService backed by a testnet AppConfigService stub.
+ * Callers should spy on `global.fetch` after calling this helper.
+ */
+export async function makePathPreviewService(
+  mainnet = false,
+): Promise<PathPreviewService> {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      PathPreviewService,
+      { provide: AppConfigService, useValue: makeAppConfigStub(mainnet) },
+    ],
+  }).compile();
+
+  return module.get<PathPreviewService>(PathPreviewService);
+}
+
+// ---------------------------------------------------------------------------
+// QuoteService factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a QuoteService with an optional pre-wired PathPreviewService mock.
+ *
+ * @param pathRows  Rows that PathPreviewService.previewPaths() should resolve to.
+ *                  Pass an empty array to simulate NO_PATH_FOUND.
+ *                  Pass `null` to make previewPaths throw ServiceUnavailableException.
+ */
+export function makeQuoteService(
+  pathRows: import('../path-preview.service').PathPreviewRow[] | null = null,
+): QuoteService {
+  const mockPreview = {
+    previewPaths:
+      pathRows === null
+        ? jest.fn().mockRejectedValue(
+            new ServiceUnavailableException(
+              'Unable to reach Stellar Horizon for path preview.',
+            ),
+          )
+        : jest.fn().mockResolvedValue({
+            paths: pathRows,
+            horizonUrl: 'https://horizon-testnet.stellar.org',
+          }),
+  };
+  return new QuoteService(mockPreview as never);
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock wiring per OracleState
+// ---------------------------------------------------------------------------
+
+/**
+ * Configures a jest fetch spy to respond according to the given OracleState.
+ *
+ * @param fetchSpy The jest.SpyInstance wrapping global.fetch.
+ * @param state    Which oracle state to simulate.
+ */
+export function wireFetchForState(
+  fetchSpy: jest.SpyInstance,
+  state: OracleState,
+): void {
+  switch (state) {
+    case 'success':
+      fetchSpy.mockResolvedValueOnce(
+        makeOkFetchResponse(HEALTHY_HORIZON_RESPONSE),
+      );
+      break;
+
+    case 'stale':
+      fetchSpy.mockResolvedValueOnce(
+        makeOkFetchResponse(STALE_HORIZON_RESPONSE),
+      );
+      break;
+
+    case 'invalid_response':
+      fetchSpy.mockResolvedValueOnce(
+        makeOkFetchResponse(INVALID_HORIZON_RESPONSE_NO_EMBEDDED),
+      );
+      break;
+
+    case 'empty_paths':
+      fetchSpy.mockResolvedValueOnce(
+        makeOkFetchResponse(EMPTY_PATHS_HORIZON_RESPONSE),
+      );
+      break;
+
+    case 'http_503':
+      fetchSpy.mockResolvedValueOnce(HTTP_503_RESPONSE);
+      break;
+
+    case 'http_429':
+      fetchSpy.mockResolvedValueOnce(HTTP_429_RESPONSE);
+      break;
+
+    case 'http_500':
+      fetchSpy.mockResolvedValueOnce(HTTP_500_RESPONSE);
+      break;
+
+    case 'network_error':
+      fetchSpy.mockRejectedValueOnce(NETWORK_TIMEOUT_ERROR);
+      break;
+
+    default: {
+      // Exhaustiveness guard
+      const _exhaustive: never = state;
+      throw new Error(`Unhandled OracleState: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Staleness detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when a price amount string looks stale / degraded.
+ * Staleness is flagged when the parsed amount is below STALE_AMOUNT_THRESHOLD.
+ */
+export function isStaleAmount(amountStr: string): boolean {
+  const parsed = parseFloat(amountStr);
+  return (
+    Number.isFinite(parsed) &&
+    parsed > 0 &&
+    parsed < STALE_AMOUNT_THRESHOLD
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Assertion helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Asserts that the error thrown by an oracle interaction matches what the
+ * scenario predicts (ServiceUnavailableException vs BadRequestException vs none).
+ */
+export async function assertOracleFailure(
+  scenario: OracleScenario,
+  action: () => Promise<unknown>,
+): Promise<void> {
+  if (scenario.expectsUnavailable) {
+    await expect(action()).rejects.toThrow(ServiceUnavailableException);
+    return;
+  }
+  if (scenario.expectsNoPath) {
+    // PathPreviewService returns empty paths; QuoteService converts that to BadRequestException.
+    // At the PathPreviewService level it just resolves to [].
+    // Callers test this directly when needed.
+    return;
+  }
+  if (scenario.expectsQuote) {
+    // No exception expected – just let it resolve.
+    await expect(action()).resolves.toBeDefined();
+    return;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Full-pipeline scenario runners
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a single OracleScenario against PathPreviewService (strict-receive).
+ *
+ * @returns The resolved paths array, or throws the expected exception.
+ */
+export async function runPathPreviewScenario(
+  scenario: OracleScenario,
+  service: PathPreviewService,
+  fetchSpy: jest.SpyInstance,
+): Promise<{ paths: import('../path-preview.service').PathPreviewRow[]; horizonUrl: string } | undefined> {
+  wireFetchForState(fetchSpy, scenario.state);
+
+  if (scenario.expectsUnavailable) {
+    await expect(
+      service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST),
+    ).rejects.toThrow(ServiceUnavailableException);
+    return undefined;
+  }
+
+  const result = await service.previewPaths(HARNESS_STRICT_RECEIVE_REQUEST);
+  return result;
+}
+
+/**
+ * Runs a single OracleScenario against QuoteService (create-quote pipeline).
+ *
+ * Uses a PathPreviewService mock rather than real fetch to isolate quote logic.
+ */
+export async function runQuoteScenario(
+  scenario: OracleScenario,
+): Promise<import('../../stellar/quote.service').QuoteService | undefined> {
+  if (scenario.expectsUnavailable) {
+    const svc = makeQuoteService(null); // previewPaths throws
+    await expect(
+      svc.createQuote(HARNESS_QUOTE_REQUEST),
+    ).rejects.toThrow(ServiceUnavailableException);
+    return svc;
+  }
+
+  if (scenario.expectsNoPath) {
+    const svc = makeQuoteService([]); // empty paths
+    await expect(
+      svc.createQuote(HARNESS_QUOTE_REQUEST),
+    ).rejects.toThrow(BadRequestException);
+    return svc;
+  }
+
+  if (scenario.expectsQuote) {
+    // Build the appropriate path rows based on oracle state
+    const { HEALTHY_PATH_ROW } = await import('./oracle-harness.fixtures');
+    const fakeRow = { ...HEALTHY_PATH_ROW };
+    const svc = makeQuoteService([fakeRow as import('../path-preview.service').PathPreviewRow]);
+    const quote = await svc.createQuote(HARNESS_QUOTE_REQUEST);
+    return svc as unknown as undefined;
+    void quote;
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Parameterised runner (for use with describe.each / test.each)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a Jest test.each–compatible table from ORACLE_SCENARIOS.
+ *
+ * Usage:
+ *   test.each(oracleScenariosTable())(
+ *     '%s',
+ *     async (_label, scenario) => { ... },
+ *   );
+ */
+export function oracleScenariosTable(
+  scenarios: readonly OracleScenario[] = [],
+): [string, OracleScenario][] {
+  return scenarios.map((s) => [`[${s.state}] ${s.description}`, s]);
+}

--- a/app/backend/src/stellar/path-preview.service.ts
+++ b/app/backend/src/stellar/path-preview.service.ts
@@ -174,7 +174,8 @@ export class PathPreviewService {
       );
     }
 
-    const records = json._embedded?.records ?? [];
+    const rawRecords = json._embedded?.records;
+    const records: HorizonPathRecord[] = Array.isArray(rawRecords) ? rawRecords : [];
     const paths: PathPreviewRow[] = records.map((r) => ({
       sourceAmount: r.source_amount,
       sourceAsset: formatAssetLabel(
@@ -251,7 +252,8 @@ export class PathPreviewService {
       );
     }
 
-    const records = json._embedded?.records ?? [];
+    const rawRecords2 = json._embedded?.records;
+    const records: HorizonPathRecord[] = Array.isArray(rawRecords2) ? rawRecords2 : [];
     const paths: PathPreviewRow[] = records.map((r) => ({
       sourceAmount: r.source_amount,
       sourceAsset: formatAssetLabel(


### PR DESCRIPTION
## Summary

Closes #673

Adds a dedicated test harness for oracle outages, stale data, and malformed responses so pricing-related regressions are caught before deploys.

cc @Cedarich — lint errors fixed (unused imports removed), build and lint both pass locally.

## Changes

### New files
- `app/backend/src/stellar/__tests__/oracle-harness.fixtures.ts` — reusable fixtures for 8 canonical oracle states: success, stale, invalid response, empty paths, HTTP 503/429/500, and network error
- `app/backend/src/stellar/__tests__/oracle-harness.helpers.ts` — factory functions (`makePathPreviewService`, `makeQuoteService`), fetch mock wiring (`wireFetchForState`), staleness detection (`isStaleAmount`), parameterised scenario runners reusable in future oracle tests
- `app/backend/src/stellar/__tests__/oracle-failure.harness.unit.spec.ts` — 63 tests covering:
  - `PathPreviewService` HTTP failures (503/429/500/network error) on strict-receive and strict-send
  - Malformed Horizon responses (missing `_embedded`, non-array records, NaN/negative amounts, partial data)
  - Stale oracle data detection via `isStaleAmount()`
  - `QuoteService` fee/pricing propagation: `ServiceUnavailableException`, `NO_PATH_FOUND`, fee breakdown correctness, NaN-safe slippage, quote expiry
  - Full parameterised suite exercising all 8 `ORACLE_SCENARIOS` against both services
  - Harness self-tests for internal consistency

### Bug fix
- `app/backend/src/stellar/path-preview.service.ts` — added `Array.isArray` guard before `.map()` on Horizon `records` in both `previewPaths` and `strictSendPaths`; prevents `TypeError` when oracle returns a non-array payload

## CI status
- ✅ Lint — clean (0 errors, 0 warnings)
- ✅ Build — `nest build` passes
- ✅ Tests — 63/63 pass in ~5.7s (pure mocks, no network)

## Acceptance criteria

- [x] Oracle-related regressions are covered by dedicated tests
- [x] Harness supports success and failure scenarios (8 canonical states)
- [x] CI can run the harness repeatably — no network calls, ~5.7s runtime
