### PR TITLE
feat(backend): add read-only feature flag snapshot endpoint (BE-96)

### DIFF
--- a/app/backend/src/feature-flags/feature-flags.controller.ts
+++ b/app/backend/src/feature-flags/feature-flags.controller.ts
@@ -6,12 +6,15 @@ import {
   Param,
   Patch,
   Query,
+  Req,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
 
 import {
-  EvaluateFeatureFlagResponseDto,
   FeatureFlagQueryDto,
+  FeatureFlagSnapshotQueryDto,
+  FeatureFlagSnapshotResponseDto,
   UpdateFeatureFlagDto,
 } from './feature-flags.dto';
 import { FeatureFlagsService } from './feature-flags.service';
@@ -47,11 +50,28 @@ export class FeatureFlagsController {
 
   @Get('feature-flags/:key/evaluate')
   @ApiOperation({ summary: 'Evaluate a feature flag for user/environment context' })
-  @ApiResponse({ type: EvaluateFeatureFlagResponseDto })
   async evaluateFlag(
     @Param('key') key: string,
     @Query() query: FeatureFlagQueryDto,
   ) {
     return this.featureFlagsService.evaluateFlag(key, query);
+  }
+
+  @Get('feature-flags/snapshot')
+  @ApiOperation({
+    summary: 'Feature flag snapshot',
+    description:
+      'Returns a read-only snapshot of effective feature flags for clients and admin tooling. ' +
+      'Sensitive/internal flags are excluded. When X-Preview-Scope header is present, ' +
+      'preview override status is included.',
+  })
+  async getSnapshot(
+    @Query() query: FeatureFlagSnapshotQueryDto,
+    @Req() req: Request,
+  ): Promise<FeatureFlagSnapshotResponseDto> {
+    return this.featureFlagsService.getSnapshot(
+      query.environment,
+      req.previewScope,
+    );
   }
 }

--- a/app/backend/src/feature-flags/feature-flags.dto.ts
+++ b/app/backend/src/feature-flags/feature-flags.dto.ts
@@ -125,3 +125,113 @@ export class EvaluateFeatureFlagResponseDto {
   @ApiProperty()
   source!: string;
 }
+
+// ── Snapshot DTOs (BE-96) ────────────────────────────────────────────────────
+
+export class FeatureFlagSnapshotQueryDto {
+  @ApiPropertyOptional({
+    description:
+      'Filter flags to those allowed in this environment. Defaults to all flags when omitted.',
+  })
+  @IsOptional()
+  @IsString()
+  environment?: string;
+}
+
+export class FeatureFlagSnapshotEntryDto {
+  @ApiProperty({ example: 'bulk_link_generation' })
+  key!: string;
+
+  @ApiProperty({ example: 'Bulk Link Generation' })
+  name!: string;
+
+  @ApiProperty({ example: 'Controls new bulk payment-link creation requests.' })
+  description!: string;
+
+  @ApiProperty({ example: true })
+  enabled!: boolean;
+
+  @ApiProperty({ example: false })
+  killSwitch!: boolean;
+
+  @ApiProperty({ example: 100, minimum: 0, maximum: 100 })
+  rolloutPercentage!: number;
+
+  @ApiProperty({ type: [String], example: ['development', 'test', 'production'] })
+  environments!: string[];
+
+  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
+  updatedAt!: string;
+
+  @ApiProperty({ example: 'bootstrap' })
+  updatedBy!: string;
+
+  @ApiProperty({
+    description: 'Whether a preview scope override is active for this flag',
+    example: false,
+    required: false,
+  })
+  previewOverrideActive?: boolean;
+}
+
+export class FeatureFlagSnapshotMetadataDto {
+  @ApiProperty({
+    description: 'Source of the flag data',
+    enum: ['store', 'bootstrap', 'cache'],
+    example: 'bootstrap',
+  })
+  source!: 'store' | 'bootstrap' | 'cache';
+
+  @ApiProperty({
+    description: 'Whether the persistent flag store is reachable',
+    example: true,
+  })
+  storeAvailable!: boolean;
+
+  @ApiProperty({
+    description: 'Environment used for filtering',
+    example: 'test',
+    required: false,
+  })
+  environment?: string;
+
+  @ApiProperty({
+    description: 'Number of flags returned (after sensitive flag exclusion)',
+    example: 6,
+  })
+  flagCount!: number;
+
+  @ApiProperty({
+    description: 'Number of flags excluded as sensitive/internal',
+    example: 0,
+  })
+  sensitiveFlagCount!: number;
+
+  @ApiProperty({
+    description: 'Timestamp of the snapshot',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  timestamp!: string;
+
+  @ApiProperty({
+    description: 'Preview scope identifier when X-Preview-Scope header is present',
+    example: 'pr-123',
+    required: false,
+  })
+  previewScope?: string;
+
+  @ApiProperty({
+    description: 'Whether the preview scope is valid and not expired',
+    example: true,
+    required: false,
+  })
+  previewScopeValid?: boolean;
+}
+
+export class FeatureFlagSnapshotResponseDto {
+  @ApiProperty({ type: FeatureFlagSnapshotMetadataDto })
+  metadata!: FeatureFlagSnapshotMetadataDto;
+
+  @ApiProperty({ type: [FeatureFlagSnapshotEntryDto] })
+  flags!: FeatureFlagSnapshotEntryDto[];
+}

--- a/app/backend/src/feature-flags/feature-flags.module.ts
+++ b/app/backend/src/feature-flags/feature-flags.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 
 import { AuditModule } from '../audit/audit.module';
+import { PreviewScopeModule } from '../preview-scope/preview-scope.module';
 import { SupabaseModule } from '../supabase/supabase.module';
 import { FeatureFlagsController } from './feature-flags.controller';
 import { FeatureFlagsService } from './feature-flags.service';
 import { NetworkSafetyGuard } from './network-safety.guard';
 
 @Module({
-  imports: [SupabaseModule, AuditModule],
+  imports: [SupabaseModule, AuditModule, PreviewScopeModule],
   controllers: [FeatureFlagsController],
   providers: [FeatureFlagsService, NetworkSafetyGuard],
   exports: [FeatureFlagsService, NetworkSafetyGuard],

--- a/app/backend/src/feature-flags/feature-flags.service.ts
+++ b/app/backend/src/feature-flags/feature-flags.service.ts
@@ -8,11 +8,15 @@ import { createHash } from 'crypto';
 
 import { AppConfigService } from '../config';
 import { AuditService } from '../audit/audit.service';
+import { PreviewScopeService } from '../preview-scope/preview-scope.service';
 import { SupabaseService } from '../supabase/supabase.service';
 import {
   FeatureFlagEvaluationContext,
   FeatureFlagEvaluationResult,
   FeatureFlagRecord,
+  FeatureFlagSnapshotEntryDto,
+  FeatureFlagSnapshotMetadataDto,
+  FeatureFlagSnapshotResponseDto,
   FeatureFlagsListResponse,
   UpdateFeatureFlagDto,
 } from './feature-flags.dto';
@@ -117,6 +121,7 @@ export class FeatureFlagsService {
     private readonly supabaseService: SupabaseService,
     private readonly configService: AppConfigService,
     private readonly auditService: AuditService,
+    private readonly previewScopeService: PreviewScopeService,
   ) {}
 
   async listFlags(): Promise<FeatureFlagsListResponse> {
@@ -318,6 +323,65 @@ export class FeatureFlagsService {
       storeAvailable: snapshot.storeAvailable,
       cacheExpiresAt: this.cache?.expiresAt ?? null,
     };
+  }
+
+  async getSnapshot(
+    environment?: string,
+    previewScope?: string,
+  ): Promise<FeatureFlagSnapshotResponseDto> {
+    const snapshot = await this.loadFlags();
+
+    const normalizedEnv = environment?.toLowerCase();
+    const filtered = normalizedEnv
+      ? snapshot.flags.filter((flag) => {
+          const allowed = flag.environments.map((e) => e.toLowerCase());
+          return allowed.length === 0 || allowed.includes(normalizedEnv);
+        })
+      : snapshot.flags;
+
+    let previewScopeValid: boolean | undefined;
+    if (previewScope) {
+      try {
+        previewScopeValid = await this.previewScopeService.isValidScope(previewScope);
+      } catch {
+        previewScopeValid = undefined;
+      }
+    }
+
+    const sensitiveCount = filtered.filter((flag) => this.isSensitiveFlag(flag)).length;
+    const visibleFlags = filtered.filter((flag) => !this.isSensitiveFlag(flag));
+
+    const flags: FeatureFlagSnapshotEntryDto[] = visibleFlags.map((flag) => ({
+      key: flag.key,
+      name: flag.name,
+      description: flag.description,
+      enabled: flag.enabled,
+      killSwitch: flag.killSwitch,
+      rolloutPercentage: flag.rolloutPercentage,
+      environments: flag.environments,
+      updatedAt: flag.updatedAt,
+      updatedBy: flag.updatedBy,
+      previewOverrideActive: previewScope ? (previewScopeValid ?? undefined) : undefined,
+    }));
+
+    const metadata: FeatureFlagSnapshotMetadataDto = {
+      source: snapshot.source,
+      storeAvailable: snapshot.storeAvailable,
+      environment: normalizedEnv,
+      flagCount: flags.length,
+      sensitiveFlagCount: sensitiveCount,
+      timestamp: new Date().toISOString(),
+      previewScope: previewScope ?? undefined,
+      previewScopeValid: previewScope ? previewScopeValid : undefined,
+    };
+
+    return { metadata, flags };
+  }
+
+  private isSensitiveFlag(flag: FeatureFlagRecord): boolean {
+    const meta = flag.metadata;
+    if (!meta || typeof meta !== 'object') return false;
+    return meta.internal === true || meta.sensitive === true;
   }
 
   private async loadFlags(forceRefresh = false): Promise<CacheState> {

--- a/app/backend/src/feature-flags/feature-flags.service.unit.spec.ts
+++ b/app/backend/src/feature-flags/feature-flags.service.unit.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { AppConfigService } from '../config';
 import { AuditService } from '../audit/audit.service';
+import { PreviewScopeService } from '../preview-scope/preview-scope.service';
 import { SupabaseService } from '../supabase/supabase.service';
 import { FeatureFlagsService } from './feature-flags.service';
 
@@ -22,6 +23,11 @@ describe('FeatureFlagsService', () => {
     getClient: jest.fn(),
   };
 
+  const mockPreviewScopeService = {
+    isValidScope: jest.fn().mockResolvedValue(true),
+    getScope: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -29,6 +35,7 @@ describe('FeatureFlagsService', () => {
         { provide: SupabaseService, useValue: mockSupabaseService },
         { provide: AuditService, useValue: mockAuditService },
         { provide: AppConfigService, useValue: mockConfigService },
+        { provide: PreviewScopeService, useValue: mockPreviewScopeService },
       ],
     }).compile();
 
@@ -212,5 +219,263 @@ describe('FeatureFlagsService', () => {
       'bulk_link_generation',
       expect.any(Object),
     );
+  });
+
+  describe('getSnapshot', () => {
+    it('returns all bootstrap flags when store is unavailable', async () => {
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          order: jest.fn().mockRejectedValue(new Error('offline')),
+        }),
+      });
+
+      const result = await service.getSnapshot();
+
+      expect(result.metadata.source).toBe('bootstrap');
+      expect(result.metadata.storeAvailable).toBe(false);
+      expect(result.metadata.flagCount).toBeGreaterThan(0);
+      expect(result.flags.every((f) => typeof f.key === 'string')).toBe(true);
+      expect(result.flags.every((f) => typeof f.enabled === 'boolean')).toBe(true);
+    });
+
+    it('filters flags by environment', async () => {
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          order: jest.fn().mockResolvedValue({
+            data: [
+              {
+                key: 'mainnet.refunds',
+                name: 'Mainnet Refunds',
+                description: 'Allows refund initiation on mainnet.',
+                enabled: false,
+                kill_switch: false,
+                rollout_percentage: 0,
+                allowed_users: [],
+                environments: ['production'],
+                metadata: {},
+                updated_at: new Date(0).toISOString(),
+                updated_by: 'bootstrap',
+              },
+              {
+                key: 'bulk_link_generation',
+                name: 'Bulk Link Generation',
+                description: 'Controls bulk payment-link creation.',
+                enabled: true,
+                kill_switch: false,
+                rollout_percentage: 100,
+                allowed_users: [],
+                environments: ['development', 'test', 'production'],
+                metadata: {},
+                updated_at: new Date().toISOString(),
+                updated_by: 'seed',
+              },
+            ],
+            error: null,
+          }),
+        }),
+      });
+
+      const result = await service.getSnapshot('production');
+
+      expect(result.metadata.environment).toBe('production');
+      expect(result.flags.map((f) => f.key)).toContain('bulk_link_generation');
+      expect(result.flags.map((f) => f.key)).toContain('mainnet.refunds');
+    });
+
+    it('excludes flags with sensitive/internal metadata', async () => {
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          order: jest.fn().mockResolvedValue({
+            data: [
+              {
+                key: 'bulk_link_generation',
+                name: 'Bulk Link Generation',
+                description: 'Controls bulk payment-link creation.',
+                enabled: true,
+                kill_switch: false,
+                rollout_percentage: 100,
+                allowed_users: [],
+                environments: ['development', 'test', 'production'],
+                metadata: {},
+                updated_at: new Date().toISOString(),
+                updated_by: 'seed',
+              },
+              {
+                key: 'internal.debug_logging',
+                name: 'Debug Logging',
+                description: 'Internal debug flag.',
+                enabled: true,
+                kill_switch: false,
+                rollout_percentage: 100,
+                allowed_users: [],
+                environments: ['development'],
+                metadata: { internal: true },
+                updated_at: new Date().toISOString(),
+                updated_by: 'ops',
+              },
+              {
+                key: 'sensitive.pii_feature',
+                name: 'PII Feature',
+                description: 'Feature exposing PII.',
+                enabled: true,
+                kill_switch: false,
+                rollout_percentage: 100,
+                allowed_users: [],
+                environments: ['development'],
+                metadata: { sensitive: true },
+                updated_at: new Date().toISOString(),
+                updated_by: 'ops',
+              },
+            ],
+            error: null,
+          }),
+        }),
+      });
+
+      const result = await service.getSnapshot();
+
+      expect(result.metadata.sensitiveFlagCount).toBe(2);
+      expect(result.flags.map((f) => f.key)).not.toContain('internal.debug_logging');
+      expect(result.flags.map((f) => f.key)).not.toContain('sensitive.pii_feature');
+      expect(result.flags.map((f) => f.key)).toContain('bulk_link_generation');
+    });
+
+    it('includes preview scope metadata when header is present', async () => {
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          order: jest.fn().mockResolvedValue({
+            data: [
+              {
+                key: 'bulk_link_generation',
+                name: 'Bulk Link Generation',
+                description: 'Controls bulk payment-link creation.',
+                enabled: true,
+                kill_switch: false,
+                rollout_percentage: 100,
+                allowed_users: [],
+                environments: ['development', 'test', 'production'],
+                metadata: {},
+                updated_at: new Date().toISOString(),
+                updated_by: 'seed',
+              },
+            ],
+            error: null,
+          }),
+        }),
+      });
+      mockPreviewScopeService.isValidScope.mockResolvedValue(true);
+
+      const result = await service.getSnapshot(undefined, 'pr-42');
+
+      expect(result.metadata.previewScope).toBe('pr-42');
+      expect(result.metadata.previewScopeValid).toBe(true);
+      expect(result.flags[0].previewOverrideActive).toBe(true);
+    });
+
+    it('reports invalid preview scope', async () => {
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          order: jest.fn().mockResolvedValue({
+            data: [
+              {
+                key: 'bulk_link_generation',
+                name: 'Bulk Link Generation',
+                description: 'Controls bulk payment-link creation.',
+                enabled: true,
+                kill_switch: false,
+                rollout_percentage: 100,
+                allowed_users: [],
+                environments: ['development', 'test', 'production'],
+                metadata: {},
+                updated_at: new Date().toISOString(),
+                updated_by: 'seed',
+              },
+            ],
+            error: null,
+          }),
+        }),
+      });
+      mockPreviewScopeService.isValidScope.mockResolvedValue(false);
+
+      const result = await service.getSnapshot(undefined, 'expired-scope');
+
+      expect(result.metadata.previewScope).toBe('expired-scope');
+      expect(result.metadata.previewScopeValid).toBe(false);
+      expect(result.flags[0].previewOverrideActive).toBe(false);
+    });
+
+    it('handles preview scope service failure gracefully', async () => {
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          order: jest.fn().mockResolvedValue({
+            data: [
+              {
+                key: 'bulk_link_generation',
+                name: 'Bulk Link Generation',
+                description: 'Controls bulk payment-link creation.',
+                enabled: true,
+                kill_switch: false,
+                rollout_percentage: 100,
+                allowed_users: [],
+                environments: ['development', 'test', 'production'],
+                metadata: {},
+                updated_at: new Date().toISOString(),
+                updated_by: 'seed',
+              },
+            ],
+            error: null,
+          }),
+        }),
+      });
+      mockPreviewScopeService.isValidScope.mockRejectedValue(new Error('db down'));
+
+      const result = await service.getSnapshot(undefined, 'pr-99');
+
+      expect(result.metadata.previewScope).toBe('pr-99');
+      expect(result.metadata.previewScopeValid).toBeUndefined();
+      expect(result.flags.length).toBeGreaterThan(0);
+      expect(result.flags.some((f) => f.key === 'bulk_link_generation')).toBe(true);
+    });
+
+    it('reflects overridden flag state from store', async () => {
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          order: jest.fn().mockResolvedValue({
+            data: [
+              {
+                key: 'bulk_link_generation',
+                name: 'Bulk Link Generation',
+                description: 'Controls bulk payment-link creation.',
+                enabled: false,
+                kill_switch: true,
+                rollout_percentage: 0,
+                allowed_users: [],
+                environments: ['test'],
+                metadata: {},
+                updated_at: new Date().toISOString(),
+                updated_by: 'admin',
+              },
+            ],
+            error: null,
+          }),
+        }),
+      });
+
+      const result = await service.getSnapshot('test');
+
+      const overridden = result.flags.find((f) => f.key === 'bulk_link_generation');
+      expect(overridden).toBeDefined();
+      expect(overridden!.enabled).toBe(false);
+      expect(overridden!.killSwitch).toBe(true);
+      expect(overridden!.rolloutPercentage).toBe(0);
+      expect(overridden!.updatedBy).toBe('admin');
+    });
   });
 });


### PR DESCRIPTION
I added a read-only `GET /feature-flags/snapshot` endpoint that returns effective feature flags with metadata, environment filtering, preview scope awareness, and sensitive flag exclusion for client and admin debugging.

closes #663