### PR TITLE
test(frontend): add theme regression coverage

### DIFF
--- a/app/frontend/src/app/__tests__/__snapshots__/theme-regression.test.tsx.snap
+++ b/app/frontend/src/app/__tests__/__snapshots__/theme-regression.test.tsx.snap
@@ -1,0 +1,2330 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`theme regression coverage > renders the 'admin' surface in light and dark modes without regressions > admin-dark 1`] = `
+<div
+  class="max-w-6xl mx-auto space-y-6"
+>
+  <div
+    class="grid grid-cols-1 lg:grid-cols-2 gap-6"
+  >
+    <div
+      class="bg-card p-6 rounded-lg shadow-sm border border-border"
+    >
+      <div
+        class="flex flex-col gap-4 mb-5"
+      >
+        <div
+          class="flex flex-wrap items-center justify-between gap-3"
+        >
+          <div>
+            <h2
+              class="text-lg font-semibold text-foreground"
+            >
+              Safety Controls
+            </h2>
+            <p
+              class="text-sm text-subtle"
+            >
+              Source: 
+              <span
+                class="font-medium text-muted"
+              >
+                cache
+              </span>
+            </p>
+          </div>
+          <div
+            class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold bg-success-soft text-success"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-shield-check h-3.5 w-3.5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+              />
+              <path
+                d="m9 12 2 2 4-4"
+              />
+            </svg>
+            Persistent store healthy
+          </div>
+        </div>
+        <div
+          class="relative"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-search absolute left-2.5 top-2.5 h-4 w-4 text-subtle"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m21 21-4.34-4.34"
+            />
+            <circle
+              cx="11"
+              cy="11"
+              r="8"
+            />
+          </svg>
+          <input
+            class="pl-9 pr-4 py-2 text-sm border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-brand w-full"
+            placeholder="Search flags..."
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="space-y-4"
+      >
+        <p
+          class="text-sm text-subtle text-center py-4"
+        >
+          No flags found.
+        </p>
+      </div>
+    </div>
+    <div
+      class="bg-card p-6 rounded-lg shadow-sm border border-border"
+    >
+      <h2
+        class="text-lg font-semibold text-foreground mb-4"
+      >
+        System Health
+      </h2>
+      <div
+        class="grid grid-cols-1 sm:grid-cols-3 gap-4"
+      >
+        <div
+          class="p-4 bg-success-soft rounded-lg border border-success-soft"
+        >
+          <div
+            class="flex items-center space-x-2 text-success mb-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-activity h-5 w-5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"
+              />
+            </svg>
+            <span
+              class="font-medium"
+            >
+              API Status
+            </span>
+          </div>
+          <p
+            class="text-2xl font-bold text-foreground"
+          >
+            Operational
+          </p>
+        </div>
+        <div
+          class="p-4 bg-brand-soft rounded-lg border border-brand-soft"
+        >
+          <div
+            class="flex items-center space-x-2 text-brand mb-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-database-zap h-5 w-5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <ellipse
+                cx="12"
+                cy="5"
+                rx="9"
+                ry="3"
+              />
+              <path
+                d="M3 5V19A9 3 0 0 0 15 21.84"
+              />
+              <path
+                d="M21 5V8"
+              />
+              <path
+                d="M21 12L18 17H22L19 22"
+              />
+              <path
+                d="M3 12A9 3 0 0 0 14.59 14.87"
+              />
+            </svg>
+            <span
+              class="font-medium"
+            >
+              Flag Store
+            </span>
+          </div>
+          <p
+            class="text-2xl font-bold text-foreground"
+          >
+            Persistent
+          </p>
+        </div>
+        <div
+          class="p-4 bg-warning-soft rounded-lg border border-warning-soft"
+        >
+          <div
+            class="flex items-center space-x-2 text-warning mb-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-shield-alert h-5 w-5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+              />
+              <path
+                d="M12 8v4"
+              />
+              <path
+                d="M12 16h.01"
+              />
+            </svg>
+            <span
+              class="font-medium"
+            >
+              Uptime
+            </span>
+          </div>
+          <p
+            class="text-2xl font-bold text-foreground"
+          >
+            2m
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="bg-card p-6 rounded-lg shadow-sm border border-border"
+  >
+    <div
+      class="flex justify-between items-center mb-6"
+    >
+      <div>
+        <h2
+          class="text-lg font-semibold text-foreground"
+        >
+          Audit Logs
+        </h2>
+        <p
+          class="text-sm text-subtle"
+        >
+          Feature flag changes are persisted here.
+        </p>
+      </div>
+      <div
+        class="flex items-center space-x-2"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-funnel h-4 w-4 text-subtle"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 20a1 1 0 0 0 .553.895l2 1A1 1 0 0 0 14 21v-7a2 2 0 0 1 .517-1.341L21.74 4.67A1 1 0 0 0 21 3H3a1 1 0 0 0-.742 1.67l7.225 7.989A2 2 0 0 1 10 14z"
+          />
+        </svg>
+        <select
+          class="border border-border rounded-md py-1.5 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand bg-card"
+        >
+          <option
+            value="ALL"
+          >
+            ALL
+          </option>
+        </select>
+      </div>
+    </div>
+    <div
+      class="overflow-x-auto"
+    >
+      <table
+        class="w-full text-left text-sm text-subtle"
+      >
+        <thead
+          class="text-xs text-muted uppercase bg-background border-b border-border"
+        >
+          <tr>
+            <th
+              class="px-4 py-3 rounded-tl-lg"
+            >
+              Timestamp
+            </th>
+            <th
+              class="px-4 py-3"
+            >
+              Action
+            </th>
+            <th
+              class="px-4 py-3"
+            >
+              Actor
+            </th>
+            <th
+              class="px-4 py-3 rounded-tr-lg"
+            >
+              Details
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              class="px-4 py-8 text-center text-subtle"
+              colspan="4"
+            >
+              No logs found matching the selected filter.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`theme regression coverage > renders the 'admin' surface in light and dark modes without regressions > admin-light 1`] = `
+<div
+  class="max-w-6xl mx-auto space-y-6"
+>
+  <div
+    class="grid grid-cols-1 lg:grid-cols-2 gap-6"
+  >
+    <div
+      class="bg-card p-6 rounded-lg shadow-sm border border-border"
+    >
+      <div
+        class="flex flex-col gap-4 mb-5"
+      >
+        <div
+          class="flex flex-wrap items-center justify-between gap-3"
+        >
+          <div>
+            <h2
+              class="text-lg font-semibold text-foreground"
+            >
+              Safety Controls
+            </h2>
+            <p
+              class="text-sm text-subtle"
+            >
+              Source: 
+              <span
+                class="font-medium text-muted"
+              >
+                cache
+              </span>
+            </p>
+          </div>
+          <div
+            class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold bg-success-soft text-success"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-shield-check h-3.5 w-3.5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+              />
+              <path
+                d="m9 12 2 2 4-4"
+              />
+            </svg>
+            Persistent store healthy
+          </div>
+        </div>
+        <div
+          class="relative"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-search absolute left-2.5 top-2.5 h-4 w-4 text-subtle"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m21 21-4.34-4.34"
+            />
+            <circle
+              cx="11"
+              cy="11"
+              r="8"
+            />
+          </svg>
+          <input
+            class="pl-9 pr-4 py-2 text-sm border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-brand w-full"
+            placeholder="Search flags..."
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="space-y-4"
+      >
+        <p
+          class="text-sm text-subtle text-center py-4"
+        >
+          No flags found.
+        </p>
+      </div>
+    </div>
+    <div
+      class="bg-card p-6 rounded-lg shadow-sm border border-border"
+    >
+      <h2
+        class="text-lg font-semibold text-foreground mb-4"
+      >
+        System Health
+      </h2>
+      <div
+        class="grid grid-cols-1 sm:grid-cols-3 gap-4"
+      >
+        <div
+          class="p-4 bg-success-soft rounded-lg border border-success-soft"
+        >
+          <div
+            class="flex items-center space-x-2 text-success mb-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-activity h-5 w-5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"
+              />
+            </svg>
+            <span
+              class="font-medium"
+            >
+              API Status
+            </span>
+          </div>
+          <p
+            class="text-2xl font-bold text-foreground"
+          >
+            Operational
+          </p>
+        </div>
+        <div
+          class="p-4 bg-brand-soft rounded-lg border border-brand-soft"
+        >
+          <div
+            class="flex items-center space-x-2 text-brand mb-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-database-zap h-5 w-5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <ellipse
+                cx="12"
+                cy="5"
+                rx="9"
+                ry="3"
+              />
+              <path
+                d="M3 5V19A9 3 0 0 0 15 21.84"
+              />
+              <path
+                d="M21 5V8"
+              />
+              <path
+                d="M21 12L18 17H22L19 22"
+              />
+              <path
+                d="M3 12A9 3 0 0 0 14.59 14.87"
+              />
+            </svg>
+            <span
+              class="font-medium"
+            >
+              Flag Store
+            </span>
+          </div>
+          <p
+            class="text-2xl font-bold text-foreground"
+          >
+            Persistent
+          </p>
+        </div>
+        <div
+          class="p-4 bg-warning-soft rounded-lg border border-warning-soft"
+        >
+          <div
+            class="flex items-center space-x-2 text-warning mb-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-shield-alert h-5 w-5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+              />
+              <path
+                d="M12 8v4"
+              />
+              <path
+                d="M12 16h.01"
+              />
+            </svg>
+            <span
+              class="font-medium"
+            >
+              Uptime
+            </span>
+          </div>
+          <p
+            class="text-2xl font-bold text-foreground"
+          >
+            2m
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="bg-card p-6 rounded-lg shadow-sm border border-border"
+  >
+    <div
+      class="flex justify-between items-center mb-6"
+    >
+      <div>
+        <h2
+          class="text-lg font-semibold text-foreground"
+        >
+          Audit Logs
+        </h2>
+        <p
+          class="text-sm text-subtle"
+        >
+          Feature flag changes are persisted here.
+        </p>
+      </div>
+      <div
+        class="flex items-center space-x-2"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-funnel h-4 w-4 text-subtle"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 20a1 1 0 0 0 .553.895l2 1A1 1 0 0 0 14 21v-7a2 2 0 0 1 .517-1.341L21.74 4.67A1 1 0 0 0 21 3H3a1 1 0 0 0-.742 1.67l7.225 7.989A2 2 0 0 1 10 14z"
+          />
+        </svg>
+        <select
+          class="border border-border rounded-md py-1.5 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand bg-card"
+        >
+          <option
+            value="ALL"
+          >
+            ALL
+          </option>
+        </select>
+      </div>
+    </div>
+    <div
+      class="overflow-x-auto"
+    >
+      <table
+        class="w-full text-left text-sm text-subtle"
+      >
+        <thead
+          class="text-xs text-muted uppercase bg-background border-b border-border"
+        >
+          <tr>
+            <th
+              class="px-4 py-3 rounded-tl-lg"
+            >
+              Timestamp
+            </th>
+            <th
+              class="px-4 py-3"
+            >
+              Action
+            </th>
+            <th
+              class="px-4 py-3"
+            >
+              Actor
+            </th>
+            <th
+              class="px-4 py-3 rounded-tr-lg"
+            >
+              Details
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              class="px-4 py-8 text-center text-subtle"
+              colspan="4"
+            >
+              No logs found matching the selected filter.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`theme regression coverage > renders the 'dashboard' surface in light and dark modes without regressions > dashboard-dark 1`] = `
+<div
+  class="relative min-h-screen text-foreground"
+>
+  <a
+    class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-indigo-500 focus:px-3 focus:py-2 focus:text-sm focus:font-semibold focus:text-white"
+    href="#dashboard-main"
+  >
+    Skip to dashboard content
+  </a>
+  <div
+    data-testid="network-badge"
+  />
+  <div
+    class="fixed left-[-30%] top-[-20%] h-[60%] w-[60%] rounded-full bg-indigo-500/10 blur-[120px]"
+  />
+  <div
+    class="fixed bottom-[-20%] right-[-30%] h-[50%] w-[50%] rounded-full bg-purple-500/5 blur-[100px]"
+  />
+  <aside
+    class="fixed left-0 top-0 z-20 hidden h-screen w-72 flex-col border-r border-border bg-card backdrop-blur-3xl md:flex"
+  >
+    <nav
+      aria-label="Dashboard navigation"
+      class="flex-1 space-y-2 px-4 py-20"
+    >
+      <a
+        aria-current="page"
+        class="flex items-center gap-3 rounded-2xl border border-border bg-surface px-4 py-3 font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        href="/dashboard"
+      >
+        <span>
+          Dashboard
+        </span>
+      </a>
+      <a
+        class="flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-muted transition hover:bg-surface hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        href="/generator"
+      >
+        <span>
+          Link Generator
+        </span>
+      </a>
+      <a
+        class="flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-muted transition hover:bg-surface hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        href="/notifications"
+      >
+        <span>
+          Notifications
+        </span>
+      </a>
+      <a
+        class="flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-muted transition hover:bg-surface hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        href="/settings"
+      >
+        <span>
+          Profile Settings
+        </span>
+      </a>
+    </nav>
+  </aside>
+  <main
+    class="relative z-10 p-4 sm:p-6 md:ml-72 md:p-12"
+    id="dashboard-main"
+  >
+    <header
+      class="mb-10 flex flex-col gap-6 md:mb-16 md:flex-row md:items-start md:justify-between"
+    >
+      <div>
+        <nav
+          class="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-subtle md:mb-4"
+        >
+          <span>
+            QuickEx
+          </span>
+          <span>
+            /
+          </span>
+          <span
+            class="text-foreground"
+          >
+            Dashboard
+          </span>
+        </nav>
+        <h1
+          class="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl"
+        >
+          Welcome back.
+        </h1>
+        <p
+          class="mt-2 text-sm font-medium text-muted sm:text-base md:text-lg"
+        >
+          Your payments, escrows, and action items all in one place.
+        </p>
+      </div>
+      <div
+        class="flex flex-wrap items-center gap-3"
+      >
+        <a
+          aria-label="Open notifications panel"
+          class="rounded-xl border border-border-strong bg-surface px-4 py-3 text-sm font-semibold text-foreground transition hover:bg-surface-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          href="/notifications"
+        >
+          Open notifications
+        </a>
+        <button
+          aria-label="Withdraw funds"
+          class="rounded-xl bg-indigo-500 px-4 py-3 font-semibold text-white shadow-lg transition hover:bg-indigo-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          type="button"
+        >
+          Withdraw funds
+        </button>
+      </div>
+    </header>
+    <div
+      class="mb-8 space-y-3"
+    >
+      <p
+        aria-live="polite"
+        class="text-sm text-muted"
+      >
+        Notifications can jump you directly into payments, active bids, and listing updates.
+      </p>
+    </div>
+    <section
+      class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2 md:mb-16 lg:grid-cols-3"
+    >
+      <div
+        class="group relative overflow-hidden rounded-3xl border border-border bg-card p-6 transition hover:border-indigo-500/30"
+      >
+        <div
+          class="absolute right-0 top-0 p-4 opacity-10 transition group-hover:opacity-20"
+        >
+          <span
+            class="text-6xl font-semibold text-brand"
+          >
+            $
+          </span>
+        </div>
+        <p
+          class="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-muted"
+        >
+          Total Volume
+        </p>
+        <div
+          class="flex items-baseline gap-2"
+        >
+          <p
+            class="text-4xl font-semibold text-foreground"
+          >
+            $1,200.00
+          </p>
+          <span
+            class="rounded-full bg-emerald-400/10 px-2 py-1 text-xs font-semibold text-success"
+          >
+            Live Backend Data
+          </span>
+        </div>
+        <p
+          class="mt-2 text-xs text-subtle"
+        >
+          Avg tx size: 
+          $75.00
+        </p>
+      </div>
+      <div
+        class="rounded-3xl border border-border bg-card p-6"
+      >
+        <p
+          class="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-muted"
+        >
+          Payments & Success Rate
+        </p>
+        <div
+          class="flex items-baseline gap-2"
+        >
+          <p
+            class="text-4xl font-semibold text-foreground"
+          >
+            92.0
+            %
+          </p>
+          <span
+            class="text-sm font-medium text-muted"
+          >
+            (
+            44
+             txs)
+          </span>
+        </div>
+        <div
+          class="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-surface-strong"
+        >
+          <div
+            class="h-full bg-indigo-400 transition-all duration-500"
+            style="width: 92%;"
+          />
+        </div>
+        <p
+          class="mt-2 text-xs text-subtle"
+        >
+          41
+           settled, 
+          3
+           failed
+        </p>
+      </div>
+      <div
+        class="rounded-3xl border border-indigo-300/50 bg-indigo-500 p-6 text-white shadow-[0_20px_40px_-15px_rgba(99,102,241,0.3)]"
+      >
+        <p
+          class="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-white/90"
+        >
+          Available Payout
+        </p>
+        <p
+          class="text-4xl font-semibold text-white"
+        >
+          1,020.00
+           
+          <span
+            class="text-xl opacity-80"
+          >
+            USDC
+          </span>
+        </p>
+        <p
+          class="mt-3 text-xs text-white/90"
+        >
+          2
+           refunds • Estimated settlement: 3 seconds
+        </p>
+      </div>
+    </section>
+    <div
+      class="mb-10 md:mb-16"
+    >
+      <div
+        data-testid="analytics-dashboard"
+      />
+    </div>
+    <section
+      class="overflow-hidden rounded-3xl border border-border bg-card shadow-2xl backdrop-blur-2xl"
+      id="dashboard-activity"
+      tabindex="-1"
+    >
+      <div
+        class="flex flex-col justify-between gap-4 border-b border-border p-6 sm:flex-row sm:p-10"
+      >
+        <div>
+          <h2
+            class="text-2xl font-semibold text-foreground"
+          >
+            Activity Feed
+          </h2>
+          <p
+            class="mt-1 text-sm text-muted"
+          >
+            Direct payment history, with actions and notification deep links.
+          </p>
+        </div>
+        <div
+          class="rounded-xl border border-border bg-surface p-2"
+        >
+          <label
+            class="sr-only"
+            for="dashboard-range"
+          >
+            Filter activity period
+          </label>
+          <select
+            class="bg-transparent text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            id="dashboard-range"
+          >
+            <option
+              selected=""
+            >
+              Last 30 Days
+            </option>
+            <option>
+              Yearly
+            </option>
+          </select>
+        </div>
+      </div>
+      <div
+        class="overflow-x-auto"
+      >
+        <table
+          class="min-w-[700px] w-full text-left"
+        >
+          <caption
+            class="sr-only"
+          >
+            Recent payment activity with actions to extend TTL or clean up completed records.
+          </caption>
+          <thead>
+            <tr
+              class="border-b border-border text-[10px] font-semibold uppercase tracking-[0.24em] text-muted"
+            >
+              <th
+                class="px-6 py-4 sm:px-10 sm:py-6"
+              >
+                Transaction ID
+              </th>
+              <th
+                class="px-6 py-4 sm:px-10 sm:py-6"
+              >
+                Asset
+              </th>
+              <th
+                class="px-6 py-4 sm:px-10 sm:py-6"
+              >
+                Memo / Status
+              </th>
+              <th
+                class="px-6 py-4 sm:px-10 sm:py-6"
+              >
+                Timestamp
+              </th>
+              <th
+                class="px-6 py-4 text-right sm:px-10 sm:py-6"
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="divide-y divide-border"
+          />
+        </table>
+      </div>
+      <div
+        class="bg-surface p-6 text-center sm:p-8"
+      >
+        <a
+          class="text-sm font-semibold text-muted transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          href="/notifications?category=payments"
+        >
+          View payment alerts
+        </a>
+      </div>
+    </section>
+    <section
+      class="mt-10 overflow-hidden rounded-3xl border border-border bg-card shadow-2xl backdrop-blur-2xl md:mt-16"
+    >
+      <div
+        class="flex flex-col items-start justify-between gap-4 border-b border-border p-6 sm:flex-row sm:items-center sm:p-10"
+      >
+        <div>
+          <h2
+            class="text-2xl font-semibold text-foreground"
+          >
+            Escrow and Listing Activity
+          </h2>
+          <p
+            class="mt-1 text-sm text-muted"
+          >
+            Notifications here land on the exact bid or listing that needs your attention.
+          </p>
+        </div>
+        <a
+          class="rounded-xl border border-indigo-300/40 bg-indigo-500/10 px-5 py-2.5 text-sm font-semibold text-brand transition hover:bg-indigo-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          href="/notifications?category=escrows"
+        >
+          Open escrow alerts
+        </a>
+      </div>
+      <div
+        class="grid divide-y divide-border md:grid-cols-2 md:divide-x md:divide-y-0"
+      >
+        <div
+          class="p-6 sm:p-8"
+          id="dashboard-bids"
+          tabindex="-1"
+        >
+          <h3
+            class="mb-5 text-sm font-semibold uppercase tracking-[0.24em] text-muted"
+          >
+            My Active Bids
+          </h3>
+          <p
+            class="text-sm text-muted"
+          >
+            No active bids yet.
+          </p>
+        </div>
+        <div
+          class="p-6 sm:p-8"
+          id="dashboard-listings"
+          tabindex="-1"
+        >
+          <h3
+            class="mb-5 text-sm font-semibold uppercase tracking-[0.24em] text-muted"
+          >
+            My Listings
+          </h3>
+          <p
+            class="text-sm text-muted"
+          >
+            No usernames listed yet.
+          </p>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>
+`;
+
+exports[`theme regression coverage > renders the 'dashboard' surface in light and dark modes without regressions > dashboard-light 1`] = `
+<div
+  class="relative min-h-screen text-foreground"
+>
+  <a
+    class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-indigo-500 focus:px-3 focus:py-2 focus:text-sm focus:font-semibold focus:text-white"
+    href="#dashboard-main"
+  >
+    Skip to dashboard content
+  </a>
+  <div
+    data-testid="network-badge"
+  />
+  <div
+    class="fixed left-[-30%] top-[-20%] h-[60%] w-[60%] rounded-full bg-indigo-500/10 blur-[120px]"
+  />
+  <div
+    class="fixed bottom-[-20%] right-[-30%] h-[50%] w-[50%] rounded-full bg-purple-500/5 blur-[100px]"
+  />
+  <aside
+    class="fixed left-0 top-0 z-20 hidden h-screen w-72 flex-col border-r border-border bg-card backdrop-blur-3xl md:flex"
+  >
+    <nav
+      aria-label="Dashboard navigation"
+      class="flex-1 space-y-2 px-4 py-20"
+    >
+      <a
+        aria-current="page"
+        class="flex items-center gap-3 rounded-2xl border border-border bg-surface px-4 py-3 font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        href="/dashboard"
+      >
+        <span>
+          Dashboard
+        </span>
+      </a>
+      <a
+        class="flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-muted transition hover:bg-surface hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        href="/generator"
+      >
+        <span>
+          Link Generator
+        </span>
+      </a>
+      <a
+        class="flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-muted transition hover:bg-surface hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        href="/notifications"
+      >
+        <span>
+          Notifications
+        </span>
+      </a>
+      <a
+        class="flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-muted transition hover:bg-surface hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        href="/settings"
+      >
+        <span>
+          Profile Settings
+        </span>
+      </a>
+    </nav>
+  </aside>
+  <main
+    class="relative z-10 p-4 sm:p-6 md:ml-72 md:p-12"
+    id="dashboard-main"
+  >
+    <header
+      class="mb-10 flex flex-col gap-6 md:mb-16 md:flex-row md:items-start md:justify-between"
+    >
+      <div>
+        <nav
+          class="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-subtle md:mb-4"
+        >
+          <span>
+            QuickEx
+          </span>
+          <span>
+            /
+          </span>
+          <span
+            class="text-foreground"
+          >
+            Dashboard
+          </span>
+        </nav>
+        <h1
+          class="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl"
+        >
+          Welcome back.
+        </h1>
+        <p
+          class="mt-2 text-sm font-medium text-muted sm:text-base md:text-lg"
+        >
+          Your payments, escrows, and action items all in one place.
+        </p>
+      </div>
+      <div
+        class="flex flex-wrap items-center gap-3"
+      >
+        <a
+          aria-label="Open notifications panel"
+          class="rounded-xl border border-border-strong bg-surface px-4 py-3 text-sm font-semibold text-foreground transition hover:bg-surface-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          href="/notifications"
+        >
+          Open notifications
+        </a>
+        <button
+          aria-label="Withdraw funds"
+          class="rounded-xl bg-indigo-500 px-4 py-3 font-semibold text-white shadow-lg transition hover:bg-indigo-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          type="button"
+        >
+          Withdraw funds
+        </button>
+      </div>
+    </header>
+    <div
+      class="mb-8 space-y-3"
+    >
+      <p
+        aria-live="polite"
+        class="text-sm text-muted"
+      >
+        Notifications can jump you directly into payments, active bids, and listing updates.
+      </p>
+    </div>
+    <section
+      class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2 md:mb-16 lg:grid-cols-3"
+    >
+      <div
+        class="group relative overflow-hidden rounded-3xl border border-border bg-card p-6 transition hover:border-indigo-500/30"
+      >
+        <div
+          class="absolute right-0 top-0 p-4 opacity-10 transition group-hover:opacity-20"
+        >
+          <span
+            class="text-6xl font-semibold text-brand"
+          >
+            $
+          </span>
+        </div>
+        <p
+          class="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-muted"
+        >
+          Total Volume
+        </p>
+        <div
+          class="flex items-baseline gap-2"
+        >
+          <p
+            class="text-4xl font-semibold text-foreground"
+          >
+            $1,200.00
+          </p>
+          <span
+            class="rounded-full bg-emerald-400/10 px-2 py-1 text-xs font-semibold text-success"
+          >
+            Live Backend Data
+          </span>
+        </div>
+        <p
+          class="mt-2 text-xs text-subtle"
+        >
+          Avg tx size: 
+          $75.00
+        </p>
+      </div>
+      <div
+        class="rounded-3xl border border-border bg-card p-6"
+      >
+        <p
+          class="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-muted"
+        >
+          Payments & Success Rate
+        </p>
+        <div
+          class="flex items-baseline gap-2"
+        >
+          <p
+            class="text-4xl font-semibold text-foreground"
+          >
+            92.0
+            %
+          </p>
+          <span
+            class="text-sm font-medium text-muted"
+          >
+            (
+            44
+             txs)
+          </span>
+        </div>
+        <div
+          class="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-surface-strong"
+        >
+          <div
+            class="h-full bg-indigo-400 transition-all duration-500"
+            style="width: 92%;"
+          />
+        </div>
+        <p
+          class="mt-2 text-xs text-subtle"
+        >
+          41
+           settled, 
+          3
+           failed
+        </p>
+      </div>
+      <div
+        class="rounded-3xl border border-indigo-300/50 bg-indigo-500 p-6 text-white shadow-[0_20px_40px_-15px_rgba(99,102,241,0.3)]"
+      >
+        <p
+          class="mb-1 text-xs font-semibold uppercase tracking-[0.24em] text-white/90"
+        >
+          Available Payout
+        </p>
+        <p
+          class="text-4xl font-semibold text-white"
+        >
+          1,020.00
+           
+          <span
+            class="text-xl opacity-80"
+          >
+            USDC
+          </span>
+        </p>
+        <p
+          class="mt-3 text-xs text-white/90"
+        >
+          2
+           refunds • Estimated settlement: 3 seconds
+        </p>
+      </div>
+    </section>
+    <div
+      class="mb-10 md:mb-16"
+    >
+      <div
+        data-testid="analytics-dashboard"
+      />
+    </div>
+    <section
+      class="overflow-hidden rounded-3xl border border-border bg-card shadow-2xl backdrop-blur-2xl"
+      id="dashboard-activity"
+      tabindex="-1"
+    >
+      <div
+        class="flex flex-col justify-between gap-4 border-b border-border p-6 sm:flex-row sm:p-10"
+      >
+        <div>
+          <h2
+            class="text-2xl font-semibold text-foreground"
+          >
+            Activity Feed
+          </h2>
+          <p
+            class="mt-1 text-sm text-muted"
+          >
+            Direct payment history, with actions and notification deep links.
+          </p>
+        </div>
+        <div
+          class="rounded-xl border border-border bg-surface p-2"
+        >
+          <label
+            class="sr-only"
+            for="dashboard-range"
+          >
+            Filter activity period
+          </label>
+          <select
+            class="bg-transparent text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            id="dashboard-range"
+          >
+            <option
+              selected=""
+            >
+              Last 30 Days
+            </option>
+            <option>
+              Yearly
+            </option>
+          </select>
+        </div>
+      </div>
+      <div
+        class="overflow-x-auto"
+      >
+        <table
+          class="min-w-[700px] w-full text-left"
+        >
+          <caption
+            class="sr-only"
+          >
+            Recent payment activity with actions to extend TTL or clean up completed records.
+          </caption>
+          <thead>
+            <tr
+              class="border-b border-border text-[10px] font-semibold uppercase tracking-[0.24em] text-muted"
+            >
+              <th
+                class="px-6 py-4 sm:px-10 sm:py-6"
+              >
+                Transaction ID
+              </th>
+              <th
+                class="px-6 py-4 sm:px-10 sm:py-6"
+              >
+                Asset
+              </th>
+              <th
+                class="px-6 py-4 sm:px-10 sm:py-6"
+              >
+                Memo / Status
+              </th>
+              <th
+                class="px-6 py-4 sm:px-10 sm:py-6"
+              >
+                Timestamp
+              </th>
+              <th
+                class="px-6 py-4 text-right sm:px-10 sm:py-6"
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="divide-y divide-border"
+          />
+        </table>
+      </div>
+      <div
+        class="bg-surface p-6 text-center sm:p-8"
+      >
+        <a
+          class="text-sm font-semibold text-muted transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          href="/notifications?category=payments"
+        >
+          View payment alerts
+        </a>
+      </div>
+    </section>
+    <section
+      class="mt-10 overflow-hidden rounded-3xl border border-border bg-card shadow-2xl backdrop-blur-2xl md:mt-16"
+    >
+      <div
+        class="flex flex-col items-start justify-between gap-4 border-b border-border p-6 sm:flex-row sm:items-center sm:p-10"
+      >
+        <div>
+          <h2
+            class="text-2xl font-semibold text-foreground"
+          >
+            Escrow and Listing Activity
+          </h2>
+          <p
+            class="mt-1 text-sm text-muted"
+          >
+            Notifications here land on the exact bid or listing that needs your attention.
+          </p>
+        </div>
+        <a
+          class="rounded-xl border border-indigo-300/40 bg-indigo-500/10 px-5 py-2.5 text-sm font-semibold text-brand transition hover:bg-indigo-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          href="/notifications?category=escrows"
+        >
+          Open escrow alerts
+        </a>
+      </div>
+      <div
+        class="grid divide-y divide-border md:grid-cols-2 md:divide-x md:divide-y-0"
+      >
+        <div
+          class="p-6 sm:p-8"
+          id="dashboard-bids"
+          tabindex="-1"
+        >
+          <h3
+            class="mb-5 text-sm font-semibold uppercase tracking-[0.24em] text-muted"
+          >
+            My Active Bids
+          </h3>
+          <p
+            class="text-sm text-muted"
+          >
+            No active bids yet.
+          </p>
+        </div>
+        <div
+          class="p-6 sm:p-8"
+          id="dashboard-listings"
+          tabindex="-1"
+        >
+          <h3
+            class="mb-5 text-sm font-semibold uppercase tracking-[0.24em] text-muted"
+          >
+            My Listings
+          </h3>
+          <p
+            class="text-sm text-muted"
+          >
+            No usernames listed yet.
+          </p>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>
+`;
+
+exports[`theme regression coverage > renders the 'public payment profile' surface in light and dark modes without regressions > public-payment-profile-dark 1`] = `
+<div
+  class="min-h-screen flex items-center justify-center text-foreground"
+>
+  <p>
+    Loading profile...
+  </p>
+</div>
+`;
+
+exports[`theme regression coverage > renders the 'public payment profile' surface in light and dark modes without regressions > public-payment-profile-light 1`] = `
+<div
+  class="relative min-h-screen text-foreground"
+>
+  <a
+    class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-indigo-500 focus:px-3 focus:py-2 focus:text-sm focus:font-semibold focus:text-white"
+    href="#public-profile-main"
+  >
+    Skip to payment form
+  </a>
+  <div
+    data-testid="network-badge"
+  />
+  <div
+    class="fixed top-[-20%] left-[-30%] w-[60%] h-[60%] blur-[120px] rounded-full opacity-10"
+    style="background-color: rgb(99, 102, 241);"
+  />
+  <div
+    class="fixed bottom-[-20%] right-[-30%] w-[50%] h-[50%] blur-[100px] rounded-full opacity-5"
+    style="background-color: rgb(99, 102, 241);"
+  />
+  <main
+    class="relative z-10 max-w-2xl mx-auto p-4 sm:p-6 md:p-12"
+    id="public-profile-main"
+  >
+    <div
+      class="text-center mb-12"
+    >
+      <div
+        class="flex justify-center mb-6"
+      >
+        <div
+          class="w-32 h-32 rounded-full border-4 flex items-center justify-center text-5xl font-black"
+          style="border-color: rgb(99, 102, 241); color: rgb(99, 102, 241);"
+        >
+          A
+        </div>
+      </div>
+      <h1
+        class="text-4xl font-black mb-3"
+      >
+        @
+        alice
+      </h1>
+      <p
+        class="text-muted text-lg mb-6 max-w-md mx-auto"
+      >
+        Building the future of payments on Stellar
+      </p>
+      <div
+        class="flex justify-center gap-4 mb-8"
+      >
+        <a
+          aria-label="Open stellarorg on X"
+          class="w-12 h-12 rounded-full bg-surface hover:bg-surface-strong flex items-center justify-center transition text-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          href="https://twitter.com/stellarorg"
+          rel="noopener noreferrer"
+          style="color: rgb(99, 102, 241);"
+          target="_blank"
+        >
+          𝕏
+        </a>
+        <a
+          aria-label="Open stellar on GitHub"
+          class="w-12 h-12 rounded-full bg-surface hover:bg-surface-strong flex items-center justify-center transition text-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          href="https://github.com/stellar"
+          rel="noopener noreferrer"
+          style="color: rgb(99, 102, 241);"
+          target="_blank"
+        >
+          🐙
+        </a>
+      </div>
+    </div>
+    <div
+      class="rounded-3xl bg-card border border-border backdrop-blur-2xl p-8 mb-8"
+    >
+      <h2
+        class="text-2xl font-black mb-6"
+      >
+        Send Payment
+      </h2>
+      <form
+        class="space-y-4"
+      >
+        <div>
+          <label
+            class="block text-sm font-bold text-muted mb-2"
+            for="payment-amount"
+          >
+            Amount
+          </label>
+          <input
+            class="w-full px-4 py-3 rounded-xl bg-surface border border-border-strong text-foreground text-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            id="payment-amount"
+            placeholder="0.00"
+            step="0.01"
+            type="number"
+            value=""
+          />
+        </div>
+        <div>
+          <label
+            class="block text-sm font-bold text-muted mb-2"
+            for="payment-asset"
+          >
+            Asset
+          </label>
+          <select
+            class="w-full px-4 py-3 rounded-xl bg-surface border border-border-strong text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            id="payment-asset"
+          >
+            <option
+              value="USDC"
+            >
+              USDC
+            </option>
+            <option
+              value="XLM"
+            >
+              XLM
+            </option>
+            <option
+              value="AQUA"
+            >
+              AQUA
+            </option>
+            <option
+              value="yXLM"
+            >
+              yXLM
+            </option>
+          </select>
+        </div>
+        <div>
+          <label
+            class="block text-sm font-bold text-muted mb-2"
+            for="payment-memo"
+          >
+            Memo (optional)
+          </label>
+          <input
+            class="w-full px-4 py-3 rounded-xl bg-surface border border-border-strong text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            id="payment-memo"
+            maxlength="28"
+            placeholder="Payment for..."
+            type="text"
+            value=""
+          />
+        </div>
+        <button
+          aria-label="Generate payment link for alice"
+          class="w-full py-4 rounded-xl font-bold text-foreground transition hover:opacity-90 mt-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          style="background-color: rgb(99, 102, 241);"
+          type="submit"
+        >
+          Generate Payment Link
+        </button>
+      </form>
+    </div>
+    <div
+      class="text-center mt-12 text-subtle text-sm"
+    >
+      <p>
+        Powered by QuickEx • Stellar Network
+      </p>
+    </div>
+  </main>
+</div>
+`;
+
+exports[`theme regression coverage > renders the 'settings' surface in light and dark modes without regressions > settings-dark 1`] = `
+<div
+  class="relative min-h-screen text-foreground selection:bg-indigo-500/30"
+>
+  <div
+    data-testid="network-badge"
+  />
+  <div
+    class="fixed top-[-20%] left-[-30%] w-[60%] h-[60%] bg-indigo-500/10 blur-[120px] rounded-full"
+  />
+  <div
+    class="fixed bottom-[-20%] right-[-30%] w-[50%] h-[50%] bg-purple-500/5 blur-[100px] rounded-full"
+  />
+  <div
+    class="md:hidden relative z-10 p-4 border-b border-border bg-card backdrop-blur-3xl"
+  >
+    <div
+      class="flex items-center justify-between"
+    >
+      <a
+        class="text-subtle hover:text-foreground transition"
+        href="/dashboard"
+      >
+        ← Back
+      </a>
+      <h1
+        class="text-lg font-black"
+      >
+        Settings
+      </h1>
+      <div
+        class="w-16"
+      />
+       
+    </div>
+  </div>
+  <aside
+    class="hidden md:flex w-72 h-screen fixed left-0 top-0 border-r border-border bg-card backdrop-blur-3xl flex-col z-20"
+  >
+    <nav
+      class="flex-1 px-4 py-30 space-y-2"
+    >
+      <a
+        class="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition"
+        href="/dashboard"
+      >
+        <span>
+          📊
+        </span>
+         Dashboard
+      </a>
+      <a
+        class="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition"
+        href="/generator"
+      >
+        <span>
+          ⚡
+        </span>
+         Link Generator
+      </a>
+      <a
+        class="flex items-center gap-3 px-4 py-3 bg-surface border border-border rounded-2xl font-bold"
+        href="/settings"
+      >
+        <span
+          class="text-indigo-400"
+        >
+          ⚙️
+        </span>
+         Profile Settings
+      </a>
+      <a
+        class="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition"
+        href="/settings/teams"
+      >
+        <span>
+          👥
+        </span>
+         Team Management
+      </a>
+    </nav>
+  </aside>
+  <main
+    class="relative z-10 p-4 sm:p-6 md:p-12 md:ml-72 pb-24 md:pb-12"
+  >
+    <header
+      class="hidden md:block mb-10"
+    >
+      <h1
+        class="text-3xl sm:text-4xl font-black tracking-tight mb-2"
+      >
+        Profile Customization
+      </h1>
+      <p
+        class="text-subtle font-medium text-sm sm:text-base"
+      >
+        profileCustomizationDescription:john_doe
+      </p>
+    </header>
+    <div
+      class="md:hidden mb-6"
+    >
+      <p
+        class="text-subtle text-sm"
+      >
+        profileCustomizationDescription:john_doe
+      </p>
+    </div>
+    <nav
+      class="flex gap-3 mb-8"
+    >
+      <a
+        class="px-4 py-2 rounded-xl border border-border-strong bg-surface-strong text-sm font-semibold hover:bg-surface-strong"
+        href="/settings"
+      >
+        generalTab
+      </a>
+      <a
+        class="px-4 py-2 rounded-xl border border-border-strong text-sm font-semibold hover:bg-surface"
+        href="/settings/teams"
+      >
+        Team
+      </a>
+      <a
+        class="px-4 py-2 rounded-xl border border-border-strong text-sm font-semibold hover:bg-surface"
+        href="/settings/developer"
+      >
+        developerTab
+      </a>
+    </nav>
+    <div
+      class="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 lg:gap-8"
+    >
+      <div
+        class="space-y-4 sm:space-y-6"
+      >
+        <div
+          class="rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8"
+        >
+          <h2
+            class="text-lg sm:text-xl font-bold mb-4 sm:mb-6"
+          >
+            Theme Settings
+          </h2>
+          <div
+            class="space-y-4"
+          >
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                primaryColor
+              </label>
+              <div
+                class="flex gap-2 sm:gap-3"
+              >
+                <input
+                  class="w-14 sm:w-16 h-11 sm:h-12 rounded-xl border border-border-strong bg-transparent cursor-pointer"
+                  type="color"
+                  value="#6366f1"
+                />
+                <input
+                  class="flex-1 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground font-mono text-sm sm:text-base"
+                  placeholder="#6366f1"
+                  type="text"
+                  value="#6366f1"
+                />
+              </div>
+            </div>
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                avatarUrl
+              </label>
+              <input
+                class="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
+                placeholder="https://example.com/avatar.jpg"
+                type="url"
+                value=""
+              />
+            </div>
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                bioLabel
+              </label>
+              <textarea
+                class="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground resize-none text-sm sm:text-base"
+                maxlength="160"
+                placeholder="Building the future of payments on Stellar"
+                rows="3"
+              />
+              <p
+                class="text-xs text-faint mt-1"
+              >
+                0
+                /160 characters
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8"
+        >
+          <h2
+            class="text-lg sm:text-xl font-bold mb-4 sm:mb-6"
+          >
+            languageLabel
+          </h2>
+          <p
+            class="text-sm text-subtle mb-4"
+          >
+            changeLanguage
+          </p>
+          <div
+            data-testid="locale-switcher"
+          />
+        </div>
+        <div
+          class="rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8"
+        >
+          <h2
+            class="text-lg sm:text-xl font-bold mb-4 sm:mb-6"
+          >
+            Social Links
+          </h2>
+          <div
+            class="space-y-4"
+          >
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                twitterHandleLabel
+              </label>
+              <div
+                class="flex items-center gap-2"
+              >
+                <span
+                  class="text-subtle text-sm sm:text-base"
+                >
+                  @
+                </span>
+                <input
+                  class="flex-1 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
+                  maxlength="15"
+                  placeholder="stellarorg"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                discordUsernameLabel
+              </label>
+              <input
+                class="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
+                maxlength="32"
+                placeholder="user#1234"
+                type="text"
+                value=""
+              />
+            </div>
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                githubHandleLabel
+              </label>
+              <input
+                class="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
+                maxlength="39"
+                placeholder="stellar"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="hidden sm:flex gap-3 sm:gap-4"
+        >
+          <button
+            class="flex-1 px-4 sm:px-6 py-3 sm:py-4 bg-indigo-500 text-white font-bold rounded-xl hover:scale-105 active:scale-95 transition text-sm sm:text-base"
+          >
+            saveChanges
+          </button>
+          <button
+            class="px-4 sm:px-6 py-3 sm:py-4 bg-surface border border-border-strong text-foreground font-bold rounded-xl hover:bg-surface-strong transition text-sm sm:text-base whitespace-nowrap"
+          >
+            show
+             
+            preview
+          </button>
+        </div>
+      </div>
+    </div>
+  </main>
+  <div
+    class="sm:hidden fixed bottom-0 left-0 right-0 z-30 p-4 bg-card backdrop-blur-3xl border-t border-border"
+  >
+    <div
+      class="flex gap-3"
+    >
+      <button
+        class="flex-1 px-4 py-3 bg-indigo-500 text-white font-bold rounded-xl active:scale-95 transition"
+      >
+        saveChanges
+      </button>
+      <button
+        class="px-4 py-3 bg-surface border border-border-strong text-foreground font-bold rounded-xl active:scale-95 transition"
+      >
+        show
+         
+        preview
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`theme regression coverage > renders the 'settings' surface in light and dark modes without regressions > settings-light 1`] = `
+<div
+  class="relative min-h-screen text-foreground selection:bg-indigo-500/30"
+>
+  <div
+    data-testid="network-badge"
+  />
+  <div
+    class="fixed top-[-20%] left-[-30%] w-[60%] h-[60%] bg-indigo-500/10 blur-[120px] rounded-full"
+  />
+  <div
+    class="fixed bottom-[-20%] right-[-30%] w-[50%] h-[50%] bg-purple-500/5 blur-[100px] rounded-full"
+  />
+  <div
+    class="md:hidden relative z-10 p-4 border-b border-border bg-card backdrop-blur-3xl"
+  >
+    <div
+      class="flex items-center justify-between"
+    >
+      <a
+        class="text-subtle hover:text-foreground transition"
+        href="/dashboard"
+      >
+        ← Back
+      </a>
+      <h1
+        class="text-lg font-black"
+      >
+        Settings
+      </h1>
+      <div
+        class="w-16"
+      />
+       
+    </div>
+  </div>
+  <aside
+    class="hidden md:flex w-72 h-screen fixed left-0 top-0 border-r border-border bg-card backdrop-blur-3xl flex-col z-20"
+  >
+    <nav
+      class="flex-1 px-4 py-30 space-y-2"
+    >
+      <a
+        class="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition"
+        href="/dashboard"
+      >
+        <span>
+          📊
+        </span>
+         Dashboard
+      </a>
+      <a
+        class="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition"
+        href="/generator"
+      >
+        <span>
+          ⚡
+        </span>
+         Link Generator
+      </a>
+      <a
+        class="flex items-center gap-3 px-4 py-3 bg-surface border border-border rounded-2xl font-bold"
+        href="/settings"
+      >
+        <span
+          class="text-indigo-400"
+        >
+          ⚙️
+        </span>
+         Profile Settings
+      </a>
+      <a
+        class="flex items-center gap-3 px-4 py-3 text-subtle hover:text-foreground hover:bg-surface rounded-2xl font-semibold transition"
+        href="/settings/teams"
+      >
+        <span>
+          👥
+        </span>
+         Team Management
+      </a>
+    </nav>
+  </aside>
+  <main
+    class="relative z-10 p-4 sm:p-6 md:p-12 md:ml-72 pb-24 md:pb-12"
+  >
+    <header
+      class="hidden md:block mb-10"
+    >
+      <h1
+        class="text-3xl sm:text-4xl font-black tracking-tight mb-2"
+      >
+        Profile Customization
+      </h1>
+      <p
+        class="text-subtle font-medium text-sm sm:text-base"
+      >
+        profileCustomizationDescription:john_doe
+      </p>
+    </header>
+    <div
+      class="md:hidden mb-6"
+    >
+      <p
+        class="text-subtle text-sm"
+      >
+        profileCustomizationDescription:john_doe
+      </p>
+    </div>
+    <nav
+      class="flex gap-3 mb-8"
+    >
+      <a
+        class="px-4 py-2 rounded-xl border border-border-strong bg-surface-strong text-sm font-semibold hover:bg-surface-strong"
+        href="/settings"
+      >
+        generalTab
+      </a>
+      <a
+        class="px-4 py-2 rounded-xl border border-border-strong text-sm font-semibold hover:bg-surface"
+        href="/settings/teams"
+      >
+        Team
+      </a>
+      <a
+        class="px-4 py-2 rounded-xl border border-border-strong text-sm font-semibold hover:bg-surface"
+        href="/settings/developer"
+      >
+        developerTab
+      </a>
+    </nav>
+    <div
+      class="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 lg:gap-8"
+    >
+      <div
+        class="space-y-4 sm:space-y-6"
+      >
+        <div
+          class="rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8"
+        >
+          <h2
+            class="text-lg sm:text-xl font-bold mb-4 sm:mb-6"
+          >
+            Theme Settings
+          </h2>
+          <div
+            class="space-y-4"
+          >
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                primaryColor
+              </label>
+              <div
+                class="flex gap-2 sm:gap-3"
+              >
+                <input
+                  class="w-14 sm:w-16 h-11 sm:h-12 rounded-xl border border-border-strong bg-transparent cursor-pointer"
+                  type="color"
+                  value="#6366f1"
+                />
+                <input
+                  class="flex-1 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground font-mono text-sm sm:text-base"
+                  placeholder="#6366f1"
+                  type="text"
+                  value="#6366f1"
+                />
+              </div>
+            </div>
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                avatarUrl
+              </label>
+              <input
+                class="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
+                placeholder="https://example.com/avatar.jpg"
+                type="url"
+                value=""
+              />
+            </div>
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                bioLabel
+              </label>
+              <textarea
+                class="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground resize-none text-sm sm:text-base"
+                maxlength="160"
+                placeholder="Building the future of payments on Stellar"
+                rows="3"
+              />
+              <p
+                class="text-xs text-faint mt-1"
+              >
+                0
+                /160 characters
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8"
+        >
+          <h2
+            class="text-lg sm:text-xl font-bold mb-4 sm:mb-6"
+          >
+            languageLabel
+          </h2>
+          <p
+            class="text-sm text-subtle mb-4"
+          >
+            changeLanguage
+          </p>
+          <div
+            data-testid="locale-switcher"
+          />
+        </div>
+        <div
+          class="rounded-2xl sm:rounded-3xl bg-card border border-border p-5 sm:p-6 md:p-8"
+        >
+          <h2
+            class="text-lg sm:text-xl font-bold mb-4 sm:mb-6"
+          >
+            Social Links
+          </h2>
+          <div
+            class="space-y-4"
+          >
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                twitterHandleLabel
+              </label>
+              <div
+                class="flex items-center gap-2"
+              >
+                <span
+                  class="text-subtle text-sm sm:text-base"
+                >
+                  @
+                </span>
+                <input
+                  class="flex-1 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
+                  maxlength="15"
+                  placeholder="stellarorg"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                discordUsernameLabel
+              </label>
+              <input
+                class="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
+                maxlength="32"
+                placeholder="user#1234"
+                type="text"
+                value=""
+              />
+            </div>
+            <div>
+              <label
+                class="block text-xs sm:text-sm font-bold text-subtle mb-2"
+              >
+                githubHandleLabel
+              </label>
+              <input
+                class="w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl bg-surface border border-border-strong text-foreground text-sm sm:text-base"
+                maxlength="39"
+                placeholder="stellar"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="hidden sm:flex gap-3 sm:gap-4"
+        >
+          <button
+            class="flex-1 px-4 sm:px-6 py-3 sm:py-4 bg-indigo-500 text-white font-bold rounded-xl hover:scale-105 active:scale-95 transition text-sm sm:text-base"
+          >
+            saveChanges
+          </button>
+          <button
+            class="px-4 sm:px-6 py-3 sm:py-4 bg-surface border border-border-strong text-foreground font-bold rounded-xl hover:bg-surface-strong transition text-sm sm:text-base whitespace-nowrap"
+          >
+            show
+             
+            preview
+          </button>
+        </div>
+      </div>
+    </div>
+  </main>
+  <div
+    class="sm:hidden fixed bottom-0 left-0 right-0 z-30 p-4 bg-card backdrop-blur-3xl border-t border-border"
+  >
+    <div
+      class="flex gap-3"
+    >
+      <button
+        class="flex-1 px-4 py-3 bg-indigo-500 text-white font-bold rounded-xl active:scale-95 transition"
+      >
+        saveChanges
+      </button>
+      <button
+        class="px-4 py-3 bg-surface border border-border-strong text-foreground font-bold rounded-xl active:scale-95 transition"
+      >
+        show
+         
+        preview
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/app/frontend/src/app/__tests__/theme-regression.test.tsx
+++ b/app/frontend/src/app/__tests__/theme-regression.test.tsx
@@ -1,0 +1,188 @@
+import React, { useEffect } from "react";
+import type { AnchorHTMLAttributes, ImgHTMLAttributes, ReactNode } from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import PublicProfile from "@/app/[username]/page";
+import AdminPage from "@/app/admin/page";
+import Dashboard from "@/app/dashboard/page";
+import Settings from "@/app/settings/page";
+import { ThemeProvider, useTheme, type Theme } from "@/components/ThemeProvider";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ username: "alice" }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt, ...props }: ImgHTMLAttributes<HTMLImageElement>) => <img alt={alt ?? ""} {...props} />,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => undefined },
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (options?.username) {
+        return `${key}:${options.username}`;
+      }
+      if (key === "themeSettings") {
+        return "Theme Settings";
+      }
+      if (key === "settingsTitle") {
+        return "Settings";
+      }
+      if (key === "profileCustomization") {
+        return "Profile Customization";
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/components/AnalyticsDashboard", () => ({
+  default: () => <div data-testid="analytics-dashboard" />,
+}));
+
+vi.mock("@/components/NetworkBadge", () => ({
+  NetworkBadge: () => <div data-testid="network-badge" />,
+}));
+
+vi.mock("@/components/LocaleSwitcher", () => ({
+  LocaleSwitcher: () => <div data-testid="locale-switcher" />,
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  useApi: () => ({
+    data: { items: [] },
+    error: null,
+    loading: false,
+    callApi: async (fn: () => Promise<unknown>) => fn(),
+  }),
+}));
+
+vi.mock("@/hooks/analyticsApi", () => ({
+  fetchAnalytics: async () => ({
+    summary: {
+      totalVolume: 1200,
+      avgTxSize: 75,
+      conversionRate: 92,
+      totalTx: 44,
+      successfulTx: 41,
+      failedTx: 3,
+      refundCount: 2,
+    },
+  }),
+}));
+
+vi.mock("@/hooks/marketplaceApi", () => ({
+  fetchUserBids: async () => [],
+  fetchUserListings: async () => [],
+  formatCountdown: (value: string) => value,
+}));
+
+vi.mock("@/hooks/mockApi", () => ({
+  mockContractCall: async () => undefined,
+  mockFetch: async (payload: unknown) => payload,
+}));
+
+vi.mock("@/lib/api", () => ({
+  getQuickexApiBase: () => "https://api.example.test",
+}));
+
+function ThemeHarness({ theme, children }: { theme: Theme; children: ReactNode }) {
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    setTheme(theme);
+  }, [setTheme, theme]);
+
+  return <>{children}</>;
+}
+
+function renderWithTheme(ui: ReactNode, theme: Theme) {
+  return render(
+    <ThemeProvider>
+      <ThemeHarness theme={theme}>{ui}</ThemeHarness>
+    </ThemeProvider>,
+  );
+}
+
+function mockFetchResponses() {
+  const fetchMock = vi.fn(async (input: string | URL | Request) => {
+    const url = String(input);
+
+    if (url.includes("/health")) {
+      return {
+        ok: true,
+        json: async () => ({ status: "ok", uptime: 120 }),
+      };
+    }
+
+    if (url.includes("/admin/feature-flags")) {
+      return {
+        ok: true,
+        json: async () => ({ flags: [], source: "cache", storeAvailable: true }),
+      };
+    }
+
+    if (url.includes("/admin/audit")) {
+      return {
+        ok: true,
+        json: async () => ({ data: [] }),
+      };
+    }
+
+    return {
+      ok: true,
+      json: async () => ({}),
+    };
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+beforeEach(() => {
+  mockFetchResponses();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("theme regression coverage", () => {
+  it.each([
+    { name: "public payment profile", ui: <PublicProfile />, assertion: /Send Payment/i, snapshotKey: "public-payment-profile" },
+    { name: "dashboard", ui: <Dashboard />, assertion: /Welcome back\./i, snapshotKey: "dashboard" },
+    { name: "settings", ui: <Settings />, assertion: /Theme Settings/i, snapshotKey: "settings" },
+    { name: "admin", ui: <AdminPage />, assertion: /Safety Controls/i, snapshotKey: "admin" },
+  ])("renders the $name surface in light and dark modes without regressions", async ({ ui, assertion, snapshotKey }) => {
+    const lightView = renderWithTheme(ui, "light");
+    await screen.findByText(assertion);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("light")).toBe(true);
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+      expect(document.documentElement.style.colorScheme).toBe("light");
+    });
+
+    expect(lightView.container.firstChild).toMatchSnapshot(`${snapshotKey}-light`);
+
+    cleanup();
+
+    const darkView = renderWithTheme(ui, "dark");
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+      expect(document.documentElement.classList.contains("light")).toBe(false);
+      expect(document.documentElement.style.colorScheme).toBe("dark");
+    });
+
+    expect(darkView.container.firstChild).toMatchSnapshot(`${snapshotKey}-dark`);
+  });
+});

--- a/app/frontend/vitest.config.ts
+++ b/app/frontend/vitest.config.ts
@@ -2,9 +2,12 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+  },
   test: {
     globals: true,
-    environment: 'node',
+    environment: 'jsdom',
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add regression coverage for high-risk themed screens in light and dark mode
- cover public payment, dashboard, settings, and admin surfaces with snapshots
- document the expectation in the new regression suite

Closes #684