### PR TITLE
MOB-55: Bootstrap mobile runtime config from backend session data

### DIFF
--- a/app/mobile/app/payment-confirmation.tsx
+++ b/app/mobile/app/payment-confirmation.tsx
@@ -17,6 +17,8 @@ import { v4 as uuidv4 } from "uuid";
 import { ActivityIndicator } from "react-native";
 import { useContractRegistry } from "../hooks/useContractRegistry";
 import { ErrorState } from "@/components/resilience/error-state";
+import { useEnvironment } from "../contexts/EnvironmentContext";
+import { useSession } from "../contexts/SessionContext";
 
 // List of assets to attempt swaps from (hardcoded whitelist matching backend)
 const SWAPPABLE_ASSETS = ["XLM", "USDC", "AQUA", "yXLM"];
@@ -26,7 +28,9 @@ export default function PaymentConfirmationScreen() {
   const { theme } = useTheme();
   const { isConnected } = useNetworkStatus();
   const { authenticateForSensitiveAction } = useSecurity();
-  const backendUrl = process.env.EXPO_PUBLIC_API_URL || "https://api.quickex.com";
+  const { current } = useEnvironment();
+  const { data: sessionData } = useSession();
+  const backendUrl = current.apiUrl;
   const {
     isReady,
     error: registryError,
@@ -36,7 +40,7 @@ export default function PaymentConfirmationScreen() {
     fetchSource: registryFetchSource,
     isRefreshing: registryRefreshing,
     refresh: refreshRegistry,
-  } = useContractRegistry(["Escrow"], backendUrl);
+  } = useContractRegistry(["Escrow"], backendUrl, sessionData?.metadata.contracts);
   const params = useLocalSearchParams<{
     username: string;
     amount: string;

--- a/app/mobile/contexts/EnvironmentContext.tsx
+++ b/app/mobile/contexts/EnvironmentContext.tsx
@@ -14,6 +14,7 @@ import {
   type CompatibilityResult,
   ENVIRONMENTS,
   DEFAULT_ENVIRONMENT,
+  normalizeBackendMetadata,
 } from '../src/config/environment';
 import {
   loadEnvironment,
@@ -31,7 +32,7 @@ export interface EnvironmentContextValue {
   metadata: BackendMetadata | null;
   compatibility: CompatibilityResult | null;
   isFetchingMetadata: boolean;
-  processMetadata: (data: BackendMetadata) => void;
+  processMetadata: (data: Partial<BackendMetadata>) => void;
 }
 
 const EnvironmentContext = createContext<EnvironmentContextValue | undefined>(
@@ -65,10 +66,11 @@ export function EnvironmentProvider({ children }: { children: React.ReactNode })
     };
   }, []);
 
-  const processMetadata = useCallback((data: BackendMetadata) => {
-    setMetadata(data);
+  const processMetadata = useCallback((data: Partial<BackendMetadata>) => {
+    const normalized = normalizeBackendMetadata(data, current);
+    setMetadata(normalized);
 
-    const minVersion = data.minAppVersion ?? '0.0.0';
+    const minVersion = normalized.minAppVersion;
     const appVersion = '1.0.0'; // In production, read from build config
 
     if (compareVersions(appVersion, minVersion) < 0) {
@@ -76,10 +78,10 @@ export function EnvironmentProvider({ children }: { children: React.ReactNode })
         compatible: false,
         reason: `App version ${appVersion} is below minimum required ${minVersion}. Please update the app.`,
       });
-    } else if (data.stellarNetwork && data.stellarNetwork !== current.stellarNetwork) {
+    } else if (data.stellarNetwork && normalized.stellarNetwork !== current.stellarNetwork) {
       setCompatibility({
         compatible: false,
-        reason: `Stellar network mismatch: backend runs on ${data.stellarNetwork} but environment expects ${current.stellarNetwork}.`,
+        reason: `Stellar network mismatch: backend runs on ${normalized.stellarNetwork} but environment expects ${current.stellarNetwork}.`,
       });
     } else {
       setCompatibility({ compatible: true });

--- a/app/mobile/hooks/useContractRegistry.ts
+++ b/app/mobile/hooks/useContractRegistry.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ContractRegistryService } from '../services/contract-registry';
+import { ContractRegistryService, type ContractRegistry } from '../services/contract-registry';
 
 export type ContractRegistryStatus =
   | 'loading'
@@ -25,7 +25,11 @@ function formatLastUpdated(timestamp: number | null) {
   return `Updated ${elapsedDays}d ago`;
 }
 
-export function useContractRegistry(requiredContracts: string[], backendUrl: string) {
+export function useContractRegistry(
+  requiredContracts: string[],
+  backendUrl: string,
+  bootstrapRegistry?: ContractRegistry,
+) {
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<ContractRegistryStatus>('loading');
@@ -44,7 +48,7 @@ export function useContractRegistry(requiredContracts: string[], backendUrl: str
     setMissingContracts([]);
 
     try {
-      const result = await ContractRegistryService.sync(backendUrl);
+      const result = await ContractRegistryService.sync(backendUrl, bootstrapRegistry);
       const requiredContractNames = requiredContractKey ? requiredContractKey.split('|') : [];
       const missing = requiredContractNames.filter(c => !result.registry[c]);
 
@@ -72,7 +76,7 @@ export function useContractRegistry(requiredContracts: string[], backendUrl: str
       setFetchSource(null);
       setError(err instanceof Error ? err.message : 'Registry unavailable');
     }
-  }, [backendUrl, requiredContractKey]);
+  }, [backendUrl, requiredContractKey, bootstrapRegistry]);
 
   useEffect(() => {
     void syncRegistry(false);

--- a/app/mobile/services/contract-registry.ts
+++ b/app/mobile/services/contract-registry.ts
@@ -20,7 +20,21 @@ interface ContractRegistryCache {
 }
 
 export const ContractRegistryService = {
-  async sync(backendUrl: string): Promise<ContractRegistrySyncResult> {
+  async sync(backendUrl: string, bootstrapRegistry?: ContractRegistry): Promise<ContractRegistrySyncResult> {
+    if (bootstrapRegistry && Object.keys(bootstrapRegistry).length > 0) {
+      const timestamp = Date.now();
+      await AsyncStorage.setItem(CACHE_KEY, JSON.stringify({
+        timestamp,
+        data: bootstrapRegistry,
+      }));
+      return {
+        registry: bootstrapRegistry,
+        fetchedAt: timestamp,
+        isStale: false,
+        source: 'network',
+      };
+    }
+
     try {
       const response = await fetch(`${backendUrl}/api/contracts/registry`);
       if (!response.ok) throw new Error('Failed to fetch registry');

--- a/app/mobile/src/config/environment.ts
+++ b/app/mobile/src/config/environment.ts
@@ -40,14 +40,47 @@ export const ENVIRONMENTS: Record<EnvironmentId, EnvironmentConfig> = {
 
 export const DEFAULT_ENVIRONMENT: EnvironmentId = 'production';
 
+export interface RuntimeContractConfig {
+  id: string;
+  version: string;
+}
+
+export type RuntimeContracts = Record<string, RuntimeContractConfig>;
+
+export interface RuntimePreviewConfig {
+  branch?: string;
+  previewUrl?: string;
+  expiresAt?: string;
+}
+
 export interface BackendMetadata {
   appVersion: string;
   minAppVersion: string;
   environment: string;
   stellarNetwork: string;
+  contracts?: RuntimeContracts;
+  preview?: RuntimePreviewConfig;
 }
 
 export interface CompatibilityResult {
   compatible: boolean;
   reason?: string;
+}
+
+/**
+ * Fills in safe defaults for a bootstrap payload that omits fields —
+ * preview/testnet backends may not populate every field yet.
+ */
+export function normalizeBackendMetadata(
+  data: Partial<BackendMetadata> | null | undefined,
+  fallback: EnvironmentConfig,
+): BackendMetadata {
+  return {
+    appVersion: data?.appVersion ?? 'unknown',
+    minAppVersion: data?.minAppVersion ?? '0.0.0',
+    environment: data?.environment ?? fallback.id,
+    stellarNetwork: data?.stellarNetwork ?? fallback.stellarNetwork,
+    contracts: data?.contracts ?? {},
+    preview: data?.preview,
+  };
 }


### PR DESCRIPTION
## Summary
- `BackendMetadata` (session bootstrap payload) now carries `contracts` (registry) and `preview` (branch/preview-URL/expiry) metadata, alongside the existing app-version/network fields.
- Added `normalizeBackendMetadata()` so `EnvironmentContext.processMetadata` fills safe defaults when a preview/testnet backend returns an incomplete bootstrap payload, instead of trusting every field to be present.
- `ContractRegistryService.sync()` and `useContractRegistry()` now accept an optional bootstrap-provided registry, so screens that already have session-bootstrap data don't need a second `/api/contracts/registry` round trip.
- `payment-confirmation.tsx` no longer hardcodes `EXPO_PUBLIC_API_URL || "https://api.quickex.com"` for its contract registry lookup — it now reads the backend URL from the active `EnvironmentContext` (so it actually respects staging/testnet/branch-preview switching) and passes through the bootstrap-sourced contract registry.

## Why
Closes #693. The environment switcher already lets the app point at production/staging/shared-testnet/branch-preview backends, but the session bootstrap metadata type didn't carry contract/preview data, and at least one screen (`payment-confirmation`) bypassed the environment config entirely with a hardcoded URL — so switching environments didn't fully take effect and contract data required a redundant fetch.

## Test plan
- [x] `npx jest __tests__/contract-registry.test.ts __tests__/EnvironmentStorage.test.ts __tests__/session-bootstrap.test.ts` — all pass
- [x] `npx tsc --noEmit` error count unchanged before/after (115) — no new type errors introduced
- [ ] Manual QA: switch environments in the app and confirm the payment confirmation screen's contract registry lookup follows the selected environment