### PR TITLE
 fix: add mobile compatibility alias for contract registry

### DIFF
--- a/app/backend/src/contracts/contract-registry.controller.ts
+++ b/app/backend/src/contracts/contract-registry.controller.ts
@@ -35,7 +35,7 @@ import {
 })
 @RateLimitGroupTag('public')
 @UseGuards(ApiKeyGuard)
-@Controller('contracts')
+@Controller(['contracts', 'api/contracts'])
 export class ContractRegistryController {
   constructor(private readonly contractRegistryService: ContractRegistryService) {}
 

--- a/app/backend/test/contract-registry.e2e-spec.ts
+++ b/app/backend/test/contract-registry.e2e-spec.ts
@@ -1,0 +1,57 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { ContractRegistryService } from '../src/contracts/contract-registry.service';
+
+describe('ContractRegistryController (e2e)', () => {
+  let app: INestApplication;
+  let contractRegistryService: jest.Mocked<ContractRegistryService>;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ContractRegistryService)
+      .useValue({
+        getRegistry: jest.fn().mockResolvedValue({
+          etag: 'test-etag',
+          contracts: {},
+        }),
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    contractRegistryService = moduleRef.get(ContractRegistryService) as any;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /contracts/registry should return the registry', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/contracts/registry')
+      .expect(200);
+
+    expect(response.body).toEqual({
+      etag: 'test-etag',
+      contracts: {},
+    });
+    expect(response.headers['etag']).toBe('test-etag');
+  });
+
+  it('GET /api/contracts/registry should return the registry via alias', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/contracts/registry')
+      .expect(200);
+
+    expect(response.body).toEqual({
+      etag: 'test-etag',
+      contracts: {},
+    });
+    expect(response.headers['etag']).toBe('test-etag');
+  });
+});


### PR DESCRIPTION
Closes #651 


Adds a compatibility alias or route contract update for the mobile app so it can consume the contract registry without path mismatches.

## Changes Made
- **Audited current mobile registry requests** against backend routes and found the mismatch where mobile requested `/api/contracts/registry` instead of `/contracts/registry`.
- **Added a compatibility alias** using `@Controller(['contracts', 'api/contracts'])` to ensure the registry payload shape is identical across both paths.
- **Added Integration Tests** for both route forms in `test/contract-registry.e2e-spec.ts` to prevent future regressions.

## Acceptance Criteria Met
- [x] Mobile can fetch contract registry successfully without custom hacks.
- [x] Registry payloads are consistent across alias paths.
- [x] Route behavior is covered by tests.