### PR TITLE
fix(security): Backend: missing rate limiting on payment link endpoints

### DIFF
--- a/app/backend/src/links/payment-link.controller.ts
+++ b/app/backend/src/links/payment-link.controller.ts
@@ -5,12 +5,15 @@ import {
   HttpCode,
   HttpStatus,
   BadRequestException,
+  UseGuards,
 } from "@nestjs/common";
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from "@nestjs/swagger";
 import { PaymentLinkService } from "./payment-link.service";
 import { PaymentLinkStatusDto } from "../dto/link/payment-link-status.dto";
+import { CustomThrottlerGuard } from "../auth/guards/custom-throttler.guard";
 
 @ApiTags("payment-links")
+@UseGuards(CustomThrottlerGuard)
 @Controller("payment-links")
 export class PaymentLinkController {
   constructor(private readonly paymentLinkService: PaymentLinkService) {}
@@ -55,6 +58,10 @@ export class PaymentLinkController {
   @ApiResponse({
     status: 404,
     description: "Username not found",
+  })
+  @ApiResponse({
+    status: 429,
+    description: "Rate limit exceeded – retry after 60 seconds",
   })
   async getPaymentLinkStatus(
     @Query("username") username: string,

--- a/app/backend/src/usernames/usernames.controller.ts
+++ b/app/backend/src/usernames/usernames.controller.ts
@@ -11,7 +11,6 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { Throttle } from "@nestjs/throttler";
-// import { RateLimitGroup } from "../config/rate-limit.config";
 import {
   ApiBody,
   ApiOperation,
@@ -53,6 +52,7 @@ export class UsernamesController {
   ) {}
 
   @Post()
+  @Throttle({ default: { limit: 10, ttl: 60000 } }) // 10 requests per minute
   @ApiOperation({
     summary: "Create a new username",
     description:
@@ -80,6 +80,10 @@ export class UsernamesController {
   @ApiResponse({
     status: 403,
     description: "Wallet has reached the maximum allowed usernames",
+  })
+  @ApiResponse({
+    status: 429,
+    description: "Rate limit exceeded – retry after 60 seconds",
   })
   async createUsername(
     @Body() body: CreateUsernameDto,
@@ -363,6 +367,7 @@ export class UsernamesController {
   }
 
   @Post("toggle-public")
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     summary: "Toggle public profile visibility",
     description:


### PR DESCRIPTION
Closes #760

## Summary of Changes
- Applied `CustomThrottlerGuard` to `PaymentLinkController` to protect payment link status queries.
- Added `@Throttle()` decorators on username registration and profile toggle endpoints in `UsernamesController`.
- Prevented rate limit bypass and brute-force harvesting on payment link endpoints.

## Technical Requirements Checklist
- [x] Add per-IP and per-account rate limits on public payment link endpoints.
- [x] Protect username registration and payment link status queries against abuse.
