### PR TITLE
Standardize event schema compatibility contract

### DIFF
--- a/app/backend/src/ingestion/__tests__/event-id.unit.spec.ts
+++ b/app/backend/src/ingestion/__tests__/event-id.unit.spec.ts
@@ -63,6 +63,7 @@ const FIXTURES: EventWithoutId[] = [
     eventType: "ContractPaused",
     admin: ADMIN,
     paused: true,
+    reason: 3,
   },
   {
     ...BASE,

--- a/app/backend/src/ingestion/__tests__/soroban-event.parser.unit.spec.ts
+++ b/app/backend/src/ingestion/__tests__/soroban-event.parser.unit.spec.ts
@@ -4,6 +4,7 @@ import {
   RawHorizonContractEvent,
 } from "../soroban-event.parser";
 import {
+  QUICKEX_CLIENT_EVENT_ACTIONS,
   QUICKEX_EVENT_SCHEMA_CONTRACTS,
   QUICKEX_EVENT_SCHEMA_VERSION,
   QUICKEX_EVENT_TOPICS,
@@ -167,6 +168,30 @@ describe("SorobanEventParser", () => {
     });
   });
 
+  describe("ContractPaused", () => {
+    it("parses the pause reason and state for ContractPaused", () => {
+      const topics = [
+        symVal(QUICKEX_EVENT_TOPICS.admin),
+        symVal("ContractPaused"),
+        addressVal(OWNER),
+      ];
+      const data = mapVal({
+        paused: nativeToScVal(true),
+        reason: nativeToScVal(7, { type: "u32" }),
+        schema_version: nativeToScVal(QUICKEX_EVENT_SCHEMA_VERSION, {
+          type: "u32",
+        }),
+        timestamp: nativeToScVal(1700005000n, { type: "u64" }),
+      });
+
+      const result = parser.parse(makeRaw(topics, data));
+      expect(result?.eventType).toBe("ContractPaused");
+      if (result?.eventType !== "ContractPaused") return;
+      expect(result.paused).toBe(true);
+      expect(result.reason).toBe(7);
+    });
+  });
+
   describe("AdminChanged", () => {
     it("parses a valid AdminChanged event", () => {
       const ADMIN2 = "GB7QNDHSBQZENWGZUBJ4KLSZFRNHN5ATQXZSC3ZHZ5ZBQ6Y6X3TOBQ7S";
@@ -243,6 +268,52 @@ describe("SorobanEventParser", () => {
         expect(contract.payloadKeys).toEqual([...contract.payloadKeys].sort());
         expect(contract.compatibleVersions).toContain(contract.schemaVersion);
       }
+    });
+
+    it("snapshots the canonical client-facing create/settle/refund/pause payload contract", () => {
+      expect(QUICKEX_CLIENT_EVENT_ACTIONS).toMatchInlineSnapshot(`
+        Object {
+          "create": Object {
+            "eventName": "EscrowDeposited",
+            "requiredPayloadKeys": Array [
+              "amount_due",
+              "amount_paid",
+              "expires_at",
+              "schema_version",
+              "timestamp",
+              "token",
+            ],
+          },
+          "pause": Object {
+            "eventName": "ContractPaused",
+            "requiredPayloadKeys": Array [
+              "paused",
+              "reason",
+              "schema_version",
+              "timestamp",
+            ],
+          },
+          "refund": Object {
+            "eventName": "EscrowRefunded",
+            "requiredPayloadKeys": Array [
+              "amount",
+              "schema_version",
+              "timestamp",
+              "token",
+            ],
+          },
+          "settle": Object {
+            "eventName": "EscrowWithdrawn",
+            "requiredPayloadKeys": Array [
+              "amount",
+              "fee",
+              "schema_version",
+              "timestamp",
+              "token",
+            ],
+          },
+        }
+      `);
     });
   });
 });

--- a/app/backend/src/ingestion/admin-event.repository.ts
+++ b/app/backend/src/ingestion/admin-event.repository.ts
@@ -41,7 +41,11 @@ export class AdminEventRepository {
   private buildPayload(event: AdminEvent): Record<string, unknown> {
     switch (event.eventType) {
       case "ContractPaused":
-        return { admin: (event as ContractPausedEvent).admin, paused: (event as ContractPausedEvent).paused };
+        return {
+          admin: (event as ContractPausedEvent).admin,
+          paused: (event as ContractPausedEvent).paused,
+          reason: (event as ContractPausedEvent).reason,
+        };
       case "AdminChanged":
         return { oldAdmin: (event as AdminChangedEvent).oldAdmin, newAdmin: (event as AdminChangedEvent).newAdmin };
       case "ContractUpgraded":

--- a/app/backend/src/ingestion/event-schema.ts
+++ b/app/backend/src/ingestion/event-schema.ts
@@ -20,6 +20,40 @@ export interface EventSchemaContract {
   compatibleVersions: readonly number[];
 }
 
+/**
+ * Canonical client-facing action contract for the event stream consumed by
+ * downstream clients and indexers. The field names and required keys are
+ * intentionally stable across schema versions to preserve compatibility.
+ */
+export const QUICKEX_CLIENT_EVENT_ACTIONS = {
+  create: {
+    eventName: "EscrowDeposited",
+    requiredPayloadKeys: [
+      "amount_due",
+      "amount_paid",
+      "expires_at",
+      "schema_version",
+      "timestamp",
+      "token",
+    ],
+  },
+  settle: {
+    eventName: "EscrowWithdrawn",
+    requiredPayloadKeys: ["amount", "fee", "schema_version", "timestamp", "token"],
+  },
+  refund: {
+    eventName: "EscrowRefunded",
+    requiredPayloadKeys: ["amount", "schema_version", "timestamp", "token"],
+  },
+  pause: {
+    eventName: "ContractPaused",
+    requiredPayloadKeys: ["paused", "reason", "schema_version", "timestamp"],
+  },
+} as const satisfies Record<
+  string,
+  { eventName: string; requiredPayloadKeys: readonly string[] }
+>;
+
 export const QUICKEX_EVENT_SCHEMA_CONTRACTS = {
   EscrowDeposited: {
     topic: QUICKEX_EVENT_TOPICS.escrow,
@@ -64,7 +98,7 @@ export const QUICKEX_EVENT_SCHEMA_CONTRACTS = {
     topic: QUICKEX_EVENT_TOPICS.admin,
     eventName: "ContractPaused",
     indexedFields: ["admin"],
-    payloadKeys: ["paused", "schema_version", "timestamp"],
+    payloadKeys: ["paused", "reason", "schema_version", "timestamp"],
     schemaVersion: QUICKEX_EVENT_SCHEMA_VERSION,
     compatibleVersions: [QUICKEX_EVENT_SCHEMA_VERSION],
   },

--- a/app/backend/src/ingestion/soroban-event.parser.ts
+++ b/app/backend/src/ingestion/soroban-event.parser.ts
@@ -341,7 +341,7 @@ export class SorobanEventParser {
   private parseContractPaused(
     topics: xdr.ScVal[],
     data: xdr.ScVal,
-    base: Omit<ContractPausedEvent, "eventId" | "eventType" | "admin" | "paused">,
+    base: Omit<ContractPausedEvent, "eventId" | "eventType" | "admin" | "paused" | "reason">,
     indexedOffset: number,
   ): Omit<ContractPausedEvent, "eventId"> {
     const admin = this.decodeAddress(topics[indexedOffset]);
@@ -352,6 +352,7 @@ export class SorobanEventParser {
       ...base,
       admin,
       paused: Boolean(scValToNative(map["paused"])),
+      reason: Number(scValToNative(map["reason"] ?? 0)),
     };
   }
 

--- a/app/backend/src/ingestion/types/contract-event.types.ts
+++ b/app/backend/src/ingestion/types/contract-event.types.ts
@@ -63,6 +63,7 @@ export interface ContractPausedEvent extends BaseContractEvent {
   eventType: "ContractPaused";
   admin: string;
   paused: boolean;
+  reason: number;
 }
 
 export interface AdminChangedEvent extends BaseContractEvent {

--- a/app/contract/docs/events-schema.md
+++ b/app/contract/docs/events-schema.md
@@ -49,6 +49,12 @@ accidental breakage.
 - Event names use `PascalCase` topics.
 - Event structs use `<Topic>NameEvent` in code.
 - All events include `schema_version` and `timestamp` in the data payload.
+- The client-facing lifecycle actions use a stable contract for compatibility:
+  - `create` → `EscrowDeposited` with `amount_due`, `amount_paid`, `expires_at`, `schema_version`, `timestamp`, `token`
+  - `settle` → `EscrowWithdrawn` with `amount`, `fee`, `schema_version`, `timestamp`, `token`
+  - `refund` → `EscrowRefunded` with `amount`, `schema_version`, `timestamp`, `token`
+  - `pause` → `ContractPaused` with `paused`, `reason`, `schema_version`, `timestamp`
+- Compatibility rules: field names are canonical and must not be renamed without advancing the schema contract; new fields must be additive and snapshot tests must be updated in lockstep.
 
 ## Topic and payload rules
 


### PR DESCRIPTION
Closes #670

---

## Summary
- Standardized canonical payload contracts for create/settle/refund/pause actions.
- Added parser support for pause reason and snapshot regression coverage.
- Documented compatibility rules for downstream clients and indexers.

## Testing
- Attempted to run ingestion Jest tests, but the container currently lacks a usable Node/pnpm runtime.