### PR TITLE
feat(backend): implement quote cache and revalidation API (BE-65)

### DIFF
--- a/app/backend/src/stellar/dto/quote.dto.ts
+++ b/app/backend/src/stellar/dto/quote.dto.ts
@@ -79,6 +79,14 @@ export class CreateQuoteDto {
   @IsOptional()
   @IsBoolean()
   preflight?: boolean;
+
+  @ApiPropertyOptional({
+    description: "Force bypass cache and retrieve fresh rates from Horizon/Soroban",
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  revalidate?: boolean;
 }
 
 export class QuotePathDto {
@@ -100,4 +108,10 @@ export class QuoteResponseDto {
   @ApiProperty({ description: "Horizon URL used for path search" }) horizonUrl!: string;
   @ApiPropertyOptional({ description: "Preflight simulation result, if requested" })
   preflight?: { feasible: boolean; error?: string };
+
+  @ApiProperty({ description: "Age of the quote data in seconds", example: 0 })
+  age!: number;
+
+  @ApiProperty({ description: "Source of the quote data (hit or miss)", example: "miss" })
+  cacheSource!: "hit" | "miss";
 }

--- a/app/backend/src/stellar/quote.service.ts
+++ b/app/backend/src/stellar/quote.service.ts
@@ -8,14 +8,23 @@ import {
 import * as crypto from "crypto";
 
 import { PathPreviewService } from "./path-preview.service";
-import type { CreateQuoteDto, QuoteResponseDto } from "./dto/quote.dto";
+import type { CreateQuoteDto, QuoteResponseDto, QuotePathDto } from "./dto/quote.dto";
 
 const DEFAULT_SLIPPAGE_BPS = 50; // 0.5%
 const DEFAULT_TTL_SECONDS = 30;
+const CACHE_TTL_MS = 10_000; // 10 seconds
 
 interface StoredQuote {
   response: QuoteResponseDto;
   expiresAt: Date;
+  fetchedAt: number;
+  cacheSource: "hit" | "miss";
+}
+
+interface CacheEntry {
+  paths: QuotePathDto[];
+  horizonUrl: string;
+  fetchedAt: number;
 }
 
 @Injectable()
@@ -23,59 +32,107 @@ export class QuoteService {
   private readonly logger = new Logger(QuoteService.name);
   /** In-memory store — sufficient for debugging/dispute resolution per spec. */
   private readonly store = new Map<string, StoredQuote>();
+  /** Cache for Horizon/Soroban path preview results. */
+  private readonly cache = new Map<string, CacheEntry>();
 
   constructor(private readonly pathPreview: PathPreviewService) {}
+
+  private getCacheKey(dto: CreateQuoteDto): string {
+    const dest = dto.destinationAsset.issuer
+      ? `${dto.destinationAsset.code}:${dto.destinationAsset.issuer}`
+      : dto.destinationAsset.code;
+    const sources = dto.sourceAssets
+      .map((a) => (a.issuer ? `${a.code}:${a.issuer}` : a.code))
+      .join(",");
+    const slippage = dto.maxSlippageBps ?? DEFAULT_SLIPPAGE_BPS;
+    return `${dest}|${dto.destinationAmount}|${sources}|${slippage}`;
+  }
 
   async createQuote(dto: CreateQuoteDto): Promise<QuoteResponseDto> {
     const slippageBps = dto.maxSlippageBps ?? DEFAULT_SLIPPAGE_BPS;
     const ttl = dto.ttlSeconds ?? DEFAULT_TTL_SECONDS;
 
-    const { paths, horizonUrl } = await this.pathPreview.previewPaths({
-      destinationAmount: dto.destinationAmount,
-      destinationAsset: dto.destinationAsset,
-      sourceAssets: dto.sourceAssets,
-    });
+    const cacheKey = this.getCacheKey(dto);
+    const now = Date.now();
+    const cached = this.cache.get(cacheKey);
 
-    if (paths.length === 0) {
-      throw new BadRequestException({
-        code: "NO_PATH_FOUND",
-        message: "No payment path found for the requested asset pair.",
-      });
+    let useCache = false;
+    let quotePaths: QuotePathDto[] = [];
+    let horizonUrlStr = "";
+    let fetchedAt = now;
+    let cacheSource: "hit" | "miss" = "miss";
+
+    if (cached && !dto.revalidate) {
+      const isExpired = now - cached.fetchedAt > CACHE_TTL_MS;
+      if (!isExpired) {
+        useCache = true;
+        quotePaths = cached.paths;
+        horizonUrlStr = cached.horizonUrl;
+        fetchedAt = cached.fetchedAt;
+        cacheSource = "hit";
+        this.logger.debug(`Cache hit for key: ${cacheKey}`);
+      }
     }
 
-    const slippageFactor = 1 + slippageBps / 10_000;
+    if (!useCache) {
+      const { paths, horizonUrl } = await this.pathPreview.previewPaths({
+        destinationAmount: dto.destinationAmount,
+        destinationAsset: dto.destinationAsset,
+        sourceAssets: dto.sourceAssets,
+      });
 
-    const quotePaths = paths.map((p) => {
-      const srcNum = parseFloat(p.sourceAmount);
-      const srcWithSlippage = isFinite(srcNum)
-        ? (srcNum * slippageFactor).toFixed(7)
-        : p.sourceAmount;
+      if (paths.length === 0) {
+        throw new BadRequestException({
+          code: "NO_PATH_FOUND",
+          message: "No payment path found for the requested asset pair.",
+        });
+      }
 
-      const destNum = parseFloat(p.destinationAmount);
-      const platformFee = isFinite(destNum) ? (destNum * 0.01).toFixed(7) : "0.0000000";
-      const networkFee = "0.0000100"; // 100 stroops
-      // Combining fees of potentially different assets into a single string is non-trivial without an oracle, 
-      // but for API consistency we return the platform fee as the total fee (assuming the user pays network fee separately in XLM).
-      const totalFee = platformFee;
+      const slippageFactor = 1 + slippageBps / 10_000;
 
-      return {
-        sourceAsset: p.sourceAsset,
-        sourceAmount: p.sourceAmount,
-        sourceAmountWithSlippage: srcWithSlippage,
-        destinationAsset: p.destinationAsset,
-        destinationAmount: p.destinationAmount,
-        pathHops: p.pathHops,
-        rateDescription: p.rateDescription,
-        feeBreakdown: {
-          networkFee,
-          platformFee,
-          totalFee,
-        },
-      };
-    });
+      quotePaths = paths.map((p) => {
+        const srcNum = parseFloat(p.sourceAmount);
+        const srcWithSlippage = isFinite(srcNum)
+          ? (srcNum * slippageFactor).toFixed(7)
+          : p.sourceAmount;
+
+        const destNum = parseFloat(p.destinationAmount);
+        const platformFee = isFinite(destNum) ? (destNum * 0.01).toFixed(7) : "0.0000000";
+        const networkFee = "0.0000100"; // 100 stroops
+        // Combining fees of potentially different assets into a single string is non-trivial without an oracle, 
+        // but for API consistency we return the platform fee as the total fee (assuming the user pays network fee separately in XLM).
+        const totalFee = platformFee;
+
+        return {
+          sourceAsset: p.sourceAsset,
+          sourceAmount: p.sourceAmount,
+          sourceAmountWithSlippage: srcWithSlippage,
+          destinationAsset: p.destinationAsset,
+          destinationAmount: p.destinationAmount,
+          pathHops: p.pathHops,
+          rateDescription: p.rateDescription,
+          feeBreakdown: {
+            networkFee,
+            platformFee,
+            totalFee,
+          },
+        };
+      });
+
+      horizonUrlStr = horizonUrl;
+      fetchedAt = now;
+      cacheSource = "miss";
+
+      this.cache.set(cacheKey, {
+        paths: quotePaths,
+        horizonUrl,
+        fetchedAt,
+      });
+      this.logger.debug(`Cache miss/refresh for key: ${cacheKey}`);
+    }
 
     const quoteId = `qx_${crypto.randomBytes(12).toString("hex")}`;
-    const expiresAt = new Date(Date.now() + ttl * 1000);
+    const expiresAt = new Date(now + ttl * 1000);
 
     let preflight: QuoteResponseDto["preflight"];
     if (dto.preflight) {
@@ -84,16 +141,20 @@ export class QuoteService {
       this.logger.debug(`Preflight requested for quote ${quoteId} (stub: feasible)`);
     }
 
+    const age = Math.max(0, Math.floor((now - fetchedAt) / 1000));
+
     const response: QuoteResponseDto = {
       quoteId,
       paths: quotePaths,
       expiresAt: expiresAt.toISOString(),
       maxSlippageBps: slippageBps,
-      horizonUrl,
+      horizonUrl: horizonUrlStr,
       preflight,
+      age,
+      cacheSource,
     };
 
-    this.store.set(quoteId, { response, expiresAt });
+    this.store.set(quoteId, { response, expiresAt, fetchedAt, cacheSource });
     this.logger.log(`Quote created: ${quoteId} expires ${expiresAt.toISOString()}`);
 
     // Evict expired entries lazily to avoid unbounded growth
@@ -111,13 +172,20 @@ export class QuoteService {
       this.store.delete(quoteId);
       throw new GoneException({ code: "QUOTE_EXPIRED", message: "Quote has expired." });
     }
-    return entry.response;
+    const age = Math.max(0, Math.floor((Date.now() - entry.fetchedAt) / 1000));
+    return {
+      ...entry.response,
+      age,
+    };
   }
 
   private evictExpired(): void {
-    const now = new Date();
+    const now = Date.now();
     for (const [id, entry] of this.store) {
-      if (entry.expiresAt <= now) this.store.delete(id);
+      if (entry.expiresAt.getTime() <= now) this.store.delete(id);
+    }
+    for (const [key, entry] of this.cache) {
+      if (entry.fetchedAt + CACHE_TTL_MS <= now) this.cache.delete(key);
     }
   }
 }

--- a/app/backend/src/stellar/quote.service.unit.spec.ts
+++ b/app/backend/src/stellar/quote.service.unit.spec.ts
@@ -12,6 +12,13 @@ const MOCK_PATH: PathPreviewRow = {
   rateDescription: "0.100000 (dest/source in smallest units)",
 };
 
+interface TestQuoteService {
+  pathPreview: { previewPaths: jest.Mock };
+  getCacheKey(dto: unknown): string;
+  cache: Map<string, { fetchedAt: number }>;
+  store: Map<string, { fetchedAt: number; expiresAt: Date }>;
+}
+
 function makeService(paths: PathPreviewRow[] = [MOCK_PATH]) {
   const mockPreview = {
     previewPaths: jest.fn().mockResolvedValue({ paths, horizonUrl: "https://horizon-testnet.stellar.org" }),
@@ -85,11 +92,101 @@ describe("QuoteService", () => {
       const created = await svc.createQuote({ ...BASE_DTO, ttlSeconds: 5 });
 
       // Manually expire by manipulating the store
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const store: Map<string, { response: unknown; expiresAt: Date }> = (svc as any).store;
-      store.get(created.quoteId)!.expiresAt = new Date(Date.now() - 1000);
+      const testSvc = svc as unknown as TestQuoteService;
+      testSvc.store.get(created.quoteId)!.expiresAt = new Date(Date.now() - 1000);
 
       expect(() => svc.getQuote(created.quoteId)).toThrow(GoneException);
+    });
+  });
+
+  describe("caching and revalidation", () => {
+    it("caches the path preview results on first request (cache miss)", async () => {
+      const svc = makeService();
+      const testSvc = svc as unknown as TestQuoteService;
+      const previewSpy = jest.spyOn(testSvc.pathPreview, "previewPaths");
+
+      const res1 = await svc.createQuote(BASE_DTO);
+      expect(res1.cacheSource).toBe("miss");
+      expect(res1.age).toBe(0);
+      expect(previewSpy).toHaveBeenCalledTimes(1);
+
+      // Second request with same parameters should hit cache
+      const res2 = await svc.createQuote(BASE_DTO);
+      expect(res2.cacheSource).toBe("hit");
+      expect(res2.age).toBe(0);
+      expect(previewSpy).toHaveBeenCalledTimes(1); // Still 1 call!
+
+      // Unique quote ID for both
+      expect(res1.quoteId).not.toBe(res2.quoteId);
+      // Both exist in store
+      expect(svc.getQuote(res1.quoteId).quoteId).toBe(res1.quoteId);
+      expect(svc.getQuote(res2.quoteId).quoteId).toBe(res2.quoteId);
+    });
+
+    it("bypasses cache and updates it when revalidate is true", async () => {
+      const svc = makeService();
+      const testSvc = svc as unknown as TestQuoteService;
+      const previewSpy = jest.spyOn(testSvc.pathPreview, "previewPaths");
+
+      const res1 = await svc.createQuote(BASE_DTO);
+      expect(res1.cacheSource).toBe("miss");
+      expect(previewSpy).toHaveBeenCalledTimes(1);
+
+      // Revalidate: true
+      const res2 = await svc.createQuote({ ...BASE_DTO, revalidate: true });
+      expect(res2.cacheSource).toBe("miss");
+      expect(previewSpy).toHaveBeenCalledTimes(2);
+
+      // Next request without revalidate should be a hit (from the updated cache entry)
+      const res3 = await svc.createQuote(BASE_DTO);
+      expect(res3.cacheSource).toBe("hit");
+      expect(previewSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("expires cache after CACHE_TTL_MS has elapsed", async () => {
+      const svc = makeService();
+      const testSvc = svc as unknown as TestQuoteService;
+      const previewSpy = jest.spyOn(testSvc.pathPreview, "previewPaths");
+
+      const res1 = await svc.createQuote(BASE_DTO);
+      expect(res1.cacheSource).toBe("miss");
+      expect(previewSpy).toHaveBeenCalledTimes(1);
+
+      // Manually manipulate cache entry timestamp to be 11 seconds in past (CACHE_TTL_MS is 10s)
+      const key = testSvc.getCacheKey(BASE_DTO);
+      testSvc.cache.get(key)!.fetchedAt = Date.now() - 11_000;
+
+      const res2 = await svc.createQuote(BASE_DTO);
+      expect(res2.cacheSource).toBe("miss");
+      expect(previewSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("tracks quote age dynamically over time on retrieval", async () => {
+      const svc = makeService();
+      const res = await svc.createQuote(BASE_DTO);
+      expect(res.age).toBe(0);
+
+      // Manually manipulate the fetchedAt in store to simulate passage of 5 seconds
+      const testSvc = svc as unknown as TestQuoteService;
+      const entry = testSvc.store.get(res.quoteId);
+      entry!.fetchedAt = Date.now() - 5000;
+
+      const fetched = svc.getQuote(res.quoteId);
+      expect(fetched.age).toBe(5);
+    });
+
+    it("uses different cache entries for different slippage settings", async () => {
+      const svc = makeService();
+      const testSvc = svc as unknown as TestQuoteService;
+      const previewSpy = jest.spyOn(testSvc.pathPreview, "previewPaths");
+
+      const res1 = await svc.createQuote({ ...BASE_DTO, maxSlippageBps: 50 });
+      expect(res1.cacheSource).toBe("miss");
+      expect(previewSpy).toHaveBeenCalledTimes(1);
+
+      const res2 = await svc.createQuote({ ...BASE_DTO, maxSlippageBps: 100 });
+      expect(res2.cacheSource).toBe("miss");
+      expect(previewSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
+      ipaddr.js:
+        specifier: ^2.4.0
+        version: 2.4.0
       joi:
         specifier: ^18.0.2
         version: 18.1.1
@@ -5532,6 +5535,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -14643,6 +14650,8 @@ snapshots:
       loose-envify: 1.4.0
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.4.0: {}
 
   is-array-buffer@3.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

  Improves quote responsiveness and reduces network calls to Soroban/Horizon by caching path preview results, while still allowing clients to request a fresh quote explicitly using revalidation.

  ## Tasks & Changes

  ### 1. DTO & Validation Changes

  • quote.dto.ts: Added optional  revalidate  boolean parameter (with proper NestJS decorators  IsOptional ,  IsBoolean , and  @ApiPropertyOptional ) to let clients force refresh path rates.
  • quote.dto.ts: Added  age  (in seconds) and  cacheSource  ( 'hit' | 'miss' ) fields to provide transparency about data freshness.

  ### 2. Cache Logic in quote.service.ts

  • Implemented a short-lived cache (10 seconds) keyed canonically by destination asset, destination amount, source assets, and slippage settings.
  • When cache is hit and  revalidate  is not passed:
      • Reuses cached preview paths and horizon URL.
      • Generates a unique  quoteId  and records the session.
      • Correctly computes quote  age  using the original fetch timestamp.
  • When cache is missed or  revalidate: true  is requested:
      • Pulls fresh rates from Horizon/Soroban path search.
      • Updates the short-lived cache.
  • Dynamically calculates  age  when a client pulls a specific quote via the GET  /stellar/quote/:quoteId  endpoint.
  • Added lazy eviction of expired cache entries to prevent unbounded memory growth.

  ### 3. Tests in quote.service.unit.spec.ts

  • Added a comprehensive suite under  caching and revalidation :
      • Verified that first request results in a  miss  and caches results.
      • Verified that subsequent requests hit the cache (zero new network calls).
      • Verified that passing  revalidate: true  forces a cache bypass and refreshes entries.
      • Verified that cache entries expire after 10 seconds.
      • Verified that quote  age  increments dynamically when fetched.
      • Verified that the cache is properly keyed by slippage settings.

Closes #549