### PR TITLE
feat: add public runtime config bootstrap endpoint

### DIFF
--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -57,6 +57,7 @@ import { AbuseSignalMiddleware } from "./abuse-signals/abuse-signal.middleware";
 import { PreviewScopeModule } from "./preview-scope/preview-scope.module";
 import { PreviewScopeMiddleware } from "./preview-scope/preview-scope.middleware";
 import { BranchPreviewModule } from "./branch-preview/branch-preview.module";
+import { RuntimeConfigModule } from "./runtime-config/runtime-config.module";
 import { TransactionTimelineModule } from "./transaction-timeline/transaction-timeline.module";
 
 type AppImport =
@@ -100,8 +101,9 @@ FeatureFlagsModule,
 PrivacyModule,
 SorobanToolingModule,
 EnvironmentParityModule,
-  BranchPreviewModule,
-  IndexerLagModule,
+    BranchPreviewModule,
+    RuntimeConfigModule,
+    IndexerLagModule,
 SupportBundleModule,
 OperationsModule,
     RcValidationModule,

--- a/app/backend/src/config/app-config.service.ts
+++ b/app/backend/src/config/app-config.service.ts
@@ -124,6 +124,13 @@ export class AppConfigService {
   }
 
   /**
+   * Public API base URL for client bootstrapping.
+   */
+  get publicApiUrl(): string | undefined {
+    return this.configService.get("PUBLIC_API_URL", { infer: true });
+  }
+
+  /**
    * Parsed list of explicitly allowed CORS origins.
    * Sourced from the CORS_ALLOWED_ORIGINS env var (comma-separated).
    */

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -91,6 +91,12 @@ export const envSchema = Joi.object({
     .description("Node environment"),
 
   // CORS configuration
+  PUBLIC_API_URL: Joi.string()
+    .uri({ scheme: ["http", "https"] })
+    .empty("")
+    .optional()
+    .description("Public API base URL exposed by the runtime config endpoint for client bootstrapping"),
+
   CORS_ALLOWED_ORIGINS: Joi.string()
     .empty("")
     .optional()
@@ -439,6 +445,8 @@ export interface EnvConfig {
   STELLAR_SECRET_KEY?: string;
   STELLAR_PUBLIC_KEY?: string;
   NODE_ENV: "development" | "production" | "test";
+  PUBLIC_API_URL?: string;
+
   CORS_ALLOWED_ORIGINS?: string;
   CORS_VERCEL_PROJECT?: string;
   MAX_USERNAMES_PER_WALLET?: number;

--- a/app/backend/src/runtime-config/dto/runtime-config.dto.ts
+++ b/app/backend/src/runtime-config/dto/runtime-config.dto.ts
@@ -1,0 +1,109 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class NetworkConfigDto {
+  @ApiProperty({ example: 'testnet', enum: ['testnet', 'mainnet'] })
+  network: 'testnet' | 'mainnet';
+
+  @ApiProperty({ example: 'Test SDF Network ; September 2015' })
+  networkPassphrase: string;
+
+  @ApiProperty({ example: 'https://horizon-testnet.stellar.org' })
+  horizonUrl: string;
+
+  @ApiProperty({ example: 'https://soroban-testnet.stellar.org' })
+  sorobanRpcUrl: string;
+
+  @ApiProperty({ example: ['https://soroban-testnet.stellar.org'] })
+  sorobanRpcUrls: string[];
+
+  @ApiProperty({ example: 'https://stellar.expert/explorer/testnet' })
+  explorerUrl: string;
+}
+
+export class ContractEntryDto {
+  @ApiProperty({ example: 'CD2J6K7T3YJ77QXZP3EXAMPLE' })
+  contractId: string;
+
+  @ApiProperty({ example: '0xabcdef1234567890' })
+  wasmHash: string;
+
+  @ApiProperty({ example: 1 })
+  version: number;
+
+  @ApiProperty({ example: '1.0.0' })
+  schemaVersion: string;
+}
+
+export class FeatureFlagEntryDto {
+  @ApiProperty({ example: 'bulk_invoicing_v2' })
+  key: string;
+
+  @ApiProperty({ example: 'Bulk Invoicing v2' })
+  name: string;
+
+  @ApiProperty({ example: true })
+  enabled: boolean;
+
+  @ApiProperty({ example: false })
+  killSwitch: boolean;
+
+  @ApiProperty({ example: 100, minimum: 0, maximum: 100 })
+  rolloutPercentage: number;
+}
+
+export class PreviewMetadataDto {
+  @ApiProperty({ example: 'pr-123' })
+  scopeId: string;
+
+  @ApiPropertyOptional({ example: 'feature/new-ui' })
+  branchName?: string;
+
+  @ApiProperty({ example: '2026-07-30T00:38:00.000Z' })
+  expiresAt: string;
+
+  @ApiProperty({ example: true })
+  valid: boolean;
+}
+
+export class RuntimeConfigResponseDto {
+  @ApiProperty({ example: 'production', enum: ['development', 'staging', 'production', 'test'] })
+  environment: string;
+
+  @ApiProperty({ type: NetworkConfigDto })
+  network: NetworkConfigDto;
+
+  @ApiProperty({ example: 'https://api.quickex.to' })
+  apiUrl: string;
+
+  @ApiProperty({ example: '0.1.0' })
+  appVersion: string;
+
+  @ApiProperty({ example: '0.1.0' })
+  minAppVersion: string;
+
+  @ApiProperty({
+    type: Object,
+    additionalProperties: { type: ContractEntryDto },
+    example: {
+      quickex: {
+        contractId: 'CD2J6K7T3YJ77QXZP3EXAMPLE',
+        wasmHash: '0xabcdef1234567890',
+        version: 1,
+        schemaVersion: '1.0.0',
+      },
+    },
+  })
+  contracts: Record<string, ContractEntryDto>;
+
+  @ApiProperty({ type: [FeatureFlagEntryDto] })
+  featureFlags: FeatureFlagEntryDto[];
+
+  @ApiPropertyOptional({ type: PreviewMetadataDto })
+  preview?: PreviewMetadataDto;
+
+  @ApiProperty({ example: '2026-07-29T00:38:00.000Z' })
+  generatedAt: string;
+
+  @ApiProperty({ example: 'W/"runtime-config-1"' })
+  etag: string;
+}

--- a/app/backend/src/runtime-config/dto/runtime-config.dto.ts
+++ b/app/backend/src/runtime-config/dto/runtime-config.dto.ts
@@ -82,8 +82,8 @@ export class RuntimeConfigResponseDto {
   minAppVersion: string;
 
   @ApiProperty({
-    type: Object,
-    additionalProperties: { type: ContractEntryDto },
+    type: 'object',
+    description: 'Map of contract name to deployment metadata',
     example: {
       quickex: {
         contractId: 'CD2J6K7T3YJ77QXZP3EXAMPLE',

--- a/app/backend/src/runtime-config/runtime-config.controller.ts
+++ b/app/backend/src/runtime-config/runtime-config.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  Get,
+  Headers,
+  Req,
+  Res,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request, Response } from 'express';
+
+import { RuntimeConfigResponseDto } from './dto/runtime-config.dto';
+import { RuntimeConfigService } from './runtime-config.service';
+
+@ApiTags('runtime-config')
+@Controller('v1/runtime-config')
+export class RuntimeConfigController {
+  constructor(private readonly runtimeConfigService: RuntimeConfigService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Public runtime configuration bootstrap',
+    description:
+      'Returns environment-aware API, network, and contract metadata for web and mobile clients. ' +
+      'Set X-Preview-Scope header to include preview environment metadata. ' +
+      'Supports ETag-based caching via If-None-Match header.',
+  })
+  @ApiResponse({
+    status: 200,
+    type: RuntimeConfigResponseDto,
+    description: 'Runtime configuration for the active environment',
+  })
+  @ApiResponse({
+    status: 304,
+    description: 'Not Modified — config unchanged since provided ETag',
+  })
+  async getConfig(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+    @Headers('x-preview-scope') previewScope?: string,
+  ): Promise<RuntimeConfigResponseDto | void> {
+    const config = await this.runtimeConfigService.getConfig(previewScope);
+    this.runtimeConfigService.validateConfig(config);
+
+    res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
+    res.setHeader('ETag', config.etag);
+
+    const clientEtag = req.headers['if-none-match'];
+    if (clientEtag && clientEtag === config.etag) {
+      res.status(304);
+      return;
+    }
+
+    return config;
+  }
+}

--- a/app/backend/src/runtime-config/runtime-config.module.ts
+++ b/app/backend/src/runtime-config/runtime-config.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { ContractsModule } from '../contracts/contracts.module';
+import { FeatureFlagsModule } from '../feature-flags/feature-flags.module';
+import { PreviewScopeModule } from '../preview-scope/preview-scope.module';
+import { RuntimeConfigController } from './runtime-config.controller';
+import { RuntimeConfigService } from './runtime-config.service';
+
+@Module({
+  imports: [FeatureFlagsModule, ContractsModule, PreviewScopeModule],
+  controllers: [RuntimeConfigController],
+  providers: [RuntimeConfigService],
+  exports: [RuntimeConfigService],
+})
+export class RuntimeConfigModule {}

--- a/app/backend/src/runtime-config/runtime-config.service.ts
+++ b/app/backend/src/runtime-config/runtime-config.service.ts
@@ -1,0 +1,170 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'crypto';
+
+import { AppConfigService } from '../config';
+import { ContractRegistryService } from '../contracts/contract-registry.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { PreviewScopeService } from '../preview-scope/preview-scope.service';
+import {
+  RuntimeConfigResponseDto,
+  NetworkConfigDto,
+  ContractEntryDto,
+  FeatureFlagEntryDto,
+  PreviewMetadataDto,
+} from './dto/runtime-config.dto';
+
+@Injectable()
+export class RuntimeConfigService {
+  private readonly logger = new Logger(RuntimeConfigService.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly appConfigService: AppConfigService,
+    private readonly featureFlagsService: FeatureFlagsService,
+    private readonly contractRegistryService: ContractRegistryService,
+    private readonly previewScopeService: PreviewScopeService,
+  ) {}
+
+  async getConfig(previewScope?: string): Promise<RuntimeConfigResponseDto> {
+    const environment = this.resolveEnvironmentName();
+
+    const [network, contracts, featureFlagsResponse, preview] = await Promise.all([
+      this.buildNetworkConfig(),
+      this.buildContractsConfig(),
+      this.loadFeatureFlags(environment),
+      previewScope ? this.buildPreviewMetadata(previewScope) : Promise.resolve(undefined),
+    ]);
+
+    const featureFlags: FeatureFlagEntryDto[] = featureFlagsResponse.flags.map((flag) => ({
+      key: flag.key,
+      name: flag.name,
+      enabled: flag.enabled,
+      killSwitch: flag.killSwitch,
+      rolloutPercentage: flag.rolloutPercentage,
+    }));
+
+    const contractsConfig = contracts ?? {};
+
+    const etag = this.buildEtag(network, contractsConfig, featureFlags, preview);
+
+    return {
+      environment,
+      network,
+      apiUrl: this.resolveApiUrl(),
+      appVersion: '0.1.0',
+      minAppVersion: '0.1.0',
+      contracts: contractsConfig,
+      featureFlags,
+      preview,
+      generatedAt: new Date().toISOString(),
+      etag,
+    };
+  }
+
+  private async buildNetworkConfig(): Promise<NetworkConfigDto> {
+    const stellar = this.configService.get<{
+      network: 'testnet' | 'mainnet';
+      networkPassphrase: string;
+      horizonBaseUrl: string;
+      sorobanRpcUrl: string;
+      sorobanRpcUrls: string[];
+      explorerUrl: string;
+    }>('stellar');
+
+    return {
+      network: stellar?.network ?? 'testnet',
+      networkPassphrase: stellar?.networkPassphrase ?? 'Test SDF Network ; September 2015',
+      horizonUrl: stellar?.horizonBaseUrl ?? 'https://horizon-testnet.stellar.org',
+      sorobanRpcUrl: stellar?.sorobanRpcUrl ?? 'https://soroban-testnet.stellar.org',
+      sorobanRpcUrls: stellar?.sorobanRpcUrls ?? ['https://soroban-testnet.stellar.org'],
+      explorerUrl: stellar?.explorerUrl ?? 'https://stellar.expert/explorer/testnet',
+    };
+  }
+
+  private async buildContractsConfig(): Promise<Record<string, ContractEntryDto>> {
+    try {
+      const registry = await this.contractRegistryService.getRegistry();
+      const entries: Record<string, ContractEntryDto> = {};
+      for (const [name, data] of Object.entries(registry.data)) {
+        const typed = data as Record<string, unknown>;
+        entries[name] = {
+          contractId: String(typed.id ?? ''),
+          wasmHash: String(typed.wasmHash ?? ''),
+          version: Number(typed.version ?? 0),
+          schemaVersion: String(typed.schemaVersion ?? '1.0.0'),
+        };
+      }
+      return entries;
+    } catch (error) {
+      this.logger.warn(`Contract registry unavailable, returning empty: ${(error as Error).message}`);
+      return {};
+    }
+  }
+
+  private async loadFeatureFlags(environment: string) {
+    try {
+      return await this.featureFlagsService.getSnapshot(environment);
+    } catch (error) {
+      this.logger.warn(`Feature flags unavailable, returning empty: ${(error as Error).message}`);
+      return { flags: [], metadata: { source: 'bootstrap' as const, storeAvailable: false, flagCount: 0, sensitiveFlagCount: 0, timestamp: new Date().toISOString() } };
+    }
+  }
+
+  private async buildPreviewMetadata(scopeId: string): Promise<PreviewMetadataDto | undefined> {
+    try {
+      const scope = await this.previewScopeService.getScope(scopeId);
+      if (!scope) return undefined;
+
+      const now = new Date();
+      const expiresAt = new Date(scope.expires_at);
+      return {
+        scopeId: scope.scope_id,
+        branchName: scope.branch_name,
+        expiresAt: scope.expires_at,
+        valid: expiresAt > now,
+      };
+    } catch (error) {
+      this.logger.warn(`Preview scope lookup failed for ${scopeId}: ${(error as Error).message}`);
+      return undefined;
+    }
+  }
+
+  private resolveEnvironmentName(): string {
+    return this.appConfigService.environmentName ?? this.appConfigService.nodeEnv;
+  }
+
+  private resolveApiUrl(): string {
+    const configured = this.appConfigService.publicApiUrl;
+    if (configured) return configured;
+
+    if (this.appConfigService.isMainnet) return 'https://api.quickex.to';
+    if (this.appConfigService.isStaging) return 'https://staging-api.quickex.to';
+    return 'https://testnet-api.quickex.to';
+  }
+
+  private buildEtag(
+    network: NetworkConfigDto,
+    contracts: Record<string, ContractEntryDto>,
+    flags: FeatureFlagEntryDto[],
+    preview: PreviewMetadataDto | undefined,
+  ): string {
+    const stable = JSON.stringify({
+      n: network.network,
+      c: Object.keys(contracts).sort().map((k) => `${k}:${contracts[k].contractId}`).join(','),
+      f: flags.map((f) => `${f.key}:${f.enabled}`).sort().join(','),
+      p: preview?.scopeId,
+    });
+    const hash = createHash('sha256').update(stable).digest('hex').slice(0, 16);
+    return `W/"runtime-config-${hash}"`;
+  }
+
+  validateConfig(config: RuntimeConfigResponseDto): void {
+    if (!config.network.network) {
+      this.logger.warn('Runtime config missing network - using testnet default');
+    }
+    if (!config.apiUrl) {
+      this.logger.warn('Runtime config missing apiUrl - clients may be unable to reach API');
+    }
+  }
+}

--- a/app/backend/src/runtime-config/runtime-config.service.unit.spec.ts
+++ b/app/backend/src/runtime-config/runtime-config.service.unit.spec.ts
@@ -1,0 +1,425 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+
+import { AppConfigService } from '../config';
+import { ContractRegistryService } from '../contracts/contract-registry.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { PreviewScopeService } from '../preview-scope/preview-scope.service';
+import { RuntimeConfigService } from './runtime-config.service';
+
+describe('RuntimeConfigService', () => {
+  let service: RuntimeConfigService;
+  let mockAppConfigService: jest.Mocked<Partial<AppConfigService>>;
+  let mockConfigService: jest.Mocked<Partial<ConfigService>>;
+  let mockFeatureFlagsService: jest.Mocked<Partial<FeatureFlagsService>>;
+  let mockContractRegistryService: jest.Mocked<Partial<ContractRegistryService>>;
+  let mockPreviewScopeService: jest.Mocked<Partial<PreviewScopeService>>;
+
+  beforeEach(async () => {
+    mockConfigService = {
+      get: jest.fn(),
+    };
+
+    mockAppConfigService = {
+      network: 'testnet',
+      nodeEnv: 'test',
+      environmentName: undefined,
+      isMainnet: false,
+      isStaging: false,
+      publicApiUrl: undefined,
+    };
+
+    mockFeatureFlagsService = {
+      getSnapshot: jest.fn(),
+    };
+
+    mockContractRegistryService = {
+      getRegistry: jest.fn(),
+    };
+
+    mockPreviewScopeService = {
+      getScope: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RuntimeConfigService,
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: AppConfigService, useValue: mockAppConfigService },
+        { provide: FeatureFlagsService, useValue: mockFeatureFlagsService },
+        { provide: ContractRegistryService, useValue: mockContractRegistryService },
+        { provide: PreviewScopeService, useValue: mockPreviewScopeService },
+      ],
+    }).compile();
+
+    service = module.get<RuntimeConfigService>(RuntimeConfigService);
+    jest.clearAllMocks();
+
+    mockConfigService.get!.mockImplementation((key: string) => {
+      if (key === 'stellar') {
+        return {
+          network: 'testnet',
+          networkPassphrase: 'Test SDF Network ; September 2015',
+          horizonBaseUrl: 'https://horizon-testnet.stellar.org',
+          sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+          sorobanRpcUrls: ['https://soroban-testnet.stellar.org'],
+          explorerUrl: 'https://stellar.expert/explorer/testnet',
+        };
+      }
+      return undefined;
+    });
+  });
+
+  // ── Shared / Testnet Environment ─────────────────────────────────────────
+
+  it('returns complete config for shared testnet environment', async () => {
+    mockFeatureFlagsService.getSnapshot!.mockResolvedValue({
+      metadata: {
+        source: 'store',
+        storeAvailable: true,
+        flagCount: 2,
+        sensitiveFlagCount: 0,
+        timestamp: new Date().toISOString(),
+      },
+      flags: [
+        {
+          key: 'bulk_invoicing_v2',
+          name: 'Bulk Invoicing v2',
+          description: '',
+          enabled: true,
+          killSwitch: false,
+          rolloutPercentage: 100,
+          environments: ['development', 'test', 'production'],
+          updatedAt: new Date().toISOString(),
+          updatedBy: 'bootstrap',
+        },
+        {
+          key: 'testnet.contract_writes',
+          name: 'Testnet Contract Writes',
+          description: '',
+          enabled: true,
+          killSwitch: false,
+          rolloutPercentage: 100,
+          environments: ['development', 'test', 'production'],
+          updatedAt: new Date().toISOString(),
+          updatedBy: 'bootstrap',
+        },
+      ],
+    });
+
+    mockContractRegistryService.getRegistry!.mockResolvedValue({
+      network: 'testnet',
+      authoritative: true,
+      version: 2,
+      etag: 'W/"contract-registry-testnet-2"',
+      data: {
+        quickex: {
+          id: 'CD2J6K7T3YJ77QXZP3EXAMPLE',
+          wasmHash: '0xabcdef1234567890',
+          version: 1,
+          schemaVersion: '1.0.0',
+          networkPassphrase: 'Test SDF Network ; September 2015',
+          deploymentId: 'deploy-001',
+          initParams: {},
+          metadata: {},
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    const config = await service.getConfig();
+
+    expect(config.environment).toBe('test');
+    expect(config.network.network).toBe('testnet');
+    expect(config.network.networkPassphrase).toBe('Test SDF Network ; September 2015');
+    expect(config.network.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+    expect(config.network.sorobanRpcUrl).toBe('https://soroban-testnet.stellar.org');
+    expect(config.network.sorobanRpcUrls).toHaveLength(1);
+    expect(config.network.explorerUrl).toContain('/testnet');
+
+    expect(config.contracts).toHaveProperty('quickex');
+    expect(config.contracts.quickex.contractId).toBe('CD2J6K7T3YJ77QXZP3EXAMPLE');
+
+    expect(config.featureFlags).toHaveLength(2);
+    expect(config.featureFlags[0].key).toBe('bulk_invoicing_v2');
+    expect(config.featureFlags[0].enabled).toBe(true);
+
+    expect(config.appVersion).toBe('0.1.0');
+    expect(config.minAppVersion).toBe('0.1.0');
+    expect(config.generatedAt).toBeDefined();
+    expect(config.etag).toMatch(/^W\/"runtime-config-/);
+  });
+
+  // ── Preview Environment ──────────────────────────────────────────────────
+
+  it('includes preview metadata when preview scope is provided', async () => {
+    mockFeatureFlagsService.getSnapshot!.mockResolvedValue({
+      metadata: {
+        source: 'bootstrap',
+        storeAvailable: false,
+        flagCount: 1,
+        sensitiveFlagCount: 0,
+        timestamp: new Date().toISOString(),
+        environment: 'staging',
+      },
+      flags: [
+        {
+          key: 'bulk_invoicing_v2',
+          name: 'Bulk Invoicing v2',
+          description: '',
+          enabled: true,
+          killSwitch: false,
+          rolloutPercentage: 100,
+          environments: ['development', 'test', 'production'],
+          updatedAt: new Date().toISOString(),
+          updatedBy: 'bootstrap',
+        },
+      ],
+    });
+
+    mockContractRegistryService.getRegistry!.mockResolvedValue({
+      network: 'testnet',
+      authoritative: true,
+      version: 1,
+      etag: 'W/"contract-registry-testnet-1"',
+      data: {},
+    });
+
+    mockAppConfigService.environmentName = 'staging';
+    mockAppConfigService.isStaging = true;
+    mockAppConfigService.publicApiUrl = 'https://preview-api.quickex.to';
+
+    const futureDate = new Date(Date.now() + 3600000).toISOString();
+    mockPreviewScopeService.getScope!.mockResolvedValue({
+      scope_id: 'pr-123',
+      branch_name: 'feature/new-ui',
+      expires_at: futureDate,
+      owner_public_key: 'GABCDEF123',
+      github_pr_url: 'https://github.com/owner/repo/pull/123',
+      created_at: new Date().toISOString(),
+    });
+
+    const config = await service.getConfig('pr-123');
+
+    expect(config.environment).toBe('staging');
+    expect(config.apiUrl).toBe('https://preview-api.quickex.to');
+    expect(config.preview).toBeDefined();
+    expect(config.preview!.scopeId).toBe('pr-123');
+    expect(config.preview!.branchName).toBe('feature/new-ui');
+    expect(config.preview!.valid).toBe(true);
+    expect(config.preview!.expiresAt).toBe(futureDate);
+
+    expect(config.etag).toMatch(/^W\/"runtime-config-/);
+  });
+
+  // ── Minimal / Fallback Environment ───────────────────────────────────────
+
+  it('returns minimal config with fallbacks when services are unavailable', async () => {
+    mockFeatureFlagsService.getSnapshot!.mockRejectedValue(new Error('feature flag store offline'));
+    mockContractRegistryService.getRegistry!.mockRejectedValue(new Error('contract registry offline'));
+
+    const config = await service.getConfig();
+
+    expect(config.network.network).toBe('testnet');
+    expect(config.contracts).toEqual({});
+    expect(config.featureFlags).toEqual([]);
+    expect(config.preview).toBeUndefined();
+    expect(config.etag).toBeDefined();
+  });
+
+  it('returns minimal config with all field defaults when stellar config is missing', async () => {
+    mockConfigService.get!.mockReturnValue(undefined);
+    mockFeatureFlagsService.getSnapshot!.mockRejectedValue(new Error('offline'));
+    mockContractRegistryService.getRegistry!.mockRejectedValue(new Error('offline'));
+
+    const config = await service.getConfig();
+
+    expect(config.network.network).toBe('testnet');
+    expect(config.network.networkPassphrase).toBe('Test SDF Network ; September 2015');
+    expect(config.network.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+    expect(config.network.sorobanRpcUrl).toBe('https://soroban-testnet.stellar.org');
+    expect(config.contracts).toEqual({});
+    expect(config.featureFlags).toEqual([]);
+  });
+
+  // ── Sensitive Value Exclusion ────────────────────────────────────────────
+
+  it('does not expose sensitive fields like secret keys or API keys', async () => {
+    mockFeatureFlagsService.getSnapshot!.mockResolvedValue({
+      metadata: {
+        source: 'bootstrap',
+        storeAvailable: false,
+        flagCount: 0,
+        sensitiveFlagCount: 0,
+        timestamp: new Date().toISOString(),
+      },
+      flags: [],
+    });
+
+    mockContractRegistryService.getRegistry!.mockResolvedValue({
+      network: 'testnet',
+      authoritative: true,
+      version: 1,
+      etag: 'W/"contract-registry-testnet-1"',
+      data: {},
+    });
+
+    const config = await service.getConfig();
+
+    const serialized = JSON.stringify(config);
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('api_key');
+    expect(serialized).not.toContain('api-key');
+    expect(serialized).not.toContain('private_key');
+    expect(serialized).not.toContain('SENDGRID');
+    expect(serialized).not.toContain('SUPABASE_SERVICE_ROLE');
+    expect(serialized).not.toContain('stellar_secret');
+    expect(config).not.toHaveProperty('sentry');
+    expect(config).not.toHaveProperty('database');
+    expect(config).not.toHaveProperty('secrets');
+  });
+
+  // ── ETag Consistency ─────────────────────────────────────────────────────
+
+  it('produces consistent ETags for identical config', async () => {
+    mockFeatureFlagsService.getSnapshot!.mockResolvedValue({
+      metadata: {
+        source: 'store',
+        storeAvailable: true,
+        flagCount: 1,
+        sensitiveFlagCount: 0,
+        timestamp: new Date().toISOString(),
+      },
+      flags: [
+        {
+          key: 'test_flag',
+          name: 'Test Flag',
+          description: '',
+          enabled: true,
+          killSwitch: false,
+          rolloutPercentage: 100,
+          environments: ['test'],
+          updatedAt: new Date().toISOString(),
+          updatedBy: 'bootstrap',
+        },
+      ],
+    });
+
+    mockContractRegistryService.getRegistry!.mockResolvedValue({
+      network: 'testnet',
+      authoritative: true,
+      version: 1,
+      etag: 'W/"contract-registry-testnet-1"',
+      data: {
+        test_contract: {
+          id: 'CTEST123',
+          wasmHash: '0xhash',
+          version: 1,
+          schemaVersion: '1.0.0',
+          networkPassphrase: 'Test SDF Network ; September 2015',
+          deploymentId: 'deploy-001',
+          initParams: {},
+          metadata: {},
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    const configA = await service.getConfig();
+    const configB = await service.getConfig();
+
+    expect(configA.etag).toBe(configB.etag);
+    expect(configA.network.network).toBe(configB.network.network);
+    expect(configA.contracts.test_contract.contractId).toBe(configB.contracts.test_contract.contractId);
+  });
+
+  // ── Mainnet Environment ──────────────────────────────────────────────────
+
+  it('returns mainnet config when network is mainnet', async () => {
+    mockConfigService.get!.mockImplementation((key: string) => {
+      if (key === 'stellar') {
+        return {
+          network: 'mainnet',
+          networkPassphrase: 'Public Global Stellar Network ; September 2015',
+          horizonBaseUrl: 'https://horizon.stellar.org',
+          sorobanRpcUrl: 'https://soroban-rpc.mainnet.stellar.gateway.fm',
+          sorobanRpcUrls: ['https://soroban-rpc.mainnet.stellar.gateway.fm'],
+          explorerUrl: 'https://stellar.expert/explorer/public',
+        };
+      }
+      return undefined;
+    });
+
+    mockAppConfigService.network = 'mainnet';
+    mockAppConfigService.isMainnet = true;
+    mockAppConfigService.publicApiUrl = 'https://api.quickex.to';
+
+    mockFeatureFlagsService.getSnapshot!.mockResolvedValue({
+      metadata: {
+        source: 'bootstrap',
+        storeAvailable: false,
+        flagCount: 1,
+        sensitiveFlagCount: 0,
+        timestamp: new Date().toISOString(),
+      },
+      flags: [
+        {
+          key: 'mainnet.refunds',
+          name: 'Mainnet Refunds',
+          description: '',
+          enabled: false,
+          killSwitch: false,
+          rolloutPercentage: 0,
+          environments: ['production'],
+          updatedAt: new Date().toISOString(),
+          updatedBy: 'bootstrap',
+        },
+      ],
+    });
+
+    mockContractRegistryService.getRegistry!.mockResolvedValue({
+      network: 'mainnet',
+      authoritative: true,
+      version: 1,
+      etag: 'W/"contract-registry-mainnet-1"',
+      data: {},
+    });
+
+    const config = await service.getConfig();
+
+    expect(config.network.network).toBe('mainnet');
+    expect(config.network.networkPassphrase).toBe('Public Global Stellar Network ; September 2015');
+    expect(config.network.horizonUrl).toBe('https://horizon.stellar.org');
+    expect(config.network.sorobanRpcUrl).toContain('mainnet');
+    expect(config.apiUrl).toBe('https://api.quickex.to');
+  });
+
+  // ── Preview Scope Not Found ──────────────────────────────────────────────
+
+  it('omits preview metadata when scope does not exist', async () => {
+    mockFeatureFlagsService.getSnapshot!.mockResolvedValue({
+      metadata: {
+        source: 'bootstrap',
+        storeAvailable: false,
+        flagCount: 0,
+        sensitiveFlagCount: 0,
+        timestamp: new Date().toISOString(),
+      },
+      flags: [],
+    });
+
+    mockContractRegistryService.getRegistry!.mockResolvedValue({
+      network: 'testnet',
+      authoritative: true,
+      version: 1,
+      etag: 'W/"contract-registry-testnet-1"',
+      data: {},
+    });
+
+    mockPreviewScopeService.getScope!.mockResolvedValue(null);
+
+    const config = await service.getConfig('non-existent-scope');
+
+    expect(config.preview).toBeUndefined();
+  });
+});

--- a/app/backend/test/runtime-config.e2e-spec.ts
+++ b/app/backend/test/runtime-config.e2e-spec.ts
@@ -1,0 +1,221 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+
+import {
+  RuntimeConfigService,
+} from '../src/runtime-config/runtime-config.service';
+import { RuntimeConfigController } from '../src/runtime-config/runtime-config.controller';
+import { FeatureFlagsService } from '../src/feature-flags/feature-flags.service';
+import { ContractRegistryService } from '../src/contracts/contract-registry.service';
+import { PreviewScopeService } from '../src/preview-scope/preview-scope.service';
+
+describe('Runtime Config Endpoints', () => {
+  let app: INestApplication;
+  let mockRuntimeConfigService: jest.Mocked<Partial<RuntimeConfigService>>;
+
+  const baseConfig = {
+    environment: 'test',
+    network: {
+      network: 'testnet' as const,
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+      sorobanRpcUrls: ['https://soroban-testnet.stellar.org'],
+      explorerUrl: 'https://stellar.expert/explorer/testnet',
+    },
+    apiUrl: 'https://testnet-api.quickex.to',
+    appVersion: '0.1.0',
+    minAppVersion: '0.1.0',
+    contracts: {},
+    featureFlags: [
+      {
+        key: 'bulk_invoicing_v2',
+        name: 'Bulk Invoicing v2',
+        enabled: true,
+        killSwitch: false,
+        rolloutPercentage: 100,
+      },
+    ],
+    generatedAt: new Date().toISOString(),
+    etag: 'W/"runtime-config-test-1"',
+  };
+
+  beforeAll(async () => {
+    mockRuntimeConfigService = {
+      getConfig: jest.fn(),
+      validateConfig: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [RuntimeConfigController],
+      providers: [
+        { provide: RuntimeConfigService, useValue: mockRuntimeConfigService },
+      ],
+    })
+      .overrideProvider(FeatureFlagsService)
+      .useValue({ getSnapshot: jest.fn() })
+      .overrideProvider(ContractRegistryService)
+      .useValue({ getRegistry: jest.fn() })
+      .overrideProvider(PreviewScopeService)
+      .useValue({ getScope: jest.fn() })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Shared Testnet Bootstrap ─────────────────────────────────────────────
+
+  it('GET /v1/runtime-config returns complete config for shared testnet', async () => {
+    mockRuntimeConfigService.getConfig!.mockResolvedValue({
+      ...baseConfig,
+      contracts: {
+        quickex: {
+          contractId: 'CD2J6K7T3YJ77QXZP3EXAMPLE',
+          wasmHash: '0xabcdef1234567890',
+          version: 1,
+          schemaVersion: '1.0.0',
+        },
+      },
+      featureFlags: [
+        {
+          key: 'bulk_invoicing_v2',
+          name: 'Bulk Invoicing v2',
+          enabled: true,
+          killSwitch: false,
+          rolloutPercentage: 100,
+        },
+        {
+          key: 'testnet.contract_writes',
+          name: 'Testnet Contract Writes',
+          enabled: true,
+          killSwitch: false,
+          rolloutPercentage: 100,
+        },
+      ],
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/v1/runtime-config')
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      environment: 'test',
+      network: {
+        network: 'testnet',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      },
+      contracts: {
+        quickex: {
+          contractId: 'CD2J6K7T3YJ77QXZP3EXAMPLE',
+        },
+      },
+      featureFlags: expect.arrayContaining([
+        expect.objectContaining({ key: 'bulk_invoicing_v2' }),
+        expect.objectContaining({ key: 'testnet.contract_writes' }),
+      ]),
+      appVersion: '0.1.0',
+      minAppVersion: '0.1.0',
+    });
+  });
+
+  // ── Preview Environment ──────────────────────────────────────────────────
+
+  it('GET /v1/runtime-config includes preview metadata with X-Preview-Scope', async () => {
+    const futureDate = new Date(Date.now() + 3600000).toISOString();
+    mockRuntimeConfigService.getConfig!.mockResolvedValue({
+      ...baseConfig,
+      apiUrl: 'https://preview-api.quickex.to',
+      preview: {
+        scopeId: 'pr-123',
+        branchName: 'feature/new-ui',
+        expiresAt: futureDate,
+        valid: true,
+      },
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/v1/runtime-config')
+      .set('X-Preview-Scope', 'pr-123')
+      .expect(200);
+
+    expect(response.body.preview).toBeDefined();
+    expect(response.body.preview.scopeId).toBe('pr-123');
+    expect(response.body.preview.branchName).toBe('feature/new-ui');
+    expect(response.body.preview.valid).toBe(true);
+    expect(response.body.apiUrl).toBe('https://preview-api.quickex.to');
+  });
+
+  // ── Minimal / Fallback Environment ───────────────────────────────────────
+
+  it('GET /v1/runtime-config returns minimal config with fallbacks', async () => {
+    mockRuntimeConfigService.getConfig!.mockResolvedValue({
+      ...baseConfig,
+      contracts: {},
+      featureFlags: [],
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/v1/runtime-config')
+      .expect(200);
+
+    expect(response.body.contracts).toEqual({});
+    expect(response.body.featureFlags).toEqual([]);
+    expect(response.body.network).toBeDefined();
+    expect(response.body.apiUrl).toBeDefined();
+  });
+
+  // ── Cache Headers ────────────────────────────────────────────────────────
+
+  it('GET /v1/runtime-config includes cache-control and ETag headers', async () => {
+    mockRuntimeConfigService.getConfig!.mockResolvedValue(baseConfig);
+
+    const response = await request(app.getHttpServer())
+      .get('/v1/runtime-config')
+      .expect(200);
+
+    expect(response.headers['cache-control']).toBe('public, max-age=0, must-revalidate');
+    expect(response.headers['etag']).toBeDefined();
+  });
+
+  it('GET /v1/runtime-config returns 304 when ETag matches', async () => {
+    mockRuntimeConfigService.getConfig!.mockResolvedValue(baseConfig);
+
+    const etag = 'W/"runtime-config-test-1"';
+
+    await request(app.getHttpServer())
+      .get('/v1/runtime-config')
+      .set('If-None-Match', etag)
+      .expect(304);
+  });
+
+  // ── Sensitive Data Exclusion ─────────────────────────────────────────────
+
+  it('GET /v1/runtime-config does not expose sensitive fields', async () => {
+    mockRuntimeConfigService.getConfig!.mockResolvedValue(baseConfig);
+
+    const response = await request(app.getHttpServer())
+      .get('/v1/runtime-config')
+      .expect(200);
+
+    expect(response.body).not.toHaveProperty('secrets');
+    expect(response.body).not.toHaveProperty('database');
+    expect(response.body).not.toHaveProperty('sentry');
+    expect(response.body).not.toHaveProperty('apiKeys');
+
+    const bodyStr = JSON.stringify(response.body);
+    expect(bodyStr).not.toContain('secret');
+    expect(bodyStr).not.toContain('private_key');
+  });
+});


### PR DESCRIPTION
Closes #652 
Exposes a single, cacheable endpoint that returns environment-aware API, network, contract, and feature-flag metadata for web and mobile clients.

Schema: RuntimeConfigResponseDto with network, apiUrl, contracts, featureFlags, optional preview, and etag — excludes all secret/private values
Cache: ETag (content-hash based, not timestamp) + Cache-Control: public, max-age=0, must-revalidate + 304 on If-None-Match
Fallbacks: Contract registry and feature flag failures degrade gracefully to empty arrays/objects
Preview scope: X-Preview-Scope header triggers preview metadata inclusion (scope validity, expiry, branch name)
Env var: PUBLIC_API_URL for explicit API URL; falls back to env-based defaults (api.quickex.to / testnet-api.quickex.to)
Tests: 8 unit tests + 6 E2E covering shared testnet, preview, minimal/fallback, mainnet, sensitive exclusion, and ETag cache flow