### PR TITLE
feat(fe-41): add preview deployment diagnostics panel

### DIFF
--- a/app/frontend/VERCEL_ENV_SETUP.md
+++ b/app/frontend/VERCEL_ENV_SETUP.md
@@ -17,6 +17,31 @@ This document outlines the environment variables required for deploying the Quic
 | `NEXT_PUBLIC_QUICKEX_ANALYTICS_PUBLIC_KEY` | Analytics public key | Optional | Optional |
 | `QUICKEX_INTERNAL_API_URL` | Internal API URL (server-side) | Optional | Optional |
 
+### Deployment Diagnostics Panel Variables
+
+These variables power the **Deployment Diagnostics Panel** shown on `/settings/developer`
+for contributors testing preview deployments. The panel is automatically hidden on
+mainnet + Vercel production so end users never see it.
+
+| Variable Name | Source | Description |
+|--------------|--------|-------------|
+| `NEXT_PUBLIC_VERCEL_ENV` | Auto-injected by Vercel | `"production"` \| `"preview"` \| `"development"` |
+| `NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF` | Auto-injected by Vercel | Branch name of the deployment |
+| `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` | Auto-injected by Vercel | Full 40-char commit SHA |
+| `NEXT_PUBLIC_VERCEL_URL` | Auto-injected by Vercel | Deployment URL without protocol |
+| `NEXT_PUBLIC_VERCEL_DEPLOYED_AT` | Set in CI workflow | ISO-8601 timestamp when build was stamped. Add `echo "NEXT_PUBLIC_VERCEL_DEPLOYED_AT=$(date -u +%FT%TZ)" >> $GITHUB_ENV` to the deploy step. |
+| `NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION` | Set in contract deploy CI | Version string from `app/contract/scripts/deploy.sh`. Export it as an env var before running the Next.js build. |
+
+For local development you can set these in `.env.local`:
+
+```
+NEXT_PUBLIC_VERCEL_ENV=development
+NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF=my-local-branch
+NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=0000000000000000000000000000000000000000
+NEXT_PUBLIC_VERCEL_DEPLOYED_AT=2026-07-23T12:00:00Z
+NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION=local
+```
+
 ### Network Configuration
 
 #### Preview Environment

--- a/app/frontend/__tests__/DeploymentDiagnosticsPanel.test.tsx
+++ b/app/frontend/__tests__/DeploymentDiagnosticsPanel.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { DeploymentDiagnosticsPanel } from "@/components/DeploymentDiagnosticsPanel";

--- a/app/frontend/__tests__/DeploymentDiagnosticsPanel.test.tsx
+++ b/app/frontend/__tests__/DeploymentDiagnosticsPanel.test.tsx
@@ -1,0 +1,184 @@
+// @ts-nocheck
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DeploymentDiagnosticsPanel } from "@/components/DeploymentDiagnosticsPanel";
+
+// ---------------------------------------------------------------------------
+// Mock navigator.clipboard
+// ---------------------------------------------------------------------------
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined);
+
+Object.defineProperty(globalThis, "navigator", {
+  value: { clipboard: { writeText: writeTextMock } },
+  writable: true,
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const originalEnv = process.env;
+
+function setEnv(overrides: Record<string, string | undefined>) {
+  process.env = { ...originalEnv, ...overrides };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  writeTextMock.mockClear();
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeploymentDiagnosticsPanel", () => {
+  it("renders the panel on a testnet preview deployment", () => {
+    setEnv({
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+      NEXT_PUBLIC_VERCEL_ENV: "preview",
+      NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: "feat/diagnostics",
+      NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA:
+        "abcdef1234567890abcdef1234567890abcdef12",
+      NEXT_PUBLIC_QUICKEX_API_URL: "https://api-staging.quickex.to",
+      NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION: "v2.3.1",
+      NEXT_PUBLIC_APP_VERSION: "1.4.0-preview",
+    });
+
+    render(<DeploymentDiagnosticsPanel />);
+
+    expect(
+      screen.getByRole("region", { name: /preview deployment diagnostics/i }),
+    ).toBeDefined();
+    expect(screen.getByText("feat/diagnostics")).toBeDefined();
+    expect(screen.getByText("https://api-staging.quickex.to")).toBeDefined();
+    expect(screen.getByText("v2.3.1")).toBeDefined();
+    expect(screen.getByText("1.4.0-preview")).toBeDefined();
+  });
+
+  it("renders nothing on mainnet + production Vercel (hidden from end users)", () => {
+    setEnv({
+      NEXT_PUBLIC_STELLAR_NETWORK: "mainnet",
+      NEXT_PUBLIC_VERCEL_ENV: "production",
+    });
+
+    const { container } = render(<DeploymentDiagnosticsPanel />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the panel on mainnet + preview (mainnet branch preview)", () => {
+    setEnv({
+      NEXT_PUBLIC_STELLAR_NETWORK: "mainnet",
+      NEXT_PUBLIC_VERCEL_ENV: "preview",
+    });
+
+    render(<DeploymentDiagnosticsPanel />);
+
+    expect(
+      screen.getByRole("region", { name: /preview deployment diagnostics/i }),
+    ).toBeDefined();
+  });
+
+  it("shows 'not set' for missing optional values", () => {
+    setEnv({
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+      NEXT_PUBLIC_VERCEL_ENV: "preview",
+    });
+
+    // Clear any values that might bleed from other tests
+    delete process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF;
+    delete process.env.NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION;
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+
+    render(<DeploymentDiagnosticsPanel />);
+
+    const notSetEls = screen.getAllByText("not set");
+    expect(notSetEls.length).toBeGreaterThan(0);
+  });
+
+  it("displays the short commit SHA highlighted and the remainder dimmed", () => {
+    setEnv({
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+      NEXT_PUBLIC_VERCEL_ENV: "preview",
+      NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA:
+        "0123456789abcdef0123456789abcdef01234567",
+    });
+
+    render(<DeploymentDiagnosticsPanel />);
+
+    // Short SHA (first 7 chars) should appear as its own text node
+    expect(screen.getByText("0123456")).toBeDefined();
+  });
+
+  it("calls clipboard.writeText with the correct value when a row copy button is clicked", async () => {
+    setEnv({
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+      NEXT_PUBLIC_VERCEL_ENV: "preview",
+      NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: "my-branch",
+    });
+
+    render(<DeploymentDiagnosticsPanel />);
+
+    const branchCopyBtn = screen.getByRole("button", { name: /copy branch/i });
+    fireEvent.click(branchCopyBtn);
+
+    expect(writeTextMock).toHaveBeenCalledWith("my-branch");
+  });
+
+  it("shows '✓' feedback on the copy button after clicking, then reverts", async () => {
+    setEnv({
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+      NEXT_PUBLIC_VERCEL_ENV: "preview",
+      NEXT_PUBLIC_QUICKEX_API_URL: "https://api-staging.quickex.to",
+    });
+
+    render(<DeploymentDiagnosticsPanel />);
+
+    const apiCopyBtn = screen.getByRole("button", { name: /copy api url/i });
+    fireEvent.click(apiCopyBtn);
+
+    expect(apiCopyBtn.textContent).toBe("✓");
+
+    vi.advanceTimersByTime(2001);
+    expect(apiCopyBtn.textContent).toBe("⧉");
+  });
+
+  it("copies all rows when 'Copy all' is clicked", () => {
+    setEnv({
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+      NEXT_PUBLIC_VERCEL_ENV: "preview",
+      NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: "feat/test",
+      NEXT_PUBLIC_QUICKEX_API_URL: "https://api-staging.quickex.to",
+    });
+
+    render(<DeploymentDiagnosticsPanel />);
+
+    const copyAllBtn = screen.getByRole("button", { name: /copy all diagnostics/i });
+    fireEvent.click(copyAllBtn);
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    const copied: string = writeTextMock.mock.calls[0][0];
+    expect(copied).toContain("Branch: feat/test");
+    expect(copied).toContain("API URL: https://api-staging.quickex.to");
+  });
+
+  it("disables copy button when value is not set", () => {
+    setEnv({
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+      NEXT_PUBLIC_VERCEL_ENV: "preview",
+    });
+    delete process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF;
+
+    render(<DeploymentDiagnosticsPanel />);
+
+    const branchCopyBtn = screen.getByRole("button", { name: /copy branch/i });
+    expect(branchCopyBtn).toHaveProperty("disabled", true);
+  });
+});

--- a/app/frontend/__tests__/deployment-info.test.ts
+++ b/app/frontend/__tests__/deployment-info.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for deployment-info.ts helpers.
+ *
+ * These run in a Node environment (no DOM required) because the helpers
+ * only read process.env and perform pure logic.
+ */
+
+import {
+  getDeploymentInfo,
+  isDiagnosticsPanelVisible,
+  type DeploymentInfo,
+} from "@/lib/deployment-info";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Save and restore process.env around each test. */
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+// ---------------------------------------------------------------------------
+// getDeploymentInfo
+// ---------------------------------------------------------------------------
+
+describe("getDeploymentInfo", () => {
+  it("returns all null / default values when no env vars are set", () => {
+    delete process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF;
+    delete process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
+    delete process.env.NEXT_PUBLIC_VERCEL_DEPLOYED_AT;
+    delete process.env.NEXT_PUBLIC_QUICKEX_API_URL;
+    delete process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+    delete process.env.NEXT_PUBLIC_VERCEL_ENV;
+    delete process.env.NEXT_PUBLIC_VERCEL_URL;
+    delete process.env.NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION;
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+
+    const info = getDeploymentInfo();
+
+    expect(info.branch).toBeNull();
+    expect(info.commitSha).toBeNull();
+    expect(info.commitShort).toBeNull();
+    expect(info.deployedAt).toBeNull();
+    expect(info.apiUrl).toBe("http://localhost:4000");
+    expect(info.network).toBe("testnet");
+    expect(info.vercelEnv).toBeNull();
+    expect(info.vercelUrl).toBeNull();
+    expect(info.contractRegistryVersion).toBeNull();
+    expect(info.appVersion).toBeNull();
+  });
+
+  it("reads all env vars correctly when they are set", () => {
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF = "feat/preview-diagnostics";
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA =
+      "abcdef1234567890abcdef1234567890abcdef12";
+    process.env.NEXT_PUBLIC_VERCEL_DEPLOYED_AT = "2026-07-23T15:00:00Z";
+    process.env.NEXT_PUBLIC_QUICKEX_API_URL = "https://api.quickex.to/";
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "mainnet";
+    process.env.NEXT_PUBLIC_VERCEL_ENV = "preview";
+    process.env.NEXT_PUBLIC_VERCEL_URL = "quickex-abc123.vercel.app";
+    process.env.NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION = "v2.3.1";
+    process.env.NEXT_PUBLIC_APP_VERSION = "1.4.0";
+
+    const info = getDeploymentInfo();
+
+    expect(info.branch).toBe("feat/preview-diagnostics");
+    expect(info.commitSha).toBe("abcdef1234567890abcdef1234567890abcdef12");
+    expect(info.commitShort).toBe("abcdef1");
+    expect(info.deployedAt).toBe("2026-07-23T15:00:00Z");
+    // Trailing slash must be stripped
+    expect(info.apiUrl).toBe("https://api.quickex.to");
+    expect(info.network).toBe("mainnet");
+    expect(info.vercelEnv).toBe("preview");
+    expect(info.vercelUrl).toBe("quickex-abc123.vercel.app");
+    expect(info.contractRegistryVersion).toBe("v2.3.1");
+    expect(info.appVersion).toBe("1.4.0");
+  });
+
+  it("derives a 7-char commitShort from commitSha", () => {
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA =
+      "0123456789abcdef0123456789abcdef01234567";
+
+    const { commitShort } = getDeploymentInfo();
+
+    expect(commitShort).toBe("0123456");
+  });
+
+  it("strips trailing slash from apiUrl", () => {
+    process.env.NEXT_PUBLIC_QUICKEX_API_URL = "https://api.example.com/";
+
+    const { apiUrl } = getDeploymentInfo();
+
+    expect(apiUrl).toBe("https://api.example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDiagnosticsPanelVisible
+// ---------------------------------------------------------------------------
+
+describe("isDiagnosticsPanelVisible", () => {
+  const base: DeploymentInfo = {
+    branch: null,
+    commitSha: null,
+    commitShort: null,
+    deployedAt: null,
+    apiUrl: "http://localhost:4000",
+    network: "testnet",
+    vercelEnv: null,
+    vercelUrl: null,
+    contractRegistryVersion: null,
+    appVersion: null,
+  };
+
+  it("is visible on testnet + preview (typical PR preview deploy)", () => {
+    expect(
+      isDiagnosticsPanelVisible({ ...base, network: "testnet", vercelEnv: "preview" }),
+    ).toBe(true);
+  });
+
+  it("is visible on mainnet + preview (e.g. a mainnet preview branch)", () => {
+    expect(
+      isDiagnosticsPanelVisible({ ...base, network: "mainnet", vercelEnv: "preview" }),
+    ).toBe(true);
+  });
+
+  it("is visible on testnet + production", () => {
+    expect(
+      isDiagnosticsPanelVisible({
+        ...base,
+        network: "testnet",
+        vercelEnv: "production",
+      }),
+    ).toBe(true);
+  });
+
+  it("is visible when vercelEnv is null (local development)", () => {
+    expect(
+      isDiagnosticsPanelVisible({ ...base, network: "mainnet", vercelEnv: null }),
+    ).toBe(true);
+  });
+
+  it("is visible on testnet with no vercelEnv", () => {
+    expect(
+      isDiagnosticsPanelVisible({ ...base, network: "testnet", vercelEnv: null }),
+    ).toBe(true);
+  });
+
+  it("is HIDDEN on mainnet + production Vercel deploy", () => {
+    expect(
+      isDiagnosticsPanelVisible({
+        ...base,
+        network: "mainnet",
+        vercelEnv: "production",
+      }),
+    ).toBe(false);
+  });
+});

--- a/app/frontend/next.config.ts
+++ b/app/frontend/next.config.ts
@@ -60,6 +60,19 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_QUICKEX_API_URL: process.env.NEXT_PUBLIC_QUICKEX_API_URL,
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
     NEXT_PUBLIC_STELLAR_NETWORK: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
+    // Vercel system env vars (already NEXT_PUBLIC_ prefixed so Vercel exposes
+    // them to the browser automatically, but listing them here ensures they
+    // are available for local overrides via .env.local as well)
+    NEXT_PUBLIC_VERCEL_ENV: process.env.NEXT_PUBLIC_VERCEL_ENV,
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF,
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+    NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,
+    // Set by the GitHub Actions deploy workflow: date -u +%FT%TZ
+    NEXT_PUBLIC_VERCEL_DEPLOYED_AT: process.env.NEXT_PUBLIC_VERCEL_DEPLOYED_AT,
+    // Set by app/contract CI deploy step
+    NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION: process.env.NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION,
+    // App version
+    NEXT_PUBLIC_APP_VERSION: process.env.NEXT_PUBLIC_APP_VERSION,
   },
 
   // Image optimization with allowed domains

--- a/app/frontend/src/app/settings/developer/page.tsx
+++ b/app/frontend/src/app/settings/developer/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import CreateAPIKeyModal from "@/components/CreateAPIKeyModal";
+import { DeploymentDiagnosticsPanel } from "@/components/DeploymentDiagnosticsPanel";
 import { getQuickexApiBase } from "@/lib/api";
 import {
   type ApiKey,
@@ -416,6 +417,9 @@ export default function DeveloperSettings() {
               ))}
             </div>
           </section>
+
+          {/* Preview Deployment Diagnostics */}
+          <DeploymentDiagnosticsPanel />
         </div>
       </div>
 

--- a/app/frontend/src/components/DeploymentDiagnosticsPanel.tsx
+++ b/app/frontend/src/components/DeploymentDiagnosticsPanel.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useState } from "react";
+import { getDeploymentInfo, isDiagnosticsPanelVisible } from "@/lib/deployment-info";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CopyState {
+  [key: string]: "idle" | "copied";
+}
+
+interface DiagnosticsRow {
+  label: string;
+  key: string;
+  value: string | null;
+  /** Monospace display for SHAs and URLs */
+  mono?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function networkBadgeClasses(network: string) {
+  return network === "mainnet"
+    ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/30"
+    : "bg-amber-500/10 text-amber-400 border-amber-500/30";
+}
+
+function vercelEnvBadgeClasses(env: string | null) {
+  if (env === "production") return "bg-emerald-500/10 text-emerald-400 border-emerald-500/30";
+  if (env === "preview") return "bg-indigo-500/10 text-brand border-indigo-500/30";
+  return "bg-surface text-subtle border-border-strong";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * DeploymentDiagnosticsPanel
+ *
+ * Read-only panel showing branch, commit SHA, deployment timestamp, API URL,
+ * Stellar network, Vercel environment, and contract registry version.
+ *
+ * All values are sourced from runtime environment variables via
+ * `getDeploymentInfo()` — nothing is hardcoded.
+ *
+ * The panel renders nothing when the deployment is mainnet + Vercel
+ * production, keeping it out of end-user views.
+ */
+export function DeploymentDiagnosticsPanel() {
+  const info = getDeploymentInfo();
+  const [copyStates, setCopyStates] = useState<CopyState>({});
+
+  // Guard: hide on mainnet + production Vercel deploy
+  if (!isDiagnosticsPanelVisible(info)) return null;
+
+  const rows: DiagnosticsRow[] = [
+    {
+      label: "Branch",
+      key: "branch",
+      value: info.branch,
+    },
+    {
+      label: "Commit SHA",
+      key: "commitSha",
+      value: info.commitSha,
+      mono: true,
+    },
+    {
+      label: "Deployed At",
+      key: "deployedAt",
+      value: info.deployedAt
+        ? new Date(info.deployedAt).toLocaleString("en-US", {
+            dateStyle: "medium",
+            timeStyle: "short",
+          })
+        : null,
+    },
+    {
+      label: "API URL",
+      key: "apiUrl",
+      value: info.apiUrl,
+      mono: true,
+    },
+    {
+      label: "Stellar Network",
+      key: "network",
+      value: info.network,
+    },
+    {
+      label: "Vercel Env",
+      key: "vercelEnv",
+      value: info.vercelEnv,
+    },
+    {
+      label: "Vercel URL",
+      key: "vercelUrl",
+      value: info.vercelUrl ? `https://${info.vercelUrl}` : null,
+      mono: true,
+    },
+    {
+      label: "Contract Registry",
+      key: "contractRegistryVersion",
+      value: info.contractRegistryVersion,
+      mono: true,
+    },
+    {
+      label: "App Version",
+      key: "appVersion",
+      value: info.appVersion,
+      mono: true,
+    },
+  ];
+
+  // The raw value that gets copied for a given row key. We copy the full
+  // unformatted value (e.g. full ISO string, not the localised display).
+  const rawValueForCopy = (key: string): string => {
+    const raw: Record<string, string | null> = {
+      branch: info.branch,
+      commitSha: info.commitSha,
+      deployedAt: info.deployedAt,
+      apiUrl: info.apiUrl,
+      network: info.network,
+      vercelEnv: info.vercelEnv,
+      vercelUrl: info.vercelUrl ? `https://${info.vercelUrl}` : null,
+      contractRegistryVersion: info.contractRegistryVersion,
+      appVersion: info.appVersion,
+    };
+    return raw[key] ?? "";
+  };
+
+  const handleCopy = (key: string) => {
+    const text = rawValueForCopy(key);
+    if (!text) return;
+    navigator.clipboard.writeText(text).then(() => {
+      setCopyStates((prev) => ({ ...prev, [key]: "copied" }));
+      setTimeout(
+        () => setCopyStates((prev) => ({ ...prev, [key]: "idle" })),
+        2000,
+      );
+    });
+  };
+
+  const handleCopyAll = () => {
+    const lines = rows
+      .map((r) => `${r.label}: ${rawValueForCopy(r.key) || "—"}`)
+      .join("\n");
+    navigator.clipboard.writeText(lines).then(() => {
+      setCopyStates((prev) => ({ ...prev, __all__: "copied" }));
+      setTimeout(
+        () => setCopyStates((prev) => ({ ...prev, __all__: "idle" })),
+        2000,
+      );
+    });
+  };
+
+  return (
+    <section
+      aria-label="Preview Deployment Diagnostics"
+      className="p-6 rounded-3xl bg-card border border-border space-y-5"
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="text-xl font-bold">Deployment Diagnostics</h2>
+            {/* Network badge */}
+            <span
+              className={`text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border ${networkBadgeClasses(info.network)}`}
+            >
+              {info.network}
+            </span>
+            {/* Vercel env badge */}
+            {info.vercelEnv && (
+              <span
+                className={`text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border ${vercelEnvBadgeClasses(info.vercelEnv)}`}
+              >
+                {info.vercelEnv}
+              </span>
+            )}
+          </div>
+          <p className="text-sm text-subtle mt-1">
+            Read-only build metadata for contributor verification and issue
+            reporting.
+          </p>
+        </div>
+
+        {/* Copy-all button */}
+        <button
+          onClick={handleCopyAll}
+          aria-label="Copy all diagnostics to clipboard"
+          className="shrink-0 px-4 py-2 rounded-xl bg-surface border border-border-strong text-xs font-semibold text-muted hover:bg-surface-strong hover:text-foreground transition"
+        >
+          {copyStates.__all__ === "copied" ? "✓ Copied all" : "⧉ Copy all"}
+        </button>
+      </div>
+
+      {/* Rows */}
+      <div className="divide-y divide-border">
+        {rows.map(({ label, key, value, mono }) => (
+          <div
+            key={key}
+            className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0"
+          >
+            {/* Label + value */}
+            <div className="min-w-0 flex-1 space-y-0.5">
+              <p className="text-xs font-semibold text-faint uppercase tracking-wider">
+                {label}
+              </p>
+              {value ? (
+                <p
+                  className={`text-sm break-all ${
+                    mono ? "font-mono text-foreground" : "text-foreground"
+                  }`}
+                >
+                  {/* Highlight short SHA inline next to full SHA */}
+                  {key === "commitSha" && info.commitShort ? (
+                    <>
+                      <span className="text-brand font-bold">
+                        {info.commitShort}
+                      </span>
+                      <span className="text-subtle">
+                        {value.slice(7)}
+                      </span>
+                    </>
+                  ) : (
+                    value
+                  )}
+                </p>
+              ) : (
+                <p className="text-sm text-faint italic">not set</p>
+              )}
+            </div>
+
+            {/* Copy button */}
+            <button
+              disabled={!value}
+              onClick={() => handleCopy(key)}
+              aria-label={`Copy ${label}`}
+              className="shrink-0 px-3 py-1.5 rounded-xl bg-surface border border-border-strong text-xs font-semibold text-muted hover:bg-surface-strong hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
+            >
+              {copyStates[key] === "copied" ? "✓" : "⧉"}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Footer note */}
+      <p className="text-xs text-faint pt-1">
+        This panel is hidden on mainnet production deployments. Include the
+        &quot;Copy all&quot; output when filing a bug report.
+      </p>
+    </section>
+  );
+}

--- a/app/frontend/src/lib/deployment-info.ts
+++ b/app/frontend/src/lib/deployment-info.ts
@@ -1,0 +1,91 @@
+/**
+ * deployment-info.ts
+ *
+ * Collects deployment metadata from runtime environment variables.
+ * All values come from process.env – nothing is hardcoded.
+ *
+ * Vercel injects the following at build time for Preview and Production:
+ *   NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF   – branch name
+ *   NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA   – full commit SHA
+ *   NEXT_PUBLIC_VERCEL_ENV              – "production" | "preview" | "development"
+ *   NEXT_PUBLIC_VERCEL_URL              – deployment URL (no protocol)
+ *
+ * NEXT_PUBLIC_VERCEL_DEPLOYED_AT should be set in the GitHub Actions
+ * deploy workflow (e.g. `echo "NEXT_PUBLIC_VERCEL_DEPLOYED_AT=$(date -u +%FT%TZ)"`)
+ * so contributors can see when the build was stamped.
+ *
+ * NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION should be injected by the contract
+ * deploy CI step (see app/contract/scripts/deploy.sh).
+ */
+
+export interface DeploymentInfo {
+  /** Git branch name, e.g. "feat/preview-diagnostics" */
+  branch: string | null;
+  /** Full 40-char commit SHA */
+  commitSha: string | null;
+  /** Short (7-char) commit SHA derived from commitSha */
+  commitShort: string | null;
+  /** ISO-8601 timestamp of when this build was deployed */
+  deployedAt: string | null;
+  /** Backend API base URL */
+  apiUrl: string;
+  /** Stellar network: "testnet" or "mainnet" */
+  network: string;
+  /** Vercel environment tier: "production" | "preview" | "development" | null */
+  vercelEnv: string | null;
+  /** Full deployment URL provided by Vercel (no protocol) */
+  vercelUrl: string | null;
+  /** Contract registry version string injected by CI during contract deploy */
+  contractRegistryVersion: string | null;
+  /** App version string */
+  appVersion: string | null;
+}
+
+/**
+ * Returns deployment metadata derived purely from runtime environment
+ * variables. Safe to call from both client and server components.
+ */
+export function getDeploymentInfo(): DeploymentInfo {
+  const commitSha =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? null;
+
+  return {
+    branch:
+      process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF ?? null,
+    commitSha,
+    commitShort: commitSha ? commitSha.slice(0, 7) : null,
+    deployedAt:
+      process.env.NEXT_PUBLIC_VERCEL_DEPLOYED_AT ?? null,
+    apiUrl:
+      (process.env.NEXT_PUBLIC_QUICKEX_API_URL ?? "http://localhost:4000").replace(
+        /\/$/,
+        "",
+      ),
+    network:
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "testnet",
+    vercelEnv:
+      process.env.NEXT_PUBLIC_VERCEL_ENV ?? null,
+    vercelUrl:
+      process.env.NEXT_PUBLIC_VERCEL_URL ?? null,
+    contractRegistryVersion:
+      process.env.NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION ?? null,
+    appVersion:
+      process.env.NEXT_PUBLIC_APP_VERSION ?? null,
+  };
+}
+
+/**
+ * Returns true when the diagnostics panel should be visible.
+ *
+ * Hidden only when both of these are true:
+ *   - Vercel environment is "production"
+ *   - Stellar network is "mainnet"
+ *
+ * This keeps the panel out of real end-user deployments while always
+ * showing it in preview branches, testnet, and local dev.
+ */
+export function isDiagnosticsPanelVisible(info: DeploymentInfo): boolean {
+  const isProductionVercel = info.vercelEnv === "production";
+  const isMainnet = info.network === "mainnet";
+  return !(isProductionVercel && isMainnet);
+}


### PR DESCRIPTION
## What

Adds a read-only Deployment Diagnostics Panel to /settings/developer so contributors testing preview deployments can instantly verify what they're looking at and copy the metadata straight into a bug report.

Closes #576

## Changes

New files
- src/lib/deployment-info.ts — getDeploymentInfo() collects branch, commit SHA, deployed-at timestamp, API URL, network, Vercel env, Vercel URL, contract registry version, and app version from runtime env vars. 
isDiagnosticsPanelVisible() encodes the hide rule. No values are hardcoded.
- src/components/DeploymentDiagnosticsPanel.tsx — the panel itself. 9 rows, per-row ⧉ copy button with 2s feedback, a "Copy all" button that produces a paste-ready Label: value block, short SHA highlighted in brand
colour, not set shown for absent values, network + Vercel env badges in the header.
- __tests__/deployment-info.test.ts — 8 unit tests covering all env var permutations and visibility logic.
- __tests__/DeploymentDiagnosticsPanel.test.tsx — 8 component tests: render/hide, copy per-row, copy-all output, disabled button when value absent, short-SHA rendering, 2s feedback timer.

Modified files
- src/app/settings/developer/page.tsx — renders <DeploymentDiagnosticsPanel /> as the last section after Scope Reference.
- next.config.ts — adds pass-through entries for the 6 new NEXT_PUBLIC_VERCEL_* and NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION vars so .env.local overrides work in local dev.
- VERCEL_ENV_SETUP.md — documents all new variables, which are auto-injected by Vercel vs set in CI, and provides a .env.local snippet for local testing.

## Visibility rule

The panel is hidden only when both conditions are true:
- NEXT_PUBLIC_VERCEL_ENV === "production"
- NEXT_PUBLIC_STELLAR_NETWORK === "mainnet"

Visible everywhere else — preview branches, testnet, and local dev.

## Testing locally

Add to .env.local and visit /settings/developer:

NEXT_PUBLIC_VERCEL_ENV=development
NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF=my-branch
NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=0000000000000000000000000000000000000000
NEXT_PUBLIC_VERCEL_DEPLOYED_AT=2026-07-23T12:00:00Z
NEXT_PUBLIC_CONTRACT_REGISTRY_VERSION=local


## Acceptance criteria

- [x] Contributors can verify branch, commit SHA, deployed-at, API URL, network, Vercel env, contract registry version, and app version at a glance
- [x] All values sourced from runtime config — nothing hardcoded
- [x] Per-field copy buttons + copy-all for pasting into bug reports
- [x] Panel hidden on mainnet + Vercel production; visible on all preview/testnet/local contexts
- [x] 16 tests covering helper logic and component behaviour