### PR TITLE
feat(dashboard): integrate activity feed with live backend API (#675)

### DIFF
--- a/app/frontend/src/app/dashboard/page.tsx
+++ b/app/frontend/src/app/dashboard/page.tsx
@@ -14,69 +14,34 @@ import {
   type UserBid,
   type UserListing,
 } from "@/hooks/marketplaceApi";
-import { mockContractCall, mockFetch } from "@/hooks/mockApi";
-
-type ActivityItem = {
-  id: string;
-  amount: string;
-  asset: string;
-  memo: string;
-  date: string;
-  status: "Pending" | "Settled" | "Privacy Enabled";
-  privacy: "Enabled" | "Public";
-  action: "extend" | "cleanup";
-};
+import {
+  fetchActivityFeed,
+  type ActivityFeedItem,
+} from "@/hooks/activityFeedApi";
 
 type DashboardResponse = {
-  items: ActivityItem[];
+  items: ActivityFeedItem[];
+  degraded: boolean;
 };
-
-const ACTIVITY_ITEMS: ActivityItem[] = [
-  {
-    id: "GD2P...5H2W",
-    amount: "50.00",
-    asset: "USDC",
-    memo: "Project milestone #1",
-    date: "2 mins ago",
-    status: "Pending",
-    privacy: "Enabled",
-    action: "extend",
-  },
-  {
-    id: "GD1R...3K9L",
-    amount: "125.00",
-    asset: "XLM",
-    memo: "Frontend consulting",
-    date: "Jan 20, 14:32",
-    status: "Settled",
-    privacy: "Public",
-    action: "cleanup",
-  },
-  {
-    id: "GC8T...9Q0M",
-    amount: "20.00",
-    asset: "USDC",
-    memo: "Subscription renewal",
-    date: "Jan 19, 09:12",
-    status: "Privacy Enabled",
-    privacy: "Enabled",
-    action: "cleanup",
-  },
-];
 
 function toAnchorId(prefix: string, value: string) {
   return `${prefix}-${value.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
 }
 
-function getStatusClasses(status: ActivityItem["status"]) {
+function getStatusClasses(status: ActivityFeedItem["status"]) {
   switch (status) {
     case "Pending":
-      return "text-warning";
+      return "border-amber-300/40 bg-amber-400/10 text-warning";
     case "Settled":
-      return "text-success";
+      return "border-emerald-300/40 bg-emerald-400/10 text-success";
     default:
-      return "text-brand";
+      return "border-slate-300/40 bg-slate-400/10 text-muted";
   }
+}
+
+function shortAddress(key: string): string {
+  if (key.length <= 12) return key;
+  return `${key.slice(0, 6)}…${key.slice(-4)}`;
 }
 
 const FOCUS_RING_CLASS =
@@ -97,6 +62,7 @@ function DashboardContent() {
   const [userBids, setUserBids] = useState<UserBid[]>([]);
   const [userListings, setUserListings] = useState<UserListing[]>([]);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [feedRetryCount, setFeedRetryCount] = useState(0);
 
   const [metricsData, setMetricsData] = useState<AnalyticsData | null>(null);
   const [metricsLoading, setMetricsLoading] = useState(true);
@@ -121,14 +87,10 @@ function DashboardContent() {
   }, [loadMetrics]);
 
   useEffect(() => {
-    void callApi(() =>
-      mockFetch({
-        items: ACTIVITY_ITEMS,
-      }),
-    );
+    void callApi(() => fetchActivityFeed(20));
     void fetchUserBids().then(setUserBids);
     void fetchUserListings().then(setUserListings);
-  }, [callApi]);
+  }, [callApi, feedRetryCount]);
 
   useEffect(() => {
     if (!statusMessage) {
@@ -210,22 +172,55 @@ function DashboardContent() {
     return null;
   }, [highlightedBid, highlightedListing, highlightedTransaction]);
 
-  const handleExtend = async (id: string) => {
-    await mockContractCall("extend", id);
-    setStatusMessage(`Storage TTL extended for transaction ${id}.`);
-  };
-
-  const handleCleanup = async (id: string) => {
-    await mockContractCall("cleanup", id);
-    setStatusMessage(`Storage deposit reclaimed for transaction ${id}.`);
+  const handleRetry = () => {
+    setFeedRetryCount((prev) => prev + 1);
   };
 
   if (loading) {
-    return <p className="text-muted">Loading dashboard...</p>;
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <div className="mb-4 h-8 w-8 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent mx-auto" />
+          <p className="text-muted">Loading dashboard...</p>
+        </div>
+      </div>
+    );
   }
 
   if (error) {
-    return <p className="text-danger">{error}</p>;
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="max-w-md text-center">
+          <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-500/10 mx-auto">
+            <svg
+              className="h-8 w-8 text-danger"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+              />
+            </svg>
+          </div>
+          <h3 className="text-lg font-semibold text-foreground">
+            Failed to load dashboard
+          </h3>
+          <p className="mt-2 text-sm text-muted">{error}</p>
+          <button
+            type="button"
+            onClick={handleRetry}
+            className="mt-6 rounded-xl bg-indigo-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg transition hover:bg-indigo-400"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -413,129 +408,172 @@ function DashboardContent() {
             <div>
               <h2 className="text-2xl font-semibold text-foreground">Activity Feed</h2>
               <p className="mt-1 text-sm text-muted">
-                Direct payment history, with actions and notification deep links.
+                Live payment history fetched from the Stellar network.
               </p>
             </div>
 
-            <div className="rounded-xl border border-border bg-surface p-2">
-              <label htmlFor="dashboard-range" className="sr-only">
-                Filter activity period
-              </label>
-              <select
-                id="dashboard-range"
-                className={`bg-transparent text-sm font-semibold text-foreground ${FOCUS_RING_CLASS}`}
-                defaultValue="Last 30 Days"
-              >
-                <option>Last 30 Days</option>
-                <option>Yearly</option>
-              </select>
-            </div>
-          </div>
-
-          <div className="overflow-x-auto">
-            <table className="min-w-[700px] w-full text-left">
-              <caption className="sr-only">
-                Recent payment activity with actions to extend TTL or clean up
-                completed records.
-              </caption>
-              <thead>
-                <tr className="border-b border-border text-[10px] font-semibold uppercase tracking-[0.24em] text-muted">
-                  <th className="px-6 py-4 sm:px-10 sm:py-6">Transaction ID</th>
-                  <th className="px-6 py-4 sm:px-10 sm:py-6">Asset</th>
-                  <th className="px-6 py-4 sm:px-10 sm:py-6">Memo / Status</th>
-                  <th className="px-6 py-4 sm:px-10 sm:py-6">Timestamp</th>
-                  <th className="px-6 py-4 text-right sm:px-10 sm:py-6">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-
-              <tbody className="divide-y divide-border">
-                {(data?.items ?? []).map((item, index) => {
-                  const isHighlighted = item.id === highlightedTransaction;
-
-                  return (
-                    <tr
-                      key={item.id}
-                      id={toAnchorId("transaction", item.id)}
-                      tabIndex={-1}
-                      className={`transition ${
-                        isHighlighted
-                          ? "bg-indigo-500/10"
-                          : "hover:bg-surface"
-                      }`}
-                    >
-                      <td className="px-6 py-6 sm:px-10">
-                        <div className="flex items-center gap-3">
-                          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-surface font-mono text-[10px] opacity-70">
-                            #{index + 1}
-                          </span>
-                          <span className="font-mono text-sm text-foreground sm:text-base">
-                            {item.id}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-6 text-lg font-semibold sm:px-10">
-                        {item.amount} {item.asset}
-                      </td>
-                      <td className="px-6 py-6 sm:px-10">
-                        <div className="flex flex-col">
-                          <span className="font-semibold text-foreground">
-                            {item.memo}
-                          </span>
-                          <div className="mt-1 flex items-center gap-2">
-                            <span
-                              className={`text-[10px] font-semibold uppercase tracking-[0.24em] ${getStatusClasses(
-                                item.status,
-                              )}`}
-                            >
-                              {item.status}
-                            </span>
-                            <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-muted">
-                              Privacy {item.privacy}
-                            </span>
-                          </div>
-                        </div>
-                      </td>
-                      <td className="px-6 py-6 text-muted sm:px-10">
-                        {item.date}
-                      </td>
-                      <td className="px-6 py-6 text-right sm:px-10">
-                        {item.action === "extend" ? (
-                          <button
-                            type="button"
-                            onClick={() => void handleExtend(item.id)}
-                            className={`rounded-full bg-indigo-500/10 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.24em] text-brand transition hover:bg-indigo-500 hover:text-white ${FOCUS_RING_CLASS}`}
-                            aria-label={`Extend TTL for transaction ${item.id}`}
-                          >
-                            Extend TTL
-                          </button>
-                        ) : (
-                          <button
-                            type="button"
-                            onClick={() => void handleCleanup(item.id)}
-                            className={`rounded-full bg-red-500/10 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.24em] text-danger transition hover:bg-red-500 hover:text-white ${FOCUS_RING_CLASS}`}
-                            aria-label={`Clean up transaction ${item.id}`}
-                          >
-                            Cleanup
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="bg-surface p-6 text-center sm:p-8">
-            <Link
-              href="/notifications?category=payments"
-              className={`text-sm font-semibold text-muted transition hover:text-foreground ${FOCUS_RING_CLASS}`}
+            <button
+              type="button"
+              onClick={handleRetry}
+              disabled={loading}
+              className={`rounded-xl border border-border bg-surface px-4 py-2 text-sm font-semibold text-muted transition hover:border-indigo-300/40 hover:text-foreground disabled:opacity-50 ${FOCUS_RING_CLASS}`}
+              aria-label="Refresh activity feed"
             >
-              View payment alerts
-            </Link>
+              {loading ? "Refreshing…" : "Refresh"}
+            </button>
           </div>
+
+          {data?.degraded ? (
+            <div className="mx-6 mt-6 rounded-2xl border border-amber-300/30 bg-amber-400/5 p-4 sm:mx-10 sm:mt-10">
+              <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
+                The activity feed is temporarily unavailable. Showing cached or
+                partial data.{" "}
+                <button
+                  type="button"
+                  onClick={handleRetry}
+                  className="underline transition hover:text-amber-800 dark:hover:text-amber-300"
+                >
+                  Retry
+                </button>
+              </p>
+            </div>
+          ) : null}
+
+          {!data || (data.items.length === 0 && !data.degraded) ? (
+            <div className="flex flex-col items-center justify-center px-6 py-16 text-center sm:px-10">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface">
+                <svg
+                  className="h-8 w-8 text-muted"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+                  />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold text-foreground">
+                No activity yet
+              </h3>
+              <p className="mt-2 max-w-md text-sm text-muted">
+                Your recent payments will appear here once transactions are
+                detected on the Stellar network. Create a payment link to get
+                started.
+              </p>
+              <Link
+                href="/generator"
+                className={`mt-6 rounded-xl bg-indigo-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg transition hover:bg-indigo-400 ${FOCUS_RING_CLASS}`}
+              >
+                Create payment link
+              </Link>
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="min-w-[700px] w-full text-left">
+                  <caption className="sr-only">
+                    Recent payment activity from the Stellar network.
+                  </caption>
+                  <thead>
+                    <tr className="border-b border-border text-[10px] font-semibold uppercase tracking-[0.24em] text-muted">
+                      <th className="px-6 py-4 sm:px-10 sm:py-6">Transaction</th>
+                      <th className="px-6 py-4 sm:px-10 sm:py-6">Amount</th>
+                      <th className="px-6 py-4 sm:px-10 sm:py-6">Memo / Status</th>
+                      <th className="px-6 py-4 sm:px-10 sm:py-6">From / To</th>
+                      <th className="px-6 py-4 sm:px-10 sm:py-6">Date</th>
+                    </tr>
+                  </thead>
+
+                  <tbody className="divide-y divide-border">
+                    {(data?.items ?? []).map((item, index) => {
+                      const isHighlighted =
+                        item.id === highlightedTransaction;
+
+                      return (
+                        <tr
+                          key={item.id}
+                          id={toAnchorId("transaction", item.id)}
+                          tabIndex={-1}
+                          className={`transition ${
+                            isHighlighted
+                              ? "bg-indigo-500/10"
+                              : "hover:bg-surface"
+                          }`}
+                        >
+                          <td className="px-6 py-6 sm:px-10">
+                            <div className="flex items-center gap-3">
+                              <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-surface font-mono text-[10px] opacity-70">
+                                #{index + 1}
+                              </span>
+                              <span className="font-mono text-sm text-foreground sm:text-base">
+                                {shortAddress(item.id)}
+                              </span>
+                            </div>
+                          </td>
+                          <td className="px-6 py-6 text-lg font-semibold sm:px-10">
+                            {item.amount} {item.asset}
+                          </td>
+                          <td className="px-6 py-6 sm:px-10">
+                            <div className="flex flex-col gap-1.5">
+                              {item.memo ? (
+                                <span className="font-semibold text-foreground">
+                                  {item.memo}
+                                </span>
+                              ) : (
+                                <span className="text-xs italic text-subtle">
+                                  No memo
+                                </span>
+                              )}
+                              <span
+                                className={`inline-flex w-fit items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.24em] ${getStatusClasses(
+                                  item.status,
+                                )}`}
+                              >
+                                {item.status}
+                              </span>
+                            </div>
+                          </td>
+                          <td className="px-6 py-6 sm:px-10">
+                            <div className="flex flex-col gap-1">
+                              <span className="text-xs text-muted">
+                                From:{" "}
+                                <span className="font-mono text-subtle">
+                                  {shortAddress(item.source)}
+                                </span>
+                              </span>
+                              <span className="text-xs text-muted">
+                                To:{" "}
+                                <span className="font-mono text-subtle">
+                                  {shortAddress(item.destination)}
+                                </span>
+                              </span>
+                            </div>
+                          </td>
+                          <td className="px-6 py-6 text-muted sm:px-10">
+                            {item.date}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="bg-surface p-6 text-center sm:p-8">
+                <Link
+                  href="/notifications?category=payments"
+                  className={`text-sm font-semibold text-muted transition hover:text-foreground ${FOCUS_RING_CLASS}`}
+                >
+                  View payment alerts
+                </Link>
+              </div>
+            </>
+          )}
         </section>
 
         <section className="mt-10 overflow-hidden rounded-3xl border border-border bg-card shadow-2xl backdrop-blur-2xl md:mt-16">

--- a/app/frontend/src/hooks/activityFeedApi.ts
+++ b/app/frontend/src/hooks/activityFeedApi.ts
@@ -1,0 +1,123 @@
+import { getQuickexApiBase } from "@/lib/api";
+import { resolvePublicKey } from "@/lib/publicKey";
+
+/**
+ * Activity feed item as displayed in the dashboard.
+ * Mirrors fields from the backend TransactionItemDto.
+ */
+export interface ActivityFeedItem {
+  id: string;
+  amount: string;
+  asset: string;
+  memo: string | null;
+  date: string;
+  status: "Settled" | "Pending";
+  source: string;
+  destination: string;
+  timestamp: string; // raw ISO for sorting
+}
+
+interface BackendTransactionItem {
+  amount: string;
+  asset: string;
+  memo?: string;
+  timestamp: string;
+  source: string;
+  destination: string;
+  status: "Success" | "Pending";
+  txHash: string;
+  pagingToken: string;
+}
+
+interface BackendResponse {
+  items: BackendTransactionItem[];
+}
+
+function simplifyAsset(asset: string): string {
+  const colonIdx = asset.indexOf(":");
+  return colonIdx > -1 ? asset.slice(0, colonIdx) : asset;
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    const date = new Date(iso);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+
+    if (diffMins < 1) return "Just now";
+    if (diffMins < 60) return `${diffMins} min ago`;
+
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 7) return `${diffDays}d ago`;
+
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function mapToActivityItem(item: BackendTransactionItem): ActivityFeedItem {
+  return {
+    id: item.txHash,
+    amount: item.amount,
+    asset: simplifyAsset(item.asset),
+    memo: item.memo ?? null,
+    date: formatTimestamp(item.timestamp),
+    status: item.status === "Success" ? "Settled" : "Pending",
+    source: item.source,
+    destination: item.destination,
+    timestamp: item.timestamp,
+  };
+}
+
+export interface ActivityFeedResponse {
+  items: ActivityFeedItem[];
+  /** True when the backend returned no data or the request failed gracefully */
+  degraded: boolean;
+}
+
+/**
+ * Fetch the dashboard activity feed from the backend.
+ * Falls back to an empty list on failure with `degraded: true`.
+ */
+export async function fetchActivityFeed(
+  limit = 20,
+): Promise<ActivityFeedResponse> {
+  const publicKey = resolvePublicKey();
+  const url = new URL(`${getQuickexApiBase()}/payments/recent`);
+  url.searchParams.set("address", publicKey);
+  url.searchParams.set("limit", String(limit));
+
+  try {
+    const res = await fetch(url.toString(), { method: "GET" });
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        // Client error (e.g. bad public key) — return empty, not degraded
+        console.warn(
+          `Activity feed: client error ${res.status}, returning empty list`,
+        );
+        return { items: [], degraded: false };
+      }
+      throw new Error(
+        `Activity feed request failed with status ${res.status}`,
+      );
+    }
+
+    const data = (await res.json()) as BackendResponse;
+    return {
+      items: (data.items ?? []).map(mapToActivityItem),
+      degraded: false,
+    };
+  } catch (error) {
+    console.warn("Activity feed: backend unavailable, returning empty list:", error);
+    return { items: [], degraded: true };
+  }
+}

--- a/app/frontend/src/hooks/analyticsApi.ts
+++ b/app/frontend/src/hooks/analyticsApi.ts
@@ -1,5 +1,6 @@
 import i18n from "i18next";
 import { getQuickexApiBase } from "@/lib/api";
+import { resolvePublicKey } from "@/lib/publicKey";
 
 export type DateRange = "24h" | "7d" | "30d" | "all";
 
@@ -65,15 +66,6 @@ type ApiReport = {
 };
 
 const analyticsCache: Partial<Record<DateRange, AnalyticsData>> = {};
-const DEFAULT_PUBLIC_KEY =
-  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
-const PUBLIC_KEY_STORAGE_CANDIDATES = [
-  "quickex.publicKey",
-  "quickex.walletPublicKey",
-  "walletPublicKey",
-  "publicKey",
-];
 const ASSET_COLORS: Record<string, string> = {
   USDC: "#6366f1",
   XLM: "#8b5cf6",
@@ -107,24 +99,6 @@ function rangeToWindow(range: DateRange): {
     endDate: end.toISOString(),
     interval,
   };
-}
-
-function resolveAnalyticsPublicKey(): string {
-  if (typeof window !== "undefined") {
-    for (const key of PUBLIC_KEY_STORAGE_CANDIDATES) {
-      const value = window.localStorage.getItem(key)?.trim();
-      if (value && PUBLIC_KEY_REGEX.test(value)) {
-        return value;
-      }
-    }
-  }
-
-  const fromEnv = process.env.NEXT_PUBLIC_QUICKEX_ANALYTICS_PUBLIC_KEY?.trim();
-  if (fromEnv && PUBLIC_KEY_REGEX.test(fromEnv)) {
-    return fromEnv;
-  }
-
-  return DEFAULT_PUBLIC_KEY;
 }
 
 function labelForPeriod(period: string): string {
@@ -217,7 +191,7 @@ export async function fetchAnalytics(range: DateRange): Promise<AnalyticsData> {
     return Promise.resolve(analyticsCache[range] as AnalyticsData);
   }
 
-  const publicKey = resolveAnalyticsPublicKey();
+  const publicKey = resolvePublicKey();
   const { startDate, endDate, interval } = rangeToWindow(range);
   const url = new URL(`${getQuickexApiBase()}/analytics/report`);
   url.searchParams.set("publicKey", publicKey);
@@ -247,7 +221,7 @@ export async function exportAnalyticsReport(
   format: "csv" | "pdf",
   reportType: "tax" | "accounting" = "accounting",
 ): Promise<void> {
-  const publicKey = resolveAnalyticsPublicKey();
+  const publicKey = resolvePublicKey();
   const { startDate, endDate, interval } = rangeToWindow(range);
   const url = new URL(`${getQuickexApiBase()}/analytics/export`);
   url.searchParams.set("publicKey", publicKey);

--- a/app/frontend/src/lib/publicKey.ts
+++ b/app/frontend/src/lib/publicKey.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared public key resolution for frontend API calls.
+ * Used by analytics and activity feed hooks to resolve the user's
+ * Stellar public key from localStorage or environment variables.
+ */
+
+const DEFAULT_PUBLIC_KEY =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+const PUBLIC_KEY_STORAGE_CANDIDATES = [
+  "quickex.publicKey",
+  "quickex.walletPublicKey",
+  "walletPublicKey",
+  "publicKey",
+];
+
+/**
+ * Resolve the user's Stellar public key from available sources:
+ * 1. localStorage (browser wallets store the key under known keys)
+ * 2. Environment variable (NEXT_PUBLIC_QUICKEX_ANALYTICS_PUBLIC_KEY)
+ * 3. Fallback to a zero-value default key
+ */
+export function resolvePublicKey(): string {
+  if (typeof window !== "undefined") {
+    for (const key of PUBLIC_KEY_STORAGE_CANDIDATES) {
+      const value = window.localStorage.getItem(key)?.trim();
+      if (value && PUBLIC_KEY_REGEX.test(value)) {
+        return value;
+      }
+    }
+  }
+
+  const fromEnv =
+    process.env.NEXT_PUBLIC_QUICKEX_ANALYTICS_PUBLIC_KEY?.trim();
+  if (fromEnv && PUBLIC_KEY_REGEX.test(fromEnv)) {
+    return fromEnv;
+  }
+
+  return DEFAULT_PUBLIC_KEY;
+}


### PR DESCRIPTION
Replace mocked ACTIVITY_ITEMS with real data from GET /payments/recent endpoint.

## What changed

### New files
- `app/frontend/src/hooks/activityFeedApi.ts` — API hook that fetches live payment activity from the backend, resolving the user Stellar public key from localStorage or environment variables. Returns structured data with a `degraded` flag when the backend is unreachable.

- `app/frontend/src/lib/publicKey.ts` — Shared utility for resolving a Stellar public key across the frontend. Extracted from the duplicated resolution logic in `analyticsApi.ts` and reused by the new activity feed hook.

### Modified files
- `app/frontend/src/app/dashboard/page.tsx`
  - Removed hardcoded `ACTIVITY_ITEMS` mock array.
  - Removed `mockFetch` and `mockContractCall` imports.
  - Integrated `fetchActivityFeed()` with refresh support.
  - Simplified the activity table columns: Transaction (tx hash), Amount, Memo/Status (with badge), From/To (shortened keys), Date.
  - Removed the mock-only privacy badge and contract action buttons.
  - Added polished empty state with clock icon and CTA link to generator.
  - Added degraded-state warning banner with retry when the backend is unavailable.
  - Added full error state with icon, message, and retry button.
  - Added spinner to the loading state.

- `app/frontend/src/hooks/analyticsApi.ts`
  - Replaced inline `resolveAnalyticsPublicKey()` with the shared `resolvePublicKey()` from `@/lib/publicKey`.

## Acceptance criteria (from #675)
- [x] Dashboard activity uses live backend data
- [x] Empty/loading/error states are clear and polished
- [x] No mock records remain in the dashboard activity list
- [x] The activity feed endpoint is integrated and falls back gracefully

## CI checks passed locally
- ESLint: 0 errors, 0 warnings
- TypeScript: clean (noEmit)
- Build: successful (Next.js 15.5.9)

## Screenshots
> (populated and empty state screenshots to be attached)

closes #675 