### PR TITLE
feat(backend): unify discovery search contract

### DIFF
--- a/app/backend/src/dto/username/search-usernames-response.dto.ts
+++ b/app/backend/src/dto/username/search-usernames-response.dto.ts
@@ -1,15 +1,90 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PublicProfileDto } from './public-profile.dto';
 
+export class SearchDiscoveryResultDto {
+  @ApiProperty({
+    description: 'Kind of search result item',
+    enum: ['profile', 'listing'],
+    example: 'profile',
+  })
+  kind: 'profile' | 'listing';
+
+  @ApiProperty({
+    description: 'Unique identifier for the item',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Username associated with the result',
+    example: 'alice',
+  })
+  username: string;
+
+  @ApiPropertyOptional({
+    description: 'Public key for profile results',
+    example: 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR',
+  })
+  publicKey?: string;
+
+  @ApiPropertyOptional({
+    description: 'Seller public key for marketplace listing results',
+    example: 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR',
+  })
+  sellerPublicKey?: string;
+
+  @ApiPropertyOptional({
+    description: 'Similarity score used to rank the result',
+    example: 95,
+  })
+  similarityScore?: number;
+
+  @ApiPropertyOptional({
+    description: 'Asking price for marketplace listing results',
+    example: 250,
+  })
+  askingPrice?: number;
+
+  @ApiPropertyOptional({
+    description: 'Marketplace listing status',
+    example: 'active',
+  })
+  status?: string;
+
+  @ApiPropertyOptional({
+    description: 'Last activity timestamp for profile results',
+    example: '2025-03-27T10:30:00Z',
+  })
+  lastActiveAt?: string;
+
+  @ApiProperty({
+    description: 'Creation timestamp for the result',
+    example: '2025-02-19T08:00:00Z',
+  })
+  createdAt: string;
+}
+
 /**
- * DTO for search usernames response
+ * DTO for unified discovery search response
  */
 export class SearchUsernamesResponseDto {
   @ApiProperty({
-    description: 'List of public profiles matching the search query',
+    description: 'Unified search results for profiles and marketplace listings',
+    type: [SearchDiscoveryResultDto],
+  })
+  results: SearchDiscoveryResultDto[];
+
+  @ApiPropertyOptional({
+    description: 'Profile-only subset retained for backwards compatibility',
     type: [PublicProfileDto],
   })
-  profiles: PublicProfileDto[];
+  profiles?: PublicProfileDto[];
+
+  @ApiProperty({
+    description: 'Whether the current query produced no matches',
+    example: false,
+  })
+  empty: boolean;
 
   @ApiProperty({
     description: 'Total number of matching results',

--- a/app/backend/src/supabase/supabase.service.ts
+++ b/app/backend/src/supabase/supabase.service.ts
@@ -655,6 +655,41 @@ export class SupabaseService {
     return data as MarketplaceListing;
   }
 
+  async searchActiveListings(
+    query: string,
+    limit: number = 10,
+  ): Promise<{ listings: MarketplaceListing[]; next_cursor: string | null; has_more: boolean; total: number }> {
+    const normalizedQuery = query.trim().toLowerCase();
+    const effectiveLimit = Math.min(100, Math.max(1, limit));
+
+    let dbQuery = this.client
+      .from("username_marketplace")
+      .select("*", { count: "exact" })
+      .eq("status", "active");
+
+    if (normalizedQuery) {
+      dbQuery = dbQuery.or(`username.ilike.%${normalizedQuery}%,seller_public_key.ilike.%${normalizedQuery}%`);
+    }
+
+    const { data, error, count } = await dbQuery
+      .order("created_at", { ascending: false })
+      .order("id", { ascending: false })
+      .limit(effectiveLimit + 1);
+
+    if (error) this.handleError(error);
+
+    const rows = (data ?? []) as MarketplaceListing[];
+    const hasMore = rows.length > effectiveLimit;
+    const listings = hasMore ? rows.slice(0, effectiveLimit) : rows;
+
+    return {
+      listings,
+      next_cursor: null,
+      has_more: hasMore,
+      total: count ?? rows.length,
+    };
+  }
+
   async getActiveListings(
     limit: number,
     cursor: string | null,

--- a/app/backend/src/usernames/usernames.controller.ts
+++ b/app/backend/src/usernames/usernames.controller.ts
@@ -178,22 +178,28 @@ export class UsernamesController {
   async searchUsernames(
     @Query() query: SearchUsernamesQueryDto,
   ): Promise<SearchUsernamesResponseDto> {
-    const results = await this.usernamesService.searchPublicUsernames(
+    const results = await this.usernamesService.searchDiscovery(
       query.query,
       query.limit,
       query.cursor,
     );
 
+    const profileResults = results.results.filter((r) => r.kind === "profile") as Array<{
+      kind: "profile"; id: string; username: string; publicKey?: string; similarityScore?: number; lastActiveAt?: string; createdAt: string;
+    }>;
+
     return {
-      profiles: results.data.map((r) => ({
+      results: results.results,
+      profiles: profileResults.map((r) => ({
         id: r.id,
         username: r.username,
-        publicKey: r.public_key,
-        lastActiveAt: r.last_active_at || r.created_at,
-        createdAt: r.created_at,
-        similarityScore: r.similarity_score,
+        publicKey: r.publicKey ?? "",
+        lastActiveAt: r.lastActiveAt || r.createdAt,
+        createdAt: r.createdAt,
+        similarityScore: r.similarityScore,
       })) as PublicProfileDto[],
-      total: results.data.length,
+      empty: results.empty,
+      total: results.total,
       next_cursor: results.next_cursor,
       has_more: results.has_more,
     };

--- a/app/backend/src/usernames/usernames.service.public-profile.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.public-profile.unit.spec.ts
@@ -14,6 +14,7 @@ describe('UsernamesService - Public Profile Discovery', () => {
   beforeEach(async () => {
     supabaseMock = {
       searchPublicUsernames: jest.fn(),
+      searchActiveListings: jest.fn(),
       getTrendingCreators: jest.fn(),
       togglePublicProfile: jest.fn(),
       updateUsernameActivity: jest.fn(),
@@ -76,6 +77,42 @@ describe('UsernamesService - Public Profile Discovery', () => {
     it('throws for short queries', async () => {
       await expect(service.searchPublicUsernames('a', 10)).rejects.toThrow(UsernameValidationError);
       await expect(service.searchPublicUsernames('', 10)).rejects.toThrow(UsernameValidationError);
+    });
+  });
+
+  describe('searchDiscovery', () => {
+    it('returns a mixed shared-result payload for profiles and listings', async () => {
+      supabaseMock.searchPublicUsernames!.mockResolvedValue([
+        { id: '1', username: 'alice', public_key: 'pk1', created_at: '2024-01-01', last_active_at: '2024-01-02', is_public: true, similarity_score: 95 },
+      ]);
+      supabaseMock.searchActiveListings!.mockResolvedValue({
+        listings: [
+          { id: 'listing-1', username: 'alice', seller_public_key: 'pk2', asking_price: 250, status: 'active', created_at: '2024-01-03', updated_at: '2024-01-03', sold_at: null, buyer_public_key: null, final_price: null },
+        ],
+        total: 1,
+        next_cursor: null,
+        has_more: false,
+      });
+
+      const res = await service.searchDiscovery('alice', 10);
+
+      expect(res.results).toHaveLength(2);
+      expect(res.results[0]).toEqual(expect.objectContaining({ kind: 'profile', username: 'alice' }));
+      expect(res.results[1]).toEqual(expect.objectContaining({ kind: 'listing', username: 'alice' }));
+      expect(res.total).toBe(2);
+      expect(res.empty).toBe(false);
+      expect(res.next_cursor).toBeNull();
+    });
+
+    it('returns an empty-state payload for blank queries', async () => {
+      const res = await service.searchDiscovery('   ', 10);
+
+      expect(res.results).toEqual([]);
+      expect(res.total).toBe(0);
+      expect(res.empty).toBe(true);
+      expect(res.has_more).toBe(false);
+      expect(supabaseMock.searchPublicUsernames).not.toHaveBeenCalled();
+      expect(supabaseMock.searchActiveListings).not.toHaveBeenCalled();
     });
   });
 

--- a/app/backend/src/usernames/usernames.service.ts
+++ b/app/backend/src/usernames/usernames.service.ts
@@ -4,6 +4,7 @@ import {
   SearchProfileResult,
   TrendingCreatorResult,
   FeaturedProfileResult,
+  MarketplaceListing,
 } from "../supabase/supabase.service";
 import { decodeCursor } from "../common/pagination/cursor.util";
 import { SupabaseUniqueConstraintError } from "../supabase/supabase.errors";
@@ -105,6 +106,85 @@ export class UsernamesService {
     return this.supabase.listUsernamesByPublicKey(publicKey) as Promise<
       UsernameRow[]
     >;
+  }
+
+  async searchDiscovery(
+    query: string,
+    limit: number = 10,
+    cursor?: string,
+  ): Promise<{ results: Array<{ kind: 'profile' | 'listing'; id: string; username: string; publicKey?: string; sellerPublicKey?: string; similarityScore?: number; askingPrice?: number; status?: string; lastActiveAt?: string; createdAt: string; }>; total: number; next_cursor: string | null; has_more: boolean; empty: boolean }> {
+    const normalizedQuery = this.normalizeUsername(query);
+
+    if (!normalizedQuery || normalizedQuery.length < 2) {
+      return {
+        results: [],
+        total: 0,
+        next_cursor: null,
+        has_more: false,
+        empty: true,
+      };
+    }
+
+    const effectiveLimit = Math.min(100, Math.max(1, limit));
+    const decodedCursor = cursor ? decodeCursor(cursor) : null;
+    const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
+
+    const [profilesResult, listingsResult] = await Promise.all([
+      this.supabase.searchPublicUsernames(normalizedQuery, fetchWindow),
+      this.supabase.searchActiveListings(normalizedQuery, fetchWindow),
+    ]);
+
+    const profileResults = profilesResult.map((profile) => ({
+      kind: 'profile' as const,
+      id: profile.id,
+      username: profile.username,
+      publicKey: profile.public_key,
+      similarityScore: profile.similarity_score,
+      lastActiveAt: profile.last_active_at || profile.created_at,
+      createdAt: profile.created_at,
+    }));
+
+    const listingResults = listingsResult.listings.map((listing: MarketplaceListing) => ({
+      kind: 'listing' as const,
+      id: listing.id,
+      username: listing.username,
+      sellerPublicKey: listing.seller_public_key,
+      askingPrice: listing.asking_price,
+      status: listing.status,
+      createdAt: listing.created_at,
+    }));
+
+    const combined = [...profileResults, ...listingResults].sort((a, b) => {
+      const scoreA = a.kind === 'profile' ? (a.similarityScore ?? 0) : 0;
+      const scoreB = b.kind === 'profile' ? (b.similarityScore ?? 0) : 0;
+      if (scoreA !== scoreB) {
+        return scoreB - scoreA;
+      }
+
+      const timeA = new Date(a.createdAt).getTime();
+      const timeB = new Date(b.createdAt).getTime();
+      return timeB - timeA;
+    });
+
+    const hasMore = combined.length > effectiveLimit;
+    const data = hasMore ? combined.slice(0, effectiveLimit) : combined;
+
+    let nextCursor: string | null = null;
+    if (hasMore && data.length > 0) {
+      const last = data[data.length - 1];
+      nextCursor = Buffer.from(
+        JSON.stringify({ pk: last.createdAt, id: last.id }),
+        'utf-8',
+      ).toString('base64url');
+    }
+
+    return {
+      results: data,
+      total: combined.length,
+      next_cursor: nextCursor,
+      has_more: hasMore,
+      empty: data.length === 0,
+    };
   }
 
   /**


### PR DESCRIPTION
Closes #662

---

## Summary
- added a shared discovery search response that combines public profile and marketplace listing results
- implemented empty-state handling and predictable mixed-result ordering for search queries
- added regression tests for mixed-result queries and blank-query behavior

## Verification
- Ran: `pnpm jest --config jest.unit.config.ts --runInBand --testPathPattern='usernames\.service\.public-profile\.unit\.spec\.ts|usernames\.controller\.public-profile\.e2e\.spec\.ts'`
- Result: 1 suite passed, 8 tests passed