### PR TITLE
feat: Add mobile compatibility alias to contract registry endpoint

### DIFF
--- a/app/backend/src/contracts/contract-registry.controller.ts
+++ b/app/backend/src/contracts/contract-registry.controller.ts
@@ -35,7 +35,7 @@ import {
 })
 @RateLimitGroupTag('public')
 @UseGuards(ApiKeyGuard)
-@Controller(['contracts', 'api/contracts'])
+@Controller(['contracts', 'api/contracts', 'mobile/contracts', 'api/mobile/contracts'])
 export class ContractRegistryController {
   constructor(private readonly contractRegistryService: ContractRegistryService) {}
 

--- a/app/backend/src/contracts/contract-registry.controller.ts
+++ b/app/backend/src/contracts/contract-registry.controller.ts
@@ -35,7 +35,7 @@ import {
 })
 @RateLimitGroupTag('public')
 @UseGuards(ApiKeyGuard)
-@Controller('contracts')
+@Controller(['contracts', 'api/contracts'])
 export class ContractRegistryController {
   constructor(private readonly contractRegistryService: ContractRegistryService) {}
 

--- a/app/backend/test/contract-registry.e2e-spec.ts
+++ b/app/backend/test/contract-registry.e2e-spec.ts
@@ -24,7 +24,7 @@ describe('ContractRegistryController (e2e)', () => {
     app = moduleRef.createNestApplication();
     await app.init();
 
-    contractRegistryService = moduleRef.get(ContractRegistryService) as any;
+    contractRegistryService = moduleRef.get(ContractRegistryService) as unknown as jest.Mocked<ContractRegistryService>;
   });
 
   afterAll(async () => {
@@ -41,6 +41,7 @@ describe('ContractRegistryController (e2e)', () => {
       contracts: {},
     });
     expect(response.headers['etag']).toBe('test-etag');
+    expect(contractRegistryService.getRegistry).toHaveBeenCalledTimes(1);
   });
 
   it('GET /api/contracts/registry should return the registry via alias', async () => {

--- a/app/backend/test/contract-registry.e2e-spec.ts
+++ b/app/backend/test/contract-registry.e2e-spec.ts
@@ -1,0 +1,57 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { ContractRegistryService } from '../src/contracts/contract-registry.service';
+
+describe('ContractRegistryController (e2e)', () => {
+  let app: INestApplication;
+  let contractRegistryService: jest.Mocked<ContractRegistryService>;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ContractRegistryService)
+      .useValue({
+        getRegistry: jest.fn().mockResolvedValue({
+          etag: 'test-etag',
+          contracts: {},
+        }),
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    contractRegistryService = moduleRef.get(ContractRegistryService) as any;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /contracts/registry should return the registry', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/contracts/registry')
+      .expect(200);
+
+    expect(response.body).toEqual({
+      etag: 'test-etag',
+      contracts: {},
+    });
+    expect(response.headers['etag']).toBe('test-etag');
+  });
+
+  it('GET /api/contracts/registry should return the registry via alias', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/contracts/registry')
+      .expect(200);
+
+    expect(response.body).toEqual({
+      etag: 'test-etag',
+      contracts: {},
+    });
+    expect(response.headers['etag']).toBe('test-etag');
+  });
+});

--- a/app/backend/test/contract-registry.e2e-spec.ts
+++ b/app/backend/test/contract-registry.e2e-spec.ts
@@ -54,4 +54,17 @@ describe('ContractRegistryController (e2e)', () => {
     });
     expect(response.headers['etag']).toBe('test-etag');
   });
+
+  it('GET /api/mobile/contracts/registry should return the registry via mobile alias', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/mobile/contracts/registry')
+      .expect(200);
+
+    expect(response.body).toEqual({
+      etag: 'test-etag',
+      contracts: {},
+    });
+    expect(response.headers['etag']).toBe('test-etag');
+  });
 });
+


### PR DESCRIPTION
Closes #651 


## Summary
Added a compatibility alias for the contract registry endpoint to ensure the mobile app can consume the registry without encountering path mismatches. This enables backward and cross-platform compatibility without breaking existing web clients.

## Changes
- Modified `ContractRegistryController` in `app/backend/src/contracts/contract-registry.controller.ts` to include `mobile/contracts` and `api/mobile/contracts` prefixes.
- This ensures the contract registry returns the exact same payload shape across all supported paths (`/api/contracts/registry` and `/api/mobile/contracts/registry`).
- Added integration tests to `app/backend/test/contract-registry.e2e-spec.ts` covering the new route aliases.

## Acceptance Criteria Met
- [x] Mobile can fetch contract registry successfully without custom hacks.
- [x] Registry payloads are consistent across alias paths.
- [x] Route behavior is covered by integration tests.
