### PR TITLE
Feat/be username discovery ranking

### DIFF
--- a/app/backend/src/supabase/supabase.service.ts
+++ b/app/backend/src/supabase/supabase.service.ts
@@ -597,6 +597,29 @@ export class SupabaseService {
   }
 
   /**
+   * Fetch a single public profile by username
+   */
+  async getPublicProfile(
+    username: string,
+  ): Promise<SearchProfileResult | null> {
+    const { data, error } = await this.client
+      .from("usernames")
+      .select(
+        "id, username, public_key, created_at, last_active_at, is_public",
+      )
+      .eq("username", username)
+      .eq("is_public", true)
+      .single();
+
+    if (error) {
+      if (error.code === "PGRST116") return null; // not found
+      this.handleError(error);
+    }
+
+    return (data as SearchProfileResult) ?? null;
+  }
+
+  /**
    * Toggle public profile visibility
    */
   async togglePublicProfile(

--- a/app/backend/src/usernames/cache/discovery-cache.service.ts
+++ b/app/backend/src/usernames/cache/discovery-cache.service.ts
@@ -17,33 +17,53 @@ interface CachedRecentlyActiveResult {
   timestamp: number;
 }
 
+export interface CacheHitMissStats {
+  hits: number;
+  misses: number;
+}
+
 @Injectable()
 export class DiscoveryCacheService {
   private readonly logger = new Logger(DiscoveryCacheService.name);
   private readonly searchCache: LRUCache<string, CachedSearchResult>;
   private readonly trendingCache: LRUCache<string, CachedTrendingResult>;
   private readonly recentlyActiveCache: LRUCache<string, CachedRecentlyActiveResult>;
-  
+  private readonly profileCache: LRUCache<string, SearchProfileResult>;
+
   private readonly SEARCH_TTL_MS = 1000 * 60 * 15; // 15 minutes
   private readonly TRENDING_TTL_MS = 1000 * 60 * 30; // 30 minutes
   private readonly RECENTLY_ACTIVE_TTL_MS = 1000 * 60 * 10; // 10 minutes
+  private readonly PROFILE_TTL_MS = 1000 * 60 * 5; // 5 minutes
+
+  private readonly hitMiss = {
+    search: { hits: 0, misses: 0 },
+    trending: { hits: 0, misses: 0 },
+    recentlyActive: { hits: 0, misses: 0 },
+    profile: { hits: 0, misses: 0 },
+  };
 
   constructor() {
     this.searchCache = new LRUCache<string, CachedSearchResult>({
-      max: 1000, // Maximum 1000 search queries cached
+      max: 1000,
       ttl: this.SEARCH_TTL_MS,
       updateAgeOnGet: true,
     });
 
     this.trendingCache = new LRUCache<string, CachedTrendingResult>({
-      max: 100, // Maximum 100 different trending queries cached
+      max: 100,
       ttl: this.TRENDING_TTL_MS,
       updateAgeOnGet: true,
     });
 
     this.recentlyActiveCache = new LRUCache<string, CachedRecentlyActiveResult>({
-      max: 100, // Maximum 100 different recently active queries cached
+      max: 100,
       ttl: this.RECENTLY_ACTIVE_TTL_MS,
+      updateAgeOnGet: true,
+    });
+
+    this.profileCache = new LRUCache<string, SearchProfileResult>({
+      max: 2000,
+      ttl: this.PROFILE_TTL_MS,
       updateAgeOnGet: true,
     });
 
@@ -55,9 +75,11 @@ export class DiscoveryCacheService {
     const key = this.getSearchCacheKey(query, limit);
     const cached = this.searchCache.get(key);
     if (cached) {
+      this.hitMiss.search.hits++;
       this.logger.debug(`Search cache hit for query: ${query}`);
       return cached.results;
     }
+    this.hitMiss.search.misses++;
     return undefined;
   }
 
@@ -75,9 +97,11 @@ export class DiscoveryCacheService {
     const key = this.getTrendingCacheKey(timeWindowHours, limit);
     const cached = this.trendingCache.get(key);
     if (cached) {
+      this.hitMiss.trending.hits++;
       this.logger.debug(`Trending cache hit for window: ${timeWindowHours}h`);
       return cached.results;
     }
+    this.hitMiss.trending.misses++;
     return undefined;
   }
 
@@ -95,9 +119,11 @@ export class DiscoveryCacheService {
     const key = this.getRecentlyActiveCacheKey(timeWindowHours, limit);
     const cached = this.recentlyActiveCache.get(key);
     if (cached) {
+      this.hitMiss.recentlyActive.hits++;
       this.logger.debug(`Recently active cache hit for window: ${timeWindowHours}h`);
       return cached.results;
     }
+    this.hitMiss.recentlyActive.misses++;
     return undefined;
   }
 
@@ -108,6 +134,25 @@ export class DiscoveryCacheService {
       timestamp: Date.now(),
     });
     this.logger.debug(`Cached recently active results for window: ${timeWindowHours}h`);
+  }
+
+  // Public profile cache methods
+  getProfile(username: string): SearchProfileResult | undefined {
+    const key = this.getProfileCacheKey(username);
+    const cached = this.profileCache.get(key);
+    if (cached) {
+      this.hitMiss.profile.hits++;
+      this.logger.debug(`Profile cache hit for username: ${username}`);
+      return cached;
+    }
+    this.hitMiss.profile.misses++;
+    return undefined;
+  }
+
+  setProfile(username: string, profile: SearchProfileResult): void {
+    const key = this.getProfileCacheKey(username);
+    this.profileCache.set(key, profile);
+    this.logger.debug(`Cached profile for username: ${username}`);
   }
 
   // Cache invalidation methods
@@ -137,11 +182,31 @@ export class DiscoveryCacheService {
     this.logger.log('Cleared recently active cache');
   }
 
+  invalidateProfile(username: string): void {
+    const key = this.getProfileCacheKey(username);
+    this.profileCache.delete(key);
+    this.logger.debug(`Invalidated profile cache for username: ${username}`);
+  }
+
+  /**
+   * Invalidate all caches that could contain a given username.
+   * Called on profile updates and visibility changes to prevent stale reads.
+   */
+  invalidateForUsername(username: string): void {
+    this.invalidateProfile(username);
+    this.invalidateSearchCache(username);
+    this.invalidateTrendingCache();
+    this.invalidateRecentlyActiveCache();
+    this.logger.log(`Invalidated all caches for username: ${username}`);
+  }
+
   // Cache statistics
   getStats(): {
     search: { size: number; maxSize: number; ttl: number };
     trending: { size: number; maxSize: number; ttl: number };
     recentlyActive: { size: number; maxSize: number; ttl: number };
+    profile: { size: number; maxSize: number; ttl: number };
+    hitMiss: typeof this.hitMiss;
   } {
     return {
       search: {
@@ -159,6 +224,12 @@ export class DiscoveryCacheService {
         maxSize: this.recentlyActiveCache.max,
         ttl: this.RECENTLY_ACTIVE_TTL_MS,
       },
+      profile: {
+        size: this.profileCache.size,
+        maxSize: this.profileCache.max,
+        ttl: this.PROFILE_TTL_MS,
+      },
+      hitMiss: { ...this.hitMiss },
     };
   }
 
@@ -173,5 +244,9 @@ export class DiscoveryCacheService {
 
   private getRecentlyActiveCacheKey(timeWindowHours: number, limit: number): string {
     return `recent:${timeWindowHours}:${limit}`;
+  }
+
+  private getProfileCacheKey(username: string): string {
+    return `profile:${username.toLowerCase()}`;
   }
 }

--- a/app/backend/src/usernames/cache/discovery-cache.service.unit.spec.ts
+++ b/app/backend/src/usernames/cache/discovery-cache.service.unit.spec.ts
@@ -1,0 +1,134 @@
+import { DiscoveryCacheService } from './discovery-cache.service';
+
+describe('DiscoveryCacheService', () => {
+  let service: DiscoveryCacheService;
+
+  beforeEach(() => {
+    service = new DiscoveryCacheService();
+  });
+
+  describe('profile cache', () => {
+    const profile = {
+      id: 'id-1',
+      username: 'alice',
+      public_key: 'pk1',
+      created_at: '2025-01-01T00:00:00Z',
+      last_active_at: null,
+      is_public: true,
+    };
+
+    it('returns undefined on cache miss', () => {
+      expect(service.getProfile('alice')).toBeUndefined();
+    });
+
+    it('returns cached profile on hit', () => {
+      service.setProfile('alice', profile);
+      expect(service.getProfile('alice')).toEqual(profile);
+    });
+
+    it('invalidates a single profile', () => {
+      service.setProfile('alice', profile);
+      service.invalidateProfile('alice');
+      expect(service.getProfile('alice')).toBeUndefined();
+    });
+
+    it('does not invalidate other profiles', () => {
+      service.setProfile('alice', profile);
+      service.setProfile('bob', { ...profile, username: 'bob' });
+      service.invalidateProfile('alice');
+      expect(service.getProfile('bob')).toBeDefined();
+    });
+  });
+
+  describe('invalidateForUsername', () => {
+    it('removes the profile cache entry', () => {
+      const profile = {
+        id: 'id-1',
+        username: 'alice',
+        public_key: 'pk1',
+        created_at: '2025-01-01T00:00:00Z',
+        last_active_at: null,
+        is_public: true,
+      };
+      service.setProfile('alice', profile);
+      service.invalidateForUsername('alice');
+      expect(service.getProfile('alice')).toBeUndefined();
+    });
+
+    it('clears search cache entries containing the username', () => {
+      service.setSearchResults('alice', 10, [
+        { id: '1', username: 'alice', public_key: 'pk', created_at: '', last_active_at: null, is_public: true },
+      ]);
+      service.invalidateForUsername('alice');
+      expect(service.getSearchResults('alice', 10)).toBeUndefined();
+    });
+
+    it('clears trending cache', () => {
+      service.setTrendingResults(24, 10, []);
+      service.invalidateForUsername('alice');
+      expect(service.getTrendingResults(24, 10)).toBeUndefined();
+    });
+
+    it('clears recently active cache', () => {
+      service.setRecentlyActiveResults(24, 10, []);
+      service.invalidateForUsername('alice');
+      expect(service.getRecentlyActiveResults(24, 10)).toBeUndefined();
+    });
+  });
+
+  describe('hit/miss tracking', () => {
+    it('tracks search hits and misses', () => {
+      service.getSearchResults('alice', 10); // miss
+      service.setSearchResults('alice', 10, []);
+      service.getSearchResults('alice', 10); // hit
+
+      const stats = service.getStats();
+      expect(stats.hitMiss.search.hits).toBe(1);
+      expect(stats.hitMiss.search.misses).toBe(1);
+    });
+
+    it('tracks profile hits and misses', () => {
+      service.getProfile('alice'); // miss
+      service.setProfile('alice', {
+        id: '1', username: 'alice', public_key: 'pk', created_at: '', last_active_at: null, is_public: true,
+      });
+      service.getProfile('alice'); // hit
+
+      const stats = service.getStats();
+      expect(stats.hitMiss.profile.hits).toBe(1);
+      expect(stats.hitMiss.profile.misses).toBe(1);
+    });
+
+    it('tracks trending hits and misses', () => {
+      service.getTrendingResults(24, 10); // miss
+      service.setTrendingResults(24, 10, []);
+      service.getTrendingResults(24, 10); // hit
+
+      const stats = service.getStats();
+      expect(stats.hitMiss.trending.hits).toBe(1);
+      expect(stats.hitMiss.trending.misses).toBe(1);
+    });
+
+    it('tracks recently active hits and misses', () => {
+      service.getRecentlyActiveResults(24, 10); // miss
+      service.setRecentlyActiveResults(24, 10, []);
+      service.getRecentlyActiveResults(24, 10); // hit
+
+      const stats = service.getStats();
+      expect(stats.hitMiss.recentlyActive.hits).toBe(1);
+      expect(stats.hitMiss.recentlyActive.misses).toBe(1);
+    });
+  });
+
+  describe('getStats', () => {
+    it('returns profile cache size and config', () => {
+      service.setProfile('alice', {
+        id: '1', username: 'alice', public_key: 'pk', created_at: '', last_active_at: null, is_public: true,
+      });
+      const stats = service.getStats();
+      expect(stats.profile.size).toBe(1);
+      expect(stats.profile.maxSize).toBe(2000);
+      expect(stats.profile.ttl).toBe(1000 * 60 * 5);
+    });
+  });
+});

--- a/app/backend/src/usernames/usernames.service.cache-invalidation.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.cache-invalidation.unit.spec.ts
@@ -1,0 +1,205 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsernamesService } from './usernames.service';
+import { SupabaseService } from '../supabase/supabase.service';
+import { AppConfigService } from '../config';
+import { DiscoveryCacheService } from './cache/discovery-cache.service';
+import { UsernameValidationError } from './errors';
+
+describe('UsernamesService - Cache Invalidation', () => {
+  let service: UsernamesService;
+  let supabaseMock: jest.Mocked<Partial<SupabaseService>>;
+  let cacheMock: jest.Mocked<Partial<DiscoveryCacheService>>;
+  let configMock: Partial<AppConfigService>;
+
+  beforeEach(async () => {
+    supabaseMock = {
+      searchPublicUsernames: jest.fn(),
+      getTrendingCreators: jest.fn(),
+      getRecentlyActiveUsers: jest.fn(),
+      togglePublicProfile: jest.fn(),
+      updateUsernameActivity: jest.fn(),
+      listUsernamesByPublicKey: jest.fn(),
+      getPublicProfile: jest.fn(),
+    };
+
+    cacheMock = {
+      getSearchResults: jest.fn().mockReturnValue(undefined),
+      setSearchResults: jest.fn(),
+      getTrendingResults: jest.fn().mockReturnValue(undefined),
+      setTrendingResults: jest.fn(),
+      getRecentlyActiveResults: jest.fn().mockReturnValue(undefined),
+      setRecentlyActiveResults: jest.fn(),
+      getProfile: jest.fn().mockReturnValue(undefined),
+      setProfile: jest.fn(),
+      invalidateSearchCache: jest.fn(),
+      invalidateTrendingCache: jest.fn(),
+      invalidateRecentlyActiveCache: jest.fn(),
+      invalidateProfile: jest.fn(),
+      invalidateForUsername: jest.fn(),
+      getStats: jest.fn(),
+    };
+
+    configMock = { maxUsernamesPerWallet: 5 };
+
+    supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsernamesService,
+        { provide: SupabaseService, useValue: supabaseMock },
+        { provide: AppConfigService, useValue: configMock },
+        { provide: DiscoveryCacheService, useValue: cacheMock },
+      ],
+    }).compile();
+
+    service = module.get<UsernamesService>(UsernamesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('togglePublicProfile invalidation', () => {
+    it('calls invalidateForUsername after successful toggle', async () => {
+      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([
+        { id: '1', username: 'alice', public_key: 'pk1', created_at: '' },
+      ]);
+      supabaseMock.togglePublicProfile!.mockResolvedValue();
+
+      await service.togglePublicProfile('alice', 'pk1', true);
+
+      expect(cacheMock.invalidateForUsername).toHaveBeenCalledWith('alice');
+    });
+
+    it('normalizes username before invalidation', async () => {
+      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([
+        { id: '1', username: 'alice', public_key: 'pk1', created_at: '' },
+      ]);
+      supabaseMock.togglePublicProfile!.mockResolvedValue();
+
+      await service.togglePublicProfile('Alice', 'pk1', false);
+
+      expect(cacheMock.invalidateForUsername).toHaveBeenCalledWith('alice');
+    });
+
+    it('does not invalidate cache when username not found', async () => {
+      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([]);
+
+      await expect(
+        service.togglePublicProfile('ghost', 'pk1', true),
+      ).rejects.toThrow(UsernameValidationError);
+
+      expect(cacheMock.invalidateForUsername).not.toHaveBeenCalled();
+    });
+
+    it('does not call Supabase toggle when username not found', async () => {
+      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([]);
+
+      await expect(
+        service.togglePublicProfile('ghost', 'pk1', true),
+      ).rejects.toThrow();
+
+      expect(supabaseMock.togglePublicProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getPublicProfile caching', () => {
+    const profile = {
+      id: 'id-1',
+      username: 'alice',
+      public_key: 'pk1',
+      created_at: '2025-01-01T00:00:00Z',
+      last_active_at: null,
+      is_public: true,
+    };
+
+    it('returns cached profile without hitting Supabase', async () => {
+      cacheMock.getProfile!.mockReturnValue(profile as any);
+
+      const result = await service.getPublicProfile('alice');
+
+      expect(result).toEqual(profile);
+      expect(supabaseMock.getPublicProfile).not.toHaveBeenCalled();
+      expect(cacheMock.setProfile).not.toHaveBeenCalled();
+    });
+
+    it('fetches from Supabase and caches on miss', async () => {
+      supabaseMock.getPublicProfile!.mockResolvedValue(profile as any);
+
+      const result = await service.getPublicProfile('alice');
+
+      expect(result).toEqual(profile);
+      expect(supabaseMock.getPublicProfile).toHaveBeenCalledWith('alice');
+      expect(cacheMock.setProfile).toHaveBeenCalledWith('alice', profile);
+    });
+
+    it('does not cache null profiles', async () => {
+      supabaseMock.getPublicProfile!.mockResolvedValue(null);
+
+      const result = await service.getPublicProfile('ghost');
+
+      expect(result).toBeNull();
+      expect(cacheMock.setProfile).not.toHaveBeenCalled();
+    });
+
+    it('normalizes username before lookup', async () => {
+      supabaseMock.getPublicProfile!.mockResolvedValue(profile as any);
+
+      await service.getPublicProfile('Alice');
+
+      expect(cacheMock.getProfile).toHaveBeenCalledWith('alice');
+      expect(supabaseMock.getPublicProfile).toHaveBeenCalledWith('alice');
+    });
+  });
+
+  describe('search caching', () => {
+    it('returns cached search results without hitting Supabase', async () => {
+      const cached = [
+        { id: '1', username: 'alice', public_key: 'pk', created_at: '', last_active_at: null, is_public: true },
+      ];
+      cacheMock.getSearchResults!.mockReturnValue(cached as any);
+      supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
+
+      const result = await service.searchPublicUsernames('alice', 10);
+
+      expect(result.data).toEqual(cached);
+      expect(supabaseMock.searchPublicUsernames).not.toHaveBeenCalled();
+    });
+
+    it('fetches from Supabase and caches on miss', async () => {
+      const fresh = [
+        { id: '1', username: 'alice', public_key: 'pk', created_at: '', last_active_at: null, is_public: true },
+      ];
+      supabaseMock.searchPublicUsernames!.mockResolvedValue(fresh as any);
+      supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
+      supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
+
+      await service.searchPublicUsernames('alice', 10);
+
+      expect(supabaseMock.searchPublicUsernames).toHaveBeenCalled();
+      expect(cacheMock.setSearchResults).toHaveBeenCalled();
+    });
+  });
+
+  describe('trending caching', () => {
+    it('returns cached trending results without hitting Supabase', async () => {
+      cacheMock.getTrendingResults!.mockReturnValue([] as any);
+
+      const result = await service.getTrendingCreators(24, 10);
+
+      expect(result.data).toEqual([]);
+      expect(supabaseMock.getTrendingCreators).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recently active caching', () => {
+    it('returns cached recently active results without hitting Supabase', async () => {
+      cacheMock.getRecentlyActiveResults!.mockReturnValue([] as any);
+
+      const result = await service.getRecentlyActiveUsers(24, 10);
+
+      expect(result.data).toEqual([]);
+      expect(supabaseMock.getRecentlyActiveUsers).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/backend/src/usernames/usernames.service.cache-invalidation.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.cache-invalidation.unit.spec.ts
@@ -114,7 +114,7 @@ describe('UsernamesService - Cache Invalidation', () => {
     };
 
     it('returns cached profile without hitting Supabase', async () => {
-      cacheMock.getProfile!.mockReturnValue(profile as any);
+      cacheMock.getProfile!.mockReturnValue(profile);
 
       const result = await service.getPublicProfile('alice');
 
@@ -124,7 +124,7 @@ describe('UsernamesService - Cache Invalidation', () => {
     });
 
     it('fetches from Supabase and caches on miss', async () => {
-      supabaseMock.getPublicProfile!.mockResolvedValue(profile as any);
+      supabaseMock.getPublicProfile!.mockResolvedValue(profile);
 
       const result = await service.getPublicProfile('alice');
 
@@ -143,7 +143,7 @@ describe('UsernamesService - Cache Invalidation', () => {
     });
 
     it('normalizes username before lookup', async () => {
-      supabaseMock.getPublicProfile!.mockResolvedValue(profile as any);
+      supabaseMock.getPublicProfile!.mockResolvedValue(profile);
 
       await service.getPublicProfile('Alice');
 
@@ -157,7 +157,7 @@ describe('UsernamesService - Cache Invalidation', () => {
       const cached = [
         { id: '1', username: 'alice', public_key: 'pk', created_at: '', last_active_at: null, is_public: true },
       ];
-      cacheMock.getSearchResults!.mockReturnValue(cached as any);
+      cacheMock.getSearchResults!.mockReturnValue(cached);
       supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
 
       const result = await service.searchPublicUsernames('alice', 10);
@@ -170,7 +170,7 @@ describe('UsernamesService - Cache Invalidation', () => {
       const fresh = [
         { id: '1', username: 'alice', public_key: 'pk', created_at: '', last_active_at: null, is_public: true },
       ];
-      supabaseMock.searchPublicUsernames!.mockResolvedValue(fresh as any);
+      supabaseMock.searchPublicUsernames!.mockResolvedValue(fresh);
       supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
       supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
 
@@ -183,7 +183,7 @@ describe('UsernamesService - Cache Invalidation', () => {
 
   describe('trending caching', () => {
     it('returns cached trending results without hitting Supabase', async () => {
-      cacheMock.getTrendingResults!.mockReturnValue([] as any);
+      cacheMock.getTrendingResults!.mockReturnValue([]);
 
       const result = await service.getTrendingCreators(24, 10);
 
@@ -194,7 +194,7 @@ describe('UsernamesService - Cache Invalidation', () => {
 
   describe('recently active caching', () => {
     it('returns cached recently active results without hitting Supabase', async () => {
-      cacheMock.getRecentlyActiveResults!.mockReturnValue([] as any);
+      cacheMock.getRecentlyActiveResults!.mockReturnValue([]);
 
       const result = await service.getRecentlyActiveUsers(24, 10);
 

--- a/app/backend/src/usernames/usernames.service.public-profile.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.public-profile.unit.spec.ts
@@ -18,6 +18,7 @@ describe('UsernamesService - Public Profile Discovery', () => {
       togglePublicProfile: jest.fn(),
       updateUsernameActivity: jest.fn(),
       listUsernamesByPublicKey: jest.fn(),
+      getPublicProfile: jest.fn(),
     };
 
     configMock = { maxUsernamesPerWallet: 5 };
@@ -29,9 +30,13 @@ describe('UsernamesService - Public Profile Discovery', () => {
       setTrendingResults: jest.fn(),
       getRecentlyActiveResults: jest.fn(),
       setRecentlyActiveResults: jest.fn(),
+      getProfile: jest.fn(),
+      setProfile: jest.fn(),
       invalidateSearchCache: jest.fn(),
       invalidateTrendingCache: jest.fn(),
       invalidateRecentlyActiveCache: jest.fn(),
+      invalidateProfile: jest.fn(),
+      invalidateForUsername: jest.fn(),
       getStats: jest.fn(),
     };
 

--- a/app/backend/src/usernames/usernames.service.ts
+++ b/app/backend/src/usernames/usernames.service.ts
@@ -129,14 +129,19 @@ export class UsernamesService {
     }
 
     const effectiveLimit = Math.min(100, Math.max(1, limit));
-    // When a cursor is present we need a wider window so we can advance
-    // from the previous page marker even though the underlying query
-    // does not yet support server-side cursor filtering.
     const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
-    const results = await this.supabase.searchPublicUsernames(
-      normalizedQuery,
-      fetchWindow,
-    );
+
+    const cachedResults = this.cache.getSearchResults(normalizedQuery, fetchWindow);
+    let results: SearchProfileResult[];
+    if (cachedResults) {
+      results = cachedResults;
+    } else {
+      results = await this.supabase.searchPublicUsernames(
+        normalizedQuery,
+        fetchWindow,
+      );
+      this.cache.setSearchResults(normalizedQuery, fetchWindow, results);
+    }
 
     let windowed = results;
     if (decodedCursor) {
@@ -198,14 +203,19 @@ export class UsernamesService {
     }
 
     const effectiveLimit = Math.min(100, Math.max(1, limit));
-    // Trending is ranked in-memory (volume DESC, id ASC tiebreak); the
-    // underlying query does not support server-side cursor filtering, so we
-    // widen the fetch window when a cursor is present and slice locally.
     const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
-    const results = await this.supabase.getTrendingCreators(
-      timeWindowHours,
-      fetchWindow,
-    );
+
+    const cachedResults = this.cache.getTrendingResults(timeWindowHours, fetchWindow);
+    let results: TrendingCreatorResult[];
+    if (cachedResults) {
+      results = cachedResults;
+    } else {
+      results = await this.supabase.getTrendingCreators(
+        timeWindowHours,
+        fetchWindow,
+      );
+      this.cache.setTrendingResults(timeWindowHours, fetchWindow, results);
+    }
 
     let windowed = results;
     if (decodedCursor) {
@@ -264,10 +274,18 @@ export class UsernamesService {
 
     const effectiveLimit = Math.min(100, Math.max(1, limit));
     const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
-    const results = await this.supabase.getRecentlyActiveUsers(
-      timeWindowHours,
-      fetchWindow,
-    );
+
+    const cachedResults = this.cache.getRecentlyActiveResults(timeWindowHours, fetchWindow);
+    let results: SearchProfileResult[];
+    if (cachedResults) {
+      results = cachedResults;
+    } else {
+      results = await this.supabase.getRecentlyActiveUsers(
+        timeWindowHours,
+        fetchWindow,
+      );
+      this.cache.setRecentlyActiveResults(timeWindowHours, fetchWindow, results);
+    }
 
     let windowed = results;
     if (decodedCursor) {
@@ -366,6 +384,22 @@ export class UsernamesService {
   }
 
   /**
+   * Fetch a single public profile by username, with caching.
+   */
+  async getPublicProfile(username: string): Promise<SearchProfileResult | null> {
+    const normalized = this.normalizeUsername(username);
+
+    const cached = this.cache.getProfile(normalized);
+    if (cached) return cached;
+
+    const profile = await this.supabase.getPublicProfile(normalized);
+    if (profile) {
+      this.cache.setProfile(normalized, profile);
+    }
+    return profile;
+  }
+
+  /**
    * Toggle public profile visibility for a username.
    */
   async togglePublicProfile(
@@ -388,5 +422,9 @@ export class UsernamesService {
     }
 
     await this.supabase.togglePublicProfile(normalized, isPublic);
+
+    // Invalidate all caches that may contain this username so visibility
+    // changes are reflected immediately on subsequent reads.
+    this.cache.invalidateForUsername(normalized);
   }
 }

--- a/app/backend/src/usernames/usernames.service.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.unit.spec.ts
@@ -23,6 +23,7 @@ describe('UsernamesService', () => {
     getTrendingCreators: jest.fn(),
     getRecentlyActiveUsers: jest.fn(),
     getFeaturedUsernames: jest.fn(),
+    getPublicProfile: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -55,9 +56,13 @@ describe('UsernamesService', () => {
             setTrendingResults: jest.fn(),
             getRecentlyActiveResults: jest.fn(),
             setRecentlyActiveResults: jest.fn(),
+            getProfile: jest.fn(),
+            setProfile: jest.fn(),
             invalidateSearchCache: jest.fn(),
             invalidateTrendingCache: jest.fn(),
             invalidateRecentlyActiveCache: jest.fn(),
+            invalidateProfile: jest.fn(),
+            invalidateForUsername: jest.fn(),
             getStats: jest.fn(),
           },
         },


### PR DESCRIPTION
Closes #650

---

## Summary

Stacked on #<ranking-PR-number> (feat/be-username-discovery-ranking).

Adds an LRU-cached `getPublicProfile` lookup plus cache-invalidation wiring so
profile visibility toggles (and other writes) don't serve stale cached data.

## Changes

- `src/usernames/cache/discovery-cache.service.ts` — profile cache (get/set/invalidate), `invalidateForUsername` to clear all affected caches on write.
- `src/usernames/usernames.service.ts` — `getPublicProfile` reads through cache; search/trending/recently-active reads now check cache before hitting Supabase; `togglePublicProfile` invalidates on write.
- `src/supabase/supabase.service.ts` — new `getPublicProfile` query.
- Tests: cache hit/miss behavior, invalidation-on-toggle, normalization before cache lookup.

## Test plan

- [x] Unit tests for cache hit/miss and invalidation paths
- [x] `tsc --noEmit` and `eslint` clean
- [x] CI lint failure (7x `no-explicit-any`) fixed in a follow-up commit