### PR TITLE
feat(crash-reporting): add submit issue report DTO for backend intake

### DIFF
--- a/app/backend/src/crash-reporting/dto/submit-issue-report.dto.ts
+++ b/app/backend/src/crash-reporting/dto/submit-issue-report.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class SubmitIssueReportDto {
+  @ApiProperty({
+    description: 'Description of the issue',
+    example: 'I encountered an error when trying to submit a transaction',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(5000)
+  userMessage: string;
+
+  @ApiPropertyOptional({
+    description: 'Error details / stack trace',
+    example: 'TypeError: Cannot read properties of undefined...',
+  })
+  @IsString()
+  @IsOptional()
+  errorDetails?: string;
+
+  @ApiPropertyOptional({
+    description: 'Browser / environment metadata',
+    example: 'Chrome 120, Windows 11, testnet',
+  })
+  @IsString()
+  @IsOptional()
+  environment?: string;
+
+  @ApiPropertyOptional({
+    description: 'Page route where the issue occurred',
+    example: '/dashboard',
+  })
+  @IsString()
+  @IsOptional()
+  route?: string;
+}


### PR DESCRIPTION
## Overview\n\nAdds the SubmitIssueReportDto needed for the contributor report issue flow integration. The frontend ReportIssueModal can now submit structured feedback to a backend intake endpoint.\n\n## Related Issue\nCloses #683\n\n## Changes\n- [ADD] SubmitIssueReportDto with userMessage, errorDetails, environment, route fields