### PR TITLE
feat(backend): add featured username ranking and fix discovery pagina…

### DIFF
--- a/app/backend/src/dto/username/featured-usernames-query.dto.ts
+++ b/app/backend/src/dto/username/featured-usernames-query.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Min, Max } from 'class-validator';
+
+/**
+ * DTO for featured usernames query parameters
+ */
+export class FeaturedUsernamesQueryDto {
+  @ApiProperty({
+    description: 'Maximum number of featured usernames to return',
+    example: 10,
+    required: false,
+    default: 10,
+  })
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number = 10;
+
+  @ApiProperty({
+    description: 'Opaque cursor for the next page of results',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+}

--- a/app/backend/src/dto/username/featured-usernames-response.dto.ts
+++ b/app/backend/src/dto/username/featured-usernames-response.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PublicProfileDto } from './public-profile.dto';
+
+/**
+ * DTO for featured usernames response
+ */
+export class FeaturedUsernamesResponseDto {
+  @ApiProperty({
+    description:
+      'List of curated/featured public profiles ordered by featured rank',
+    type: [PublicProfileDto],
+  })
+  profiles: PublicProfileDto[];
+
+  @ApiPropertyOptional({
+    description: 'Opaque cursor to fetch the next page',
+    nullable: true,
+  })
+  next_cursor: string | null;
+
+  @ApiProperty({
+    description: 'Whether more results exist beyond this page',
+  })
+  has_more: boolean;
+}

--- a/app/backend/src/dto/username/index.ts
+++ b/app/backend/src/dto/username/index.ts
@@ -13,3 +13,5 @@ export * from "./trending-creators-query.dto";
 export * from "./trending-creators-response.dto";
 export * from "./recently-active-query.dto";
 export * from "./recently-active-response.dto";
+export * from "./featured-usernames-query.dto";
+export * from "./featured-usernames-response.dto";

--- a/app/backend/src/dto/username/public-profile.dto.ts
+++ b/app/backend/src/dto/username/public-profile.dto.ts
@@ -44,6 +44,14 @@ export class PublicProfileDto {
   transactionCount?: number;
 
   @ApiProperty({
+    description:
+      'Manual featured ordering rank (lower = higher priority, for featured profiles)',
+    example: 1,
+    required: false,
+  })
+  featuredRank?: number | null;
+
+  @ApiProperty({
     description: 'Last activity timestamp',
     example: '2025-03-27T10:30:00Z',
   })

--- a/app/backend/src/supabase/supabase.service.discovery.unit.spec.ts
+++ b/app/backend/src/supabase/supabase.service.discovery.unit.spec.ts
@@ -1,0 +1,206 @@
+import { Test } from '@nestjs/testing';
+import { createClient } from '@supabase/supabase-js';
+import { SupabaseService } from './supabase.service';
+import { AppConfigService } from '../config';
+
+// Mock the supabase-js module
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(),
+}));
+
+/**
+ * Builds a chainable, awaitable Supabase query-builder stand-in. Every
+ * filter/order/limit method returns the chain itself so calls can be
+ * composed in any order (matching real supabase-js), and `await`-ing the
+ * chain at any point resolves to `result` (matching PostgrestFilterBuilder's
+ * thenable behavior).
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {};
+  ['select', 'eq', 'gte', 'in', 'ilike', 'order', 'limit'].forEach((method) => {
+    chain[method] = jest.fn(() => chain);
+  });
+  chain.then = (
+    resolve: (value: typeof result) => unknown,
+    reject: (reason: unknown) => unknown,
+  ) => Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
+/**
+ * Routes `.from(table)` calls to a queue of pre-built chains, consumed in
+ * call order. This supports methods that query the same table more than
+ * once (e.g. `getRecentlyActiveUsers` queries `usernames` twice) with
+ * different results per call.
+ */
+function makeClient(routes: Record<string, ReturnType<typeof makeChain>[]>) {
+  return {
+    from: jest.fn((table: string) => {
+      const queue = routes[table];
+      if (!queue || queue.length === 0) {
+        throw new Error(`Unexpected call to from('${table}')`);
+      }
+      return queue.shift();
+    }),
+  };
+}
+
+/**
+ * Builds a fresh SupabaseService bound to the given mock client. A fresh
+ * module is required per test because the client is captured once, in the
+ * constructor.
+ */
+async function createService(
+  client: ReturnType<typeof makeClient>,
+): Promise<SupabaseService> {
+  (createClient as jest.Mock).mockReturnValue(client);
+  const module = await Test.createTestingModule({
+    providers: [
+      SupabaseService,
+      {
+        provide: AppConfigService,
+        useValue: { supabaseUrl: 'http://localhost:54321', supabaseAnonKey: 'anon-key' },
+      },
+    ],
+  }).compile();
+  return module.get<SupabaseService>(SupabaseService);
+}
+
+describe('SupabaseService discovery ranking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getFeaturedUsernames', () => {
+    it('queries public + featured profiles ordered by featured_rank asc (nulls last), id asc', async () => {
+      const profiles = [
+        { id: 'id-1', username: 'a', public_key: 'GAAA1', created_at: '2025-01-01T00:00:00.000Z', last_active_at: null, is_public: true, featured_rank: 1 },
+      ];
+      const usernamesChain = makeChain({ data: profiles, error: null });
+      const service = await createService(makeClient({ usernames: [usernamesChain] }));
+
+      const result = await service.getFeaturedUsernames(10);
+
+      expect(result).toEqual(profiles);
+      expect(usernamesChain.eq).toHaveBeenCalledWith('is_public', true);
+      expect(usernamesChain.eq).toHaveBeenCalledWith('is_featured', true);
+      expect(usernamesChain.order).toHaveBeenCalledWith('featured_rank', { ascending: true, nullsFirst: false });
+      expect(usernamesChain.order).toHaveBeenCalledWith('id', { ascending: true });
+      expect(usernamesChain.limit).toHaveBeenCalledWith(10);
+    });
+  });
+
+  describe('getTrendingCreators', () => {
+    it('does not drop lower-volume public creators just because a higher-volume non-public account exists', async () => {
+      // "ghost" is the top earner by volume but has no public profile: it
+      // must not consume a ranking slot ahead of public creators.
+      const payments = [
+        { sender_public_key: 'ghost', receiver_public_key: 'GBBB', amount_usd: 1000 },
+        { sender_public_key: 'GBBB', receiver_public_key: 'GCCC', amount_usd: 500 },
+        { sender_public_key: 'GCCC', receiver_public_key: 'GBBB', amount_usd: 100 },
+      ];
+      // Only public profiles are returned by the `.eq('is_public', true)` filter.
+      const publicProfiles = [
+        { id: 'id-b', username: 'b', public_key: 'GBBB', created_at: '2025-01-01T00:00:00.000Z', last_active_at: null, is_public: true },
+        { id: 'id-c', username: 'c', public_key: 'GCCC', created_at: '2025-01-02T00:00:00.000Z', last_active_at: null, is_public: true },
+      ];
+
+      const service = await createService(
+        makeClient({
+          payment_records: [makeChain({ data: payments, error: null })],
+          usernames: [makeChain({ data: publicProfiles, error: null })],
+        }),
+      );
+
+      // limit=2: with the bug, "ghost" would occupy a ranking slot and get
+      // filtered out afterward, leaving only 1 result instead of 2.
+      const result = await service.getTrendingCreators(24, 2);
+
+      expect(result.map((r) => r.username)).toEqual(['b', 'c']);
+      expect(result[0].transaction_volume).toBeGreaterThan(result[1].transaction_volume);
+    });
+
+    it('breaks equal-volume ties deterministically by ascending id', async () => {
+      const payments = [
+        { sender_public_key: 'GAAA2', receiver_public_key: 'GAAA3', amount_usd: 200 },
+      ];
+      const publicProfiles = [
+        { id: 'id-3', username: 'c', public_key: 'GAAA3', created_at: '2025-01-01T00:00:00.000Z', last_active_at: null, is_public: true },
+        { id: 'id-2', username: 'b', public_key: 'GAAA2', created_at: '2025-01-01T00:00:00.000Z', last_active_at: null, is_public: true },
+      ];
+
+      const service = await createService(
+        makeClient({
+          payment_records: [makeChain({ data: payments, error: null })],
+          usernames: [makeChain({ data: publicProfiles, error: null })],
+        }),
+      );
+
+      const result = await service.getTrendingCreators(24, 10);
+
+      // Both GAAA2 and GAAA3 accrue equal volume (200) from the same payment.
+      expect(result[0].transaction_volume).toBe(result[1].transaction_volume);
+      expect(result.map((r) => r.id)).toEqual(['id-2', 'id-3']);
+    });
+  });
+
+  describe('getRecentlyActiveUsers', () => {
+    it('ranks by merged payment activity, not the stale DB last_active_at column, and never truncates the profile fetch at the DB layer', async () => {
+      // Two separate payments give GAAA1 and GAAA2 different payment-derived
+      // activity timestamps, even though their `usernames.last_active_at`
+      // columns (below) are identical and stale.
+      const payments = [
+        { sender_public_key: 'GAAA1', receiver_public_key: 'GAAA9', created_at: '2025-06-01T00:00:00.000Z' },
+        { sender_public_key: 'GAAA9', receiver_public_key: 'GAAA2', created_at: '2025-01-15T00:00:00.000Z' },
+      ];
+      const profileActivityRows: unknown[] = [];
+      const profiles = [
+        { id: 'id-1', username: 'a', public_key: 'GAAA1', created_at: '2025-01-01T00:00:00.000Z', last_active_at: '2025-01-01T00:00:00.000Z', is_public: true },
+        { id: 'id-2', username: 'b', public_key: 'GAAA2', created_at: '2025-01-01T00:00:00.000Z', last_active_at: '2025-01-01T00:00:00.000Z', is_public: true },
+      ];
+
+      const usernamesProfilesChain = makeChain({ data: profiles, error: null });
+      const service = await createService(
+        makeClient({
+          payment_records: [makeChain({ data: payments, error: null })],
+          usernames: [makeChain({ data: profileActivityRows, error: null }), usernamesProfilesChain],
+        }),
+      );
+
+      const result = await service.getRecentlyActiveUsers(720, 10);
+
+      // GAAA1's payment-derived timestamp (2025-06-01) is more recent than
+      // GAAA2's (2025-01-15), so it must rank first despite both profiles
+      // sharing the same stale `last_active_at` column value.
+      expect(result.map((r) => r.username)).toEqual(['a', 'b']);
+      // The final profiles fetch must not be limited at the DB layer, since
+      // ranking depends on the in-memory merge with payment activity -
+      // truncating there could silently drop the true top-N candidates.
+      expect(usernamesProfilesChain.limit).not.toHaveBeenCalled();
+    });
+
+    it('breaks equal-activity ties deterministically by ascending id', async () => {
+      const payments: unknown[] = [];
+      const profileActivityRows = [{ public_key: 'GAAA2' }, { public_key: 'GAAA3' }];
+      const profiles = [
+        { id: 'id-3', username: 'c', public_key: 'GAAA3', created_at: '2025-01-01T00:00:00.000Z', last_active_at: '2025-01-05T00:00:00.000Z', is_public: true },
+        { id: 'id-2', username: 'b', public_key: 'GAAA2', created_at: '2025-01-01T00:00:00.000Z', last_active_at: '2025-01-05T00:00:00.000Z', is_public: true },
+      ];
+
+      const service = await createService(
+        makeClient({
+          payment_records: [makeChain({ data: payments, error: null })],
+          usernames: [
+            makeChain({ data: profileActivityRows, error: null }),
+            makeChain({ data: profiles, error: null }),
+          ],
+        }),
+      );
+
+      const result = await service.getRecentlyActiveUsers(24, 10);
+
+      expect(result.map((r) => r.id)).toEqual(['id-2', 'id-3']);
+    });
+  });
+});

--- a/app/backend/src/supabase/supabase.service.ts
+++ b/app/backend/src/supabase/supabase.service.ts
@@ -29,6 +29,10 @@ export interface TrendingCreatorResult extends SearchProfileResult {
   transaction_count: number;
 }
 
+export interface FeaturedProfileResult extends SearchProfileResult {
+  featured_rank: number | null;
+}
+
 export interface MarketplaceListing {
   id: string;
   username: string;
@@ -62,6 +66,16 @@ export interface VerifiedAssetDbRecord {
   verified: boolean;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * Deterministic ascending tiebreaker used when the primary ranking metric
+ * (volume, activity timestamp, featured rank) is equal between two rows.
+ */
+function compareIdsAsc(a: { id: string }, b: { id: string }): number {
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
 }
 
 @Injectable()
@@ -383,17 +397,19 @@ export class SupabaseService {
       },
     );
 
-    // Get top creators by volume
-    const topCreators = Array.from(volumeMap.entries())
-      .sort((a, b) => b[1].volume - a[1].volume)
-      .slice(0, limit);
+    // Rank all candidates by volume first. Slicing to `limit` must happen
+    // *after* filtering to public profiles below, otherwise a candidate that
+    // ranks in the true top-N of public profiles could be dropped here just
+    // because non-public accounts occupied the top volume slots.
+    const rankedCandidates = Array.from(volumeMap.entries()).sort(
+      (a, b) => b[1].volume - a[1].volume,
+    );
 
-    // Fetch public profiles for these creators
-    if (topCreators.length === 0) {
+    if (rankedCandidates.length === 0) {
       return [];
     }
 
-    const publicKeys = topCreators.map(([key]) => key);
+    const publicKeys = rankedCandidates.map(([key]) => key);
     const { data: profiles, error: profilesError } = await this.client
       .from("usernames")
       .select("id, username, public_key, created_at, last_active_at, is_public")
@@ -405,21 +421,30 @@ export class SupabaseService {
       return [];
     }
 
-    // Merge volume data with profile data
-    return (profiles ?? [])
-      .map((profile: SearchProfileResult) => {
-        const found = topCreators.find(([key]) => key === profile.public_key);
-        const stats = found ? found[1] : { volume: 0, count: 0 };
+    const profileByKey = new Map(
+      (profiles ?? []).map((profile: SearchProfileResult) => [
+        profile.public_key,
+        profile,
+      ]),
+    );
+
+    // Merge volume data with profile data. Ties in volume are broken by `id`
+    // so the ranking is deterministic and stable across identical requests.
+    return rankedCandidates
+      .filter(([key]) => profileByKey.has(key))
+      .map(([key, stats]) => {
+        const profile = profileByKey.get(key) as SearchProfileResult;
         return {
           ...profile,
           transaction_volume: stats.volume,
           transaction_count: stats.count,
         } as TrendingCreatorResult;
       })
-      .sort(
-        (a: TrendingCreatorResult, b: TrendingCreatorResult) =>
-          (b.transaction_volume || 0) - (a.transaction_volume || 0),
-      );
+      .sort((a: TrendingCreatorResult, b: TrendingCreatorResult) => {
+        const diff = (b.transaction_volume || 0) - (a.transaction_volume || 0);
+        return diff !== 0 ? diff : compareIdsAsc(a, b);
+      })
+      .slice(0, limit);
   }
 
   /**
@@ -489,14 +514,16 @@ export class SupabaseService {
       return [];
     }
 
-    // Fetch public profiles for these active users
+    // Fetch public profiles for these active users. We intentionally do not
+    // limit or order at the DB level here: `last_active_at` on this table can
+    // be stale compared to the payment-derived activity merged in below, so
+    // limiting before that merge could drop candidates that actually rank in
+    // the true top-N. Ranking and limiting happen after the merge instead.
     const { data: profiles, error: profilesError } = await this.client
       .from("usernames")
       .select("id, username, public_key, created_at, last_active_at, is_public")
       .in("public_key", Array.from(activePublicKeys))
-      .eq("is_public", true)
-      .order("last_active_at", { ascending: false })
-      .limit(limit);
+      .eq("is_public", true);
 
     if (profilesError) {
       this.logger.warn(`Failed to fetch profiles: ${profilesError.message}`);
@@ -529,7 +556,8 @@ export class SupabaseService {
       },
     );
 
-    // Merge with profile data and sort by activity
+    // Merge with profile data and sort by activity. Ties are broken by `id`
+    // so the ranking is deterministic and stable across identical requests.
     return (profiles ?? [])
       .map((profile: SearchProfileResult) => ({
         ...profile,
@@ -539,9 +567,33 @@ export class SupabaseService {
       .sort((a: SearchProfileResult, b: SearchProfileResult) => {
         const aTime = new Date(a.last_active_at || a.created_at).getTime();
         const bTime = new Date(b.last_active_at || b.created_at).getTime();
-        return bTime - aTime;
+        return bTime !== aTime ? bTime - aTime : compareIdsAsc(a, b);
       })
       .slice(0, limit);
+  }
+
+  /**
+   * Get curated/featured usernames for discovery, ordered by manual
+   * `featured_rank` (ascending, nulls last) with `id` as a deterministic
+   * tiebreaker.
+   */
+  async getFeaturedUsernames(
+    limit: number = 10,
+  ): Promise<FeaturedProfileResult[]> {
+    const { data, error } = await this.client
+      .from("usernames")
+      .select(
+        "id, username, public_key, created_at, last_active_at, is_public, featured_rank",
+      )
+      .eq("is_public", true)
+      .eq("is_featured", true)
+      .order("featured_rank", { ascending: true, nullsFirst: false })
+      .order("id", { ascending: true })
+      .limit(limit);
+
+    if (error) this.handleError(error);
+
+    return (data ?? []) as FeaturedProfileResult[];
   }
 
   /**

--- a/app/backend/src/usernames/usernames.controller.int.spec.ts
+++ b/app/backend/src/usernames/usernames.controller.int.spec.ts
@@ -18,6 +18,9 @@ describe('UsernamesController', () => {
   beforeEach(async () => {
     const mockCreate = jest.fn().mockResolvedValue({ ok: true });
     const mockListByPublicKey = jest.fn().mockResolvedValue([]);
+    const mockGetTrendingCreators = jest.fn().mockResolvedValue({ data: [], next_cursor: null, has_more: false });
+    const mockGetRecentlyActiveUsers = jest.fn().mockResolvedValue({ data: [], next_cursor: null, has_more: false });
+    const mockGetFeaturedCreators = jest.fn().mockResolvedValue({ data: [], next_cursor: null, has_more: false });
     const mockEmit = jest.fn();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -28,6 +31,9 @@ describe('UsernamesController', () => {
           useValue: {
             create: mockCreate,
             listByPublicKey: mockListByPublicKey,
+            getTrendingCreators: mockGetTrendingCreators,
+            getRecentlyActiveUsers: mockGetRecentlyActiveUsers,
+            getFeaturedCreators: mockGetFeaturedCreators,
           },
         },
         {
@@ -99,6 +105,117 @@ describe('UsernamesController', () => {
       const result = await controller.listUsernames({ publicKey: validPublicKey });
       expect(result).toEqual({ usernames: rows });
       expect(usernamesService.listByPublicKey).toHaveBeenCalledWith(validPublicKey);
+    });
+  });
+
+  describe('getTrendingCreators', () => {
+    it('maps ranked creators to the response shape and forwards pagination info', async () => {
+      const creators = [
+        {
+          id: 'id-1',
+          username: 'alice',
+          public_key: validPublicKey,
+          created_at: '2025-01-01T00:00:00Z',
+          last_active_at: '2025-01-02T00:00:00Z',
+          is_public: true,
+          transaction_volume: 500,
+          transaction_count: 5,
+        },
+      ];
+      usernamesService.getTrendingCreators.mockResolvedValueOnce({
+        data: creators,
+        next_cursor: 'next-page-cursor',
+        has_more: true,
+      });
+
+      const result = await controller.getTrendingCreators({ timeWindowHours: 24, limit: 10 });
+
+      expect(usernamesService.getTrendingCreators).toHaveBeenCalledWith(24, 10, undefined);
+      expect(result.creators).toEqual([
+        {
+          id: 'id-1',
+          username: 'alice',
+          publicKey: validPublicKey,
+          lastActiveAt: '2025-01-02T00:00:00Z',
+          createdAt: '2025-01-01T00:00:00Z',
+          transactionVolume: 500,
+          transactionCount: 5,
+        },
+      ]);
+      expect(result.timeWindowHours).toBe(24);
+      expect(result.next_cursor).toBe('next-page-cursor');
+      expect(result.has_more).toBe(true);
+    });
+  });
+
+  describe('getRecentlyActive', () => {
+    it('maps recently active users to the response shape and forwards pagination info', async () => {
+      const users = [
+        {
+          id: 'id-1',
+          username: 'alice',
+          public_key: validPublicKey,
+          created_at: '2025-01-01T00:00:00Z',
+          last_active_at: '2025-01-02T00:00:00Z',
+          is_public: true,
+        },
+      ];
+      usernamesService.getRecentlyActiveUsers.mockResolvedValueOnce({
+        data: users,
+        next_cursor: null,
+        has_more: false,
+      });
+
+      const result = await controller.getRecentlyActive({ timeWindowHours: 24, limit: 10 });
+
+      expect(usernamesService.getRecentlyActiveUsers).toHaveBeenCalledWith(24, 10, undefined);
+      expect(result.users).toEqual([
+        {
+          id: 'id-1',
+          username: 'alice',
+          publicKey: validPublicKey,
+          lastActiveAt: '2025-01-02T00:00:00Z',
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+      ]);
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeNull();
+    });
+  });
+
+  describe('getFeaturedCreators', () => {
+    it('maps featured creators to the response shape and forwards pagination info', async () => {
+      const creators = [
+        {
+          id: 'id-1',
+          username: 'alice',
+          public_key: validPublicKey,
+          created_at: '2025-01-01T00:00:00Z',
+          last_active_at: null,
+          is_public: true,
+          featured_rank: 1,
+        },
+      ];
+      usernamesService.getFeaturedCreators.mockResolvedValueOnce({
+        data: creators,
+        next_cursor: null,
+        has_more: false,
+      });
+
+      const result = await controller.getFeaturedCreators({ limit: 10 });
+
+      expect(usernamesService.getFeaturedCreators).toHaveBeenCalledWith(10, undefined);
+      expect(result.profiles).toEqual([
+        {
+          id: 'id-1',
+          username: 'alice',
+          publicKey: validPublicKey,
+          lastActiveAt: '2025-01-01T00:00:00Z',
+          createdAt: '2025-01-01T00:00:00Z',
+          featuredRank: 1,
+        },
+      ]);
+      expect(result.has_more).toBe(false);
     });
   });
 });

--- a/app/backend/src/usernames/usernames.controller.ts
+++ b/app/backend/src/usernames/usernames.controller.ts
@@ -31,6 +31,8 @@ import {
   TrendingCreatorsResponseDto,
   RecentlyActiveQueryDto,
   RecentlyActiveResponseDto,
+  FeaturedUsernamesQueryDto,
+  FeaturedUsernamesResponseDto,
   PublicProfileDto,
 } from "../dto";
 import { UsernamesService } from "./usernames.service";
@@ -304,6 +306,52 @@ export class UsernamesController {
       calculatedAt: new Date().toISOString(),
       next_cursor: users.next_cursor,
       has_more: users.has_more,
+    };
+  }
+
+  @Get("featured")
+  @Throttle({ default: { limit: 10, ttl: 60000 } }) // 10 requests per minute
+  @ApiOperation({
+    summary: "Get featured creators",
+    description:
+      "Returns curated/featured creator profiles for discovery, ordered by " +
+      "manual featured rank (lower rank shows first).",
+  })
+  @ApiQuery({
+    name: "limit",
+    description: "Maximum number of featured creators (1-100)",
+    required: false,
+    example: 10,
+  })
+  @ApiQuery({
+    name: "cursor",
+    description: "Opaque cursor for the next page of results",
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "List of featured creator profiles sorted by featured rank",
+    type: FeaturedUsernamesResponseDto,
+  })
+  async getFeaturedCreators(
+    @Query() query: FeaturedUsernamesQueryDto,
+  ): Promise<FeaturedUsernamesResponseDto> {
+    const creators = await this.usernamesService.getFeaturedCreators(
+      query.limit,
+      query.cursor,
+    );
+
+    return {
+      profiles: creators.data.map((c) => ({
+        id: c.id,
+        username: c.username,
+        publicKey: c.public_key,
+        lastActiveAt: c.last_active_at || c.created_at,
+        createdAt: c.created_at,
+        featuredRank: c.featured_rank,
+      })) as PublicProfileDto[],
+      next_cursor: creators.next_cursor,
+      has_more: creators.has_more,
     };
   }
 

--- a/app/backend/src/usernames/usernames.service.ts
+++ b/app/backend/src/usernames/usernames.service.ts
@@ -3,6 +3,7 @@ import {
   SupabaseService,
   SearchProfileResult,
   TrendingCreatorResult,
+  FeaturedProfileResult,
 } from "../supabase/supabase.service";
 import { decodeCursor } from "../common/pagination/cursor.util";
 import { SupabaseUniqueConstraintError } from "../supabase/supabase.errors";
@@ -186,10 +187,7 @@ export class UsernamesService {
     limit: number = 10,
     cursor?: string,
   ): Promise<{ data: TrendingCreatorResult[]; next_cursor: string | null; has_more: boolean }> {
-    // Validate cursor format if provided (actual filtering handled by limit+1 strategy)
-    if (cursor) {
-      decodeCursor(cursor);
-    }
+    const decodedCursor = cursor ? decodeCursor(cursor) : null;
 
     if (timeWindowHours < 1 || timeWindowHours > 720) {
       throw new UsernameValidationError(
@@ -200,19 +198,44 @@ export class UsernamesService {
     }
 
     const effectiveLimit = Math.min(100, Math.max(1, limit));
+    // Trending is ranked in-memory (volume DESC, id ASC tiebreak); the
+    // underlying query does not support server-side cursor filtering, so we
+    // widen the fetch window when a cursor is present and slice locally.
+    const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
     const results = await this.supabase.getTrendingCreators(
       timeWindowHours,
-      effectiveLimit + 1,
+      fetchWindow,
     );
 
-    const hasMore = results.length > effectiveLimit;
-    const data = hasMore ? results.slice(0, effectiveLimit) : results;
+    let windowed = results;
+    if (decodedCursor) {
+      const cursorVolume = Number(decodedCursor.pk);
+      const cursorIndex = results.findIndex(
+        (row) =>
+          row.id === decodedCursor.id &&
+          row.transaction_volume === cursorVolume,
+      );
+      if (cursorIndex >= 0) {
+        windowed = results.slice(cursorIndex + 1);
+      } else {
+        // Fallback comparator for cursor continuity when the exact row is no
+        // longer in range (matches the volume DESC, id ASC ranking order).
+        windowed = results.filter((row) =>
+          row.transaction_volume !== cursorVolume
+            ? row.transaction_volume < cursorVolume
+            : row.id > decodedCursor.id,
+        );
+      }
+    }
+
+    const hasMore = windowed.length > effectiveLimit;
+    const data = hasMore ? windowed.slice(0, effectiveLimit) : windowed;
 
     let nextCursor: string | null = null;
     if (hasMore && data.length > 0) {
       const last = data[data.length - 1];
       nextCursor = Buffer.from(
-        JSON.stringify({ pk: last.created_at, id: last.id }),
+        JSON.stringify({ pk: String(last.transaction_volume), id: last.id }),
         "utf-8",
       ).toString("base64url");
     }
@@ -229,10 +252,7 @@ export class UsernamesService {
     limit: number = 10,
     cursor?: string,
   ): Promise<{ data: SearchProfileResult[]; next_cursor: string | null; has_more: boolean }> {
-    // Validate cursor format if provided (actual filtering handled by limit+1 strategy)
-    if (cursor) {
-      decodeCursor(cursor);
-    }
+    const decodedCursor = cursor ? decodeCursor(cursor) : null;
 
     if (timeWindowHours < 1 || timeWindowHours > 168) {
       throw new UsernameValidationError(
@@ -243,19 +263,101 @@ export class UsernamesService {
     }
 
     const effectiveLimit = Math.min(100, Math.max(1, limit));
+    const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
     const results = await this.supabase.getRecentlyActiveUsers(
       timeWindowHours,
-      effectiveLimit + 1,
+      fetchWindow,
     );
 
-    const hasMore = results.length > effectiveLimit;
-    const data = hasMore ? results.slice(0, effectiveLimit) : results;
+    let windowed = results;
+    if (decodedCursor) {
+      const cursorIndex = results.findIndex(
+        (row) =>
+          row.id === decodedCursor.id &&
+          (row.last_active_at || row.created_at) === decodedCursor.pk,
+      );
+      if (cursorIndex >= 0) {
+        windowed = results.slice(cursorIndex + 1);
+      } else {
+        // Fallback comparator for cursor continuity when the exact row is no
+        // longer in range (matches the last_active_at DESC, id ASC ranking).
+        windowed = results.filter((row) => {
+          const rowKey = row.last_active_at || row.created_at;
+          return rowKey !== decodedCursor.pk
+            ? rowKey < decodedCursor.pk
+            : row.id > decodedCursor.id;
+        });
+      }
+    }
+
+    const hasMore = windowed.length > effectiveLimit;
+    const data = hasMore ? windowed.slice(0, effectiveLimit) : windowed;
 
     let nextCursor: string | null = null;
     if (hasMore && data.length > 0) {
       const last = data[data.length - 1];
       nextCursor = Buffer.from(
-        JSON.stringify({ pk: last.created_at, id: last.id }),
+        JSON.stringify({
+          pk: last.last_active_at || last.created_at,
+          id: last.id,
+        }),
+        "utf-8",
+      ).toString("base64url");
+    }
+
+    return { data, next_cursor: nextCursor, has_more: hasMore };
+  }
+
+  /**
+   * Get curated/featured creators for discovery.
+   * Ordered by manual `featured_rank` (ascending, nulls last) with `id` as a
+   * deterministic tiebreaker.
+   */
+  async getFeaturedCreators(
+    limit: number = 10,
+    cursor?: string,
+  ): Promise<{ data: FeaturedProfileResult[]; next_cursor: string | null; has_more: boolean }> {
+    const decodedCursor = cursor ? decodeCursor(cursor) : null;
+
+    const effectiveLimit = Math.min(100, Math.max(1, limit));
+    const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
+    const results = await this.supabase.getFeaturedUsernames(fetchWindow);
+
+    let windowed = results;
+    if (decodedCursor) {
+      const cursorRank =
+        decodedCursor.pk === "" ? null : Number(decodedCursor.pk);
+      const cursorIndex = results.findIndex(
+        (row) => row.id === decodedCursor.id,
+      );
+      if (cursorIndex >= 0) {
+        windowed = results.slice(cursorIndex + 1);
+      } else {
+        // Fallback comparator for cursor continuity when the exact row is no
+        // longer in range (matches featured_rank ASC nulls-last, id ASC).
+        const rankValue = (rank: number | null) =>
+          rank === null ? Number.MAX_SAFE_INTEGER : rank;
+        windowed = results.filter((row) => {
+          const rowRank = rankValue(row.featured_rank);
+          const targetRank = rankValue(cursorRank);
+          return rowRank !== targetRank
+            ? rowRank > targetRank
+            : row.id > decodedCursor.id;
+        });
+      }
+    }
+
+    const hasMore = windowed.length > effectiveLimit;
+    const data = hasMore ? windowed.slice(0, effectiveLimit) : windowed;
+
+    let nextCursor: string | null = null;
+    if (hasMore && data.length > 0) {
+      const last = data[data.length - 1];
+      nextCursor = Buffer.from(
+        JSON.stringify({
+          pk: last.featured_rank === null ? "" : String(last.featured_rank),
+          id: last.id,
+        }),
         "utf-8",
       ).toString("base64url");
     }

--- a/app/backend/src/usernames/usernames.service.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.unit.spec.ts
@@ -20,6 +20,9 @@ describe('UsernamesService', () => {
     listUsernamesByPublicKey: jest.fn(),
     searchPublicUsernames: jest.fn(),
     updateUsernameActivity: jest.fn(),
+    getTrendingCreators: jest.fn(),
+    getRecentlyActiveUsers: jest.fn(),
+    getFeaturedUsernames: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -237,6 +240,129 @@ describe('UsernamesService', () => {
       expect(result.has_more).toBe(false);
       expect(result.next_cursor).toBeNull();
       expect(mockSupabaseService.searchPublicUsernames).toHaveBeenCalledWith('alice', 100);
+    });
+  });
+
+  describe('getTrendingCreators', () => {
+    // Fixture reflects the order SupabaseService now guarantees: volume DESC,
+    // with ties (id-2 / id-3, both 200) broken by ascending `id`.
+    const rows = [
+      { id: 'id-4', username: 'd', public_key: 'GAAA4', created_at: '2025-01-04T00:00:00.000Z', last_active_at: null, is_public: true, transaction_volume: 300, transaction_count: 3 },
+      { id: 'id-2', username: 'b', public_key: 'GAAA2', created_at: '2025-01-02T00:00:00.000Z', last_active_at: null, is_public: true, transaction_volume: 200, transaction_count: 2 },
+      { id: 'id-3', username: 'c', public_key: 'GAAA3', created_at: '2025-01-03T00:00:00.000Z', last_active_at: null, is_public: true, transaction_volume: 200, transaction_count: 2 },
+      { id: 'id-1', username: 'a', public_key: 'GAAA1', created_at: '2025-01-01T00:00:00.000Z', last_active_at: null, is_public: true, transaction_volume: 100, transaction_count: 1 },
+    ];
+
+    it('rejects an out-of-range time window', async () => {
+      await expect(service.getTrendingCreators(0, 10)).rejects.toThrow(UsernameValidationError);
+      await expect(service.getTrendingCreators(721, 10)).rejects.toThrow(UsernameValidationError);
+    });
+
+    it('breaks volume ties deterministically by ascending id', async () => {
+      mockSupabaseService.getTrendingCreators.mockResolvedValueOnce(rows.slice(0, 3));
+
+      const result = await service.getTrendingCreators(24, 3);
+
+      expect(result.data.map((r) => r.id)).toEqual(['id-4', 'id-2', 'id-3']);
+    });
+
+    it('returns first page with next_cursor and has_more=true', async () => {
+      mockSupabaseService.getTrendingCreators.mockResolvedValueOnce(rows.slice(0, 3));
+
+      const result = await service.getTrendingCreators(24, 2);
+
+      expect(result.data.map((r) => r.id)).toEqual(['id-4', 'id-2']);
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBeTruthy();
+    });
+
+    it('advances to next page when cursor is provided, without re-returning prior rows', async () => {
+      mockSupabaseService.getTrendingCreators.mockResolvedValueOnce(rows);
+      const cursor = Buffer.from(
+        JSON.stringify({ pk: '200', id: 'id-2' }),
+        'utf-8',
+      ).toString('base64url');
+
+      const result = await service.getTrendingCreators(24, 2, cursor);
+
+      expect(result.data.map((r) => r.id)).toEqual(['id-3', 'id-1']);
+      expect(mockSupabaseService.getTrendingCreators).toHaveBeenCalledWith(24, 100);
+    });
+
+    it('is stable across repeated calls with identical input (ranking stability)', async () => {
+      mockSupabaseService.getTrendingCreators.mockResolvedValue(rows.slice(0, 3));
+
+      const first = await service.getTrendingCreators(24, 3);
+      const second = await service.getTrendingCreators(24, 3);
+
+      expect(second.data.map((r) => r.id)).toEqual(first.data.map((r) => r.id));
+    });
+  });
+
+  describe('getRecentlyActiveUsers', () => {
+    // Fixture reflects the order SupabaseService now guarantees:
+    // last_active_at DESC, with ties (id-2 / id-3) broken by ascending `id`.
+    const rows = [
+      { id: 'id-4', username: 'd', public_key: 'GAAA4', created_at: '2025-01-01T00:00:00.000Z', last_active_at: '2025-01-04T00:00:00.000Z', is_public: true },
+      { id: 'id-2', username: 'b', public_key: 'GAAA2', created_at: '2025-01-01T00:00:00.000Z', last_active_at: '2025-01-02T00:00:00.000Z', is_public: true },
+      { id: 'id-3', username: 'c', public_key: 'GAAA3', created_at: '2025-01-01T00:00:00.000Z', last_active_at: '2025-01-02T00:00:00.000Z', is_public: true },
+      { id: 'id-1', username: 'a', public_key: 'GAAA1', created_at: '2025-01-01T00:00:00.000Z', last_active_at: '2025-01-01T00:00:00.000Z', is_public: true },
+    ];
+
+    it('rejects an out-of-range time window', async () => {
+      await expect(service.getRecentlyActiveUsers(0, 10)).rejects.toThrow(UsernameValidationError);
+      await expect(service.getRecentlyActiveUsers(169, 10)).rejects.toThrow(UsernameValidationError);
+    });
+
+    it('breaks activity-timestamp ties deterministically by ascending id', async () => {
+      mockSupabaseService.getRecentlyActiveUsers.mockResolvedValueOnce(rows.slice(0, 3));
+
+      const result = await service.getRecentlyActiveUsers(24, 3);
+
+      expect(result.data.map((r) => r.id)).toEqual(['id-4', 'id-2', 'id-3']);
+    });
+
+    it('advances to next page when cursor is provided', async () => {
+      mockSupabaseService.getRecentlyActiveUsers.mockResolvedValueOnce(rows);
+      const cursor = Buffer.from(
+        JSON.stringify({ pk: '2025-01-02T00:00:00.000Z', id: 'id-2' }),
+        'utf-8',
+      ).toString('base64url');
+
+      const result = await service.getRecentlyActiveUsers(24, 2, cursor);
+
+      expect(result.data.map((r) => r.id)).toEqual(['id-3', 'id-1']);
+    });
+  });
+
+  describe('getFeaturedCreators', () => {
+    // featured_rank 5 ties between id-2/id-3; a null rank must sort last.
+    const rows = [
+      { id: 'id-1', username: 'a', public_key: 'GAAA1', created_at: '2025-01-01T00:00:00.000Z', last_active_at: null, is_public: true, featured_rank: 1 },
+      { id: 'id-2', username: 'b', public_key: 'GAAA2', created_at: '2025-01-02T00:00:00.000Z', last_active_at: null, is_public: true, featured_rank: 5 },
+      { id: 'id-3', username: 'c', public_key: 'GAAA3', created_at: '2025-01-03T00:00:00.000Z', last_active_at: null, is_public: true, featured_rank: 5 },
+      { id: 'id-4', username: 'd', public_key: 'GAAA4', created_at: '2025-01-04T00:00:00.000Z', last_active_at: null, is_public: true, featured_rank: null },
+    ];
+
+    it('orders by featured_rank ascending with null ranks last, ties broken by id', async () => {
+      mockSupabaseService.getFeaturedUsernames.mockResolvedValueOnce(rows);
+
+      const result = await service.getFeaturedCreators(4);
+
+      expect(result.data.map((r) => r.id)).toEqual(['id-1', 'id-2', 'id-3', 'id-4']);
+    });
+
+    it('advances to next page when cursor is provided, including null-rank rows', async () => {
+      mockSupabaseService.getFeaturedUsernames.mockResolvedValueOnce(rows);
+      const cursor = Buffer.from(
+        JSON.stringify({ pk: '5', id: 'id-2' }),
+        'utf-8',
+      ).toString('base64url');
+
+      const result = await service.getFeaturedCreators(2, cursor);
+
+      expect(result.data.map((r) => r.id)).toEqual(['id-3', 'id-4']);
+      expect(result.has_more).toBe(false);
     });
   });
 });

--- a/app/backend/supabase/migrations/20260724000000_add_username_featured.sql
+++ b/app/backend/supabase/migrations/20260724000000_add_username_featured.sql
@@ -1,0 +1,17 @@
+-- Add featured status to usernames table
+-- Enables curated "featured" username discovery alongside trending/recently-active
+
+ALTER TABLE usernames
+ADD COLUMN IF NOT EXISTS is_featured BOOLEAN NOT NULL DEFAULT false;
+
+-- Manual ordering for featured profiles (lower = higher priority). NULL sorts last.
+ALTER TABLE usernames
+ADD COLUMN IF NOT EXISTS featured_rank INTEGER;
+
+-- Composite index for featured discovery lookups, ordered by rank then id (tiebreaker)
+CREATE INDEX IF NOT EXISTS usernames_featured_idx
+  ON usernames (is_featured, featured_rank, id)
+  WHERE is_featured = true AND is_public = true;
+
+COMMENT ON COLUMN usernames.is_featured IS 'Whether this profile is curated/featured for discovery';
+COMMENT ON COLUMN usernames.featured_rank IS 'Manual ordering for featured profiles (lower = higher priority); NULL sorts last';


### PR DESCRIPTION
Closes #659

---

## Summary

Backs the discovery page with a real ranking endpoint for **trending**, **recently-active**, and now **featured** usernames, and fixes correctness bugs found in the existing trending/recently-active implementations while wiring pagination through properly.

- Adds a curated `GET /username/featured` endpoint (new `is_featured` / `featured_rank` columns) alongside the existing trending and recently-active endpoints.
- Fixes cursor pagination for trending and recently-active: cursors were previously decoded but never applied, so requesting page 2 just returned page 1 again.
- Adds a deterministic tiebreaker (`id` ascending) to trending/recently-active/featured ranking so identical requests return identical order — ties were previously unstable.
- Fixes a correctness bug where both endpoints could silently drop legitimate public profiles by truncating results to `limit` *before* filtering out non-public/inactive accounts, instead of after.

## Changes

- `supabase/migrations/20260724000000_add_username_featured.sql` — `is_featured` / `featured_rank` columns + partial index.
- `src/supabase/supabase.service.ts` — new `getFeaturedUsernames()`; rank-before-slice fix + `id` tiebreak for `getTrendingCreators` / `getRecentlyActiveUsers`.
- `src/usernames/usernames.service.ts` — real cursor-based windowing for trending/recently-active; new `getFeaturedCreators()`.
- `src/usernames/usernames.controller.ts` — new `GET /username/featured` endpoint.
- `src/dto/username/` — `FeaturedUsernamesQueryDto` / `FeaturedUsernamesResponseDto`; `featuredRank` added to `PublicProfileDto`.
- Tests: ranking-stability + pagination regression tests at the service and Supabase layers (including a repro of the "public creator silently dropped" bug), plus controller response-shape tests for all three discovery endpoints.

## Test plan

- [x] `getTrendingCreators` / `getRecentlyActiveUsers` / `getFeaturedCreators` unit tests (pagination, tie-breaking, exclusion of non-public profiles)
- [x] Supabase-layer regression tests reproducing the old ranking bugs
- [x] Controller integration tests for `/username/trending`, `/username/recently-active`, `/username/featured`
- [x] `tsc --noEmit` and `eslint` clean
- [ ] Frontend discovery page wiring (mock data → these endpoints) is a separate follow-up, not included here