### PR TITLE
Contract Registry Route Compatibility Fix

### DIFF
--- a/app/mobile/__tests__/contract-registry.test.ts
+++ b/app/mobile/__tests__/contract-registry.test.ts
@@ -1,6 +1,17 @@
 import { ContractRegistryService, REGISTRY_CACHE_TTL_MS } from '../services/contract-registry';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
+function envelope(data: Record<string, unknown>, overrides: Record<string, unknown> = {}) {
+  return {
+    network: 'testnet',
+    authoritative: true,
+    version: 1,
+    etag: 'W/"contract-registry-testnet-1"',
+    data,
+    ...overrides,
+  };
+}
+
 describe('ContractRegistryService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -8,32 +19,32 @@ describe('ContractRegistryService', () => {
   });
 
   it('fetches fresh registry and caches it', async () => {
-    const mockData = { Escrow: { id: 'C123', version: '1.0' } };
-    global.fetch = jest.fn(() => 
-      Promise.resolve({ ok: true, json: () => Promise.resolve(mockData) })
+    const mockBody = envelope({ quickex: { id: 'C123', version: 1 } });
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(mockBody) })
     ) as jest.Mock;
 
     const result = await ContractRegistryService.sync('http://localhost');
-    expect(result.registry.Escrow.id).toBe('C123');
+    expect(result.registry.quickex.id).toBe('C123');
     expect(result.source).toBe('network');
     expect(result.isStale).toBe(false);
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-      '@contract_registry', 
+      '@contract_registry',
       expect.stringContaining('C123')
     );
   });
 
   it('falls back to cache on network error', async () => {
     global.fetch = jest.fn(() => Promise.reject(new Error('Network drop')));
-    
+
     const cachedState = JSON.stringify({
       timestamp: Date.now(),
-      data: { Escrow: { id: 'C456', version: '1.0' } }
+      data: { quickex: { id: 'C456', version: 1 } }
     });
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(cachedState);
 
     const result = await ContractRegistryService.sync('http://localhost');
-    expect(result.registry.Escrow.id).toBe('C456');
+    expect(result.registry.quickex.id).toBe('C456');
     expect(result.source).toBe('cache');
     expect(result.isStale).toBe(false);
   });
@@ -45,12 +56,12 @@ describe('ContractRegistryService', () => {
 
     const cachedState = JSON.stringify({
       timestamp: now - REGISTRY_CACHE_TTL_MS - 1,
-      data: { Escrow: { id: 'C789', version: '1.0' } }
+      data: { quickex: { id: 'C789', version: 1 } }
     });
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(cachedState);
 
     const result = await ContractRegistryService.sync('http://localhost');
-    expect(result.registry.Escrow.id).toBe('C789');
+    expect(result.registry.quickex.id).toBe('C789');
     expect(result.source).toBe('cache');
     expect(result.isStale).toBe(true);
   });
@@ -58,14 +69,14 @@ describe('ContractRegistryService', () => {
   it('refreshes stale registry data when the network recovers', async () => {
     const now = 1_800_000_000_000;
     jest.spyOn(Date, 'now').mockReturnValue(now);
-    const freshData = { Escrow: { id: 'C999', version: '2.0' } };
+    const freshBody = envelope({ quickex: { id: 'C999', version: 2 } }, { version: 2 });
     global.fetch = jest.fn()
       .mockRejectedValueOnce(new Error('Network drop'))
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(freshData) });
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(freshBody) });
 
     const cachedState = JSON.stringify({
       timestamp: now - REGISTRY_CACHE_TTL_MS - 1,
-      data: { Escrow: { id: 'C789', version: '1.0' } }
+      data: { quickex: { id: 'C789', version: 1 } }
     });
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(cachedState);
 
@@ -73,8 +84,8 @@ describe('ContractRegistryService', () => {
     const refreshedResult = await ContractRegistryService.sync('http://localhost');
 
     expect(staleResult.isStale).toBe(true);
-    expect(refreshedResult.registry.Escrow.id).toBe('C999');
-    expect(refreshedResult.registry.Escrow.version).toBe('2.0');
+    expect(refreshedResult.registry.quickex.id).toBe('C999');
+    expect(refreshedResult.registry.quickex.version).toBe(2);
     expect(refreshedResult.source).toBe('network');
     expect(refreshedResult.isStale).toBe(false);
   });
@@ -84,6 +95,58 @@ describe('ContractRegistryService', () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
     await expect(ContractRegistryService.sync('http://localhost'))
-      .rejects.toThrow('Registry unavailable and no cache found');
+      .rejects.toThrow('Registry unavailable and no cache found: Network drop');
+  });
+
+  it('falls back to cache when the registry route is missing (404)', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) })
+    ) as jest.Mock;
+
+    const cachedState = JSON.stringify({
+      timestamp: Date.now(),
+      data: { quickex: { id: 'C456', version: 1 } }
+    });
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(cachedState);
+
+    const result = await ContractRegistryService.sync('http://localhost');
+    expect(result.registry.quickex.id).toBe('C456');
+    expect(result.source).toBe('cache');
+  });
+
+  it('throws a route-not-found error when the registry route is missing and cache is empty', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) })
+    ) as jest.Mock;
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+    await expect(ContractRegistryService.sync('http://localhost'))
+      .rejects.toThrow('Contract registry route not found on backend');
+  });
+
+  it('falls back to cache when the response payload is malformed', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ quickex: { id: 'flat-shape' } }) })
+    ) as jest.Mock;
+
+    const cachedState = JSON.stringify({
+      timestamp: Date.now(),
+      data: { quickex: { id: 'C456', version: 1 } }
+    });
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(cachedState);
+
+    const result = await ContractRegistryService.sync('http://localhost');
+    expect(result.registry.quickex.id).toBe('C456');
+    expect(result.source).toBe('cache');
+  });
+
+  it('throws a malformed-payload error when the response has no data field and cache is empty', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ quickex: { id: 'flat-shape' } }) })
+    ) as jest.Mock;
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+    await expect(ContractRegistryService.sync('http://localhost'))
+      .rejects.toThrow('Registry unavailable and no cache found: Contract registry response payload is malformed');
   });
 });

--- a/app/mobile/app/payment-confirmation.tsx
+++ b/app/mobile/app/payment-confirmation.tsx
@@ -36,7 +36,7 @@ export default function PaymentConfirmationScreen() {
     fetchSource: registryFetchSource,
     isRefreshing: registryRefreshing,
     refresh: refreshRegistry,
-  } = useContractRegistry(["Escrow"], backendUrl);
+  } = useContractRegistry(["quickex"], backendUrl);
   const params = useLocalSearchParams<{
     username: string;
     amount: string;

--- a/app/mobile/services/contract-registry.ts
+++ b/app/mobile/services/contract-registry.ts
@@ -3,8 +3,29 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 const CACHE_KEY = '@contract_registry';
 export const REGISTRY_CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
 
+export interface ContractRegistryEntry {
+  id: string;
+  wasmHash: string;
+  version: number;
+  schemaVersion: string;
+  schemaCompatibility: { min: string; max: string };
+  networkPassphrase: string;
+  deploymentId?: string;
+  initParams?: Record<string, unknown>;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
 export interface ContractRegistry {
-  [key: string]: { id: string; version: string };
+  [key: string]: ContractRegistryEntry;
+}
+
+interface ContractRegistryEnvelope {
+  network: string;
+  authoritative: boolean;
+  version: number;
+  etag: string;
+  data: ContractRegistry;
 }
 
 export interface ContractRegistrySyncResult {
@@ -19,13 +40,32 @@ interface ContractRegistryCache {
   data: ContractRegistry;
 }
 
+function isContractRegistryEnvelope(value: unknown): value is ContractRegistryEnvelope {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as ContractRegistryEnvelope).data === 'object' &&
+    (value as ContractRegistryEnvelope).data !== null
+  );
+}
+
 export const ContractRegistryService = {
   async sync(backendUrl: string): Promise<ContractRegistrySyncResult> {
     try {
       const response = await fetch(`${backendUrl}/api/contracts/registry`);
-      if (!response.ok) throw new Error('Failed to fetch registry');
-      
-      const data = await response.json() as ContractRegistry;
+      if (response.status === 404) {
+        throw new Error('Contract registry route not found on backend');
+      }
+      if (!response.ok) {
+        throw new Error(`Failed to fetch registry (status ${response.status})`);
+      }
+
+      const body: unknown = await response.json();
+      if (!isContractRegistryEnvelope(body)) {
+        throw new Error('Contract registry response payload is malformed');
+      }
+
+      const data = body.data;
       const timestamp = Date.now();
       await AsyncStorage.setItem(CACHE_KEY, JSON.stringify({
         timestamp,
@@ -41,7 +81,7 @@ export const ContractRegistryService = {
       const cached = await AsyncStorage.getItem(CACHE_KEY);
       if (cached) {
         const parsed = JSON.parse(cached) as ContractRegistryCache;
-        // Serve stale cache if offline
+        // Serve stale cache if offline or backend returned bad data
         return {
           registry: parsed.data,
           fetchedAt: parsed.timestamp,
@@ -49,7 +89,8 @@ export const ContractRegistryService = {
           source: 'cache',
         };
       }
-      throw new Error('Registry unavailable and no cache found');
+      const reason = error instanceof Error ? error.message : 'unknown error';
+      throw new Error(`Registry unavailable and no cache found: ${reason}`);
     }
   },
 


### PR DESCRIPTION
## Summary

Closes #686 

Fixes the mobile contract registry integration, which was silently broken: the backend wraps
contract data in an envelope (`{ network, authoritative, version, etag, data: {...} }`), but
mobile treated the raw response body as the contract map itself, so lookups always failed and
the app got stuck reporting contracts as missing regardless of backend health. A second, related
bug meant even a correct lookup would never succeed on the payment confirmation screen.

- **`app/mobile/services/contract-registry.ts`** — unwrap the backend's `data` envelope instead
  of treating the response body as the flat contract map. Added distinct error handling for a
  missing route (404), other non-2xx statuses, and a malformed payload (`data` missing/invalid) —
  all fall back to cache when available, and the no-cache error now surfaces the specific
  underlying reason instead of one generic message.
- **`app/mobile/app/payment-confirmation.tsx`** — fixed the required contract name from
  `"Escrow"` to `"quickex"`, matching the backend's actual (lowercased) registry key. Without
  this, the payload fix alone wouldn't unblock this screen since the lookup would still miss.
- **`app/mobile/__tests__/contract-registry.test.ts`** — rewrote mocks to use the real envelope
  shape and added coverage for success, missing-route (404), and malformed-payload cases (both
  cache-hit and cache-miss variants).

## Test plan

- [x] `npx jest __tests__/contract-registry.test.ts` — 9/9 passing
- [x] `npx tsc --noEmit` — no new type errors introduced (pre-existing repo-wide errors in
      unrelated files are unaffected)
