### PR TITLE
feat: improve observability around hook failures

### DIFF
--- a/app/backend/src/ingestion/event-id.ts
+++ b/app/backend/src/ingestion/event-id.ts
@@ -50,6 +50,9 @@ function getIdentityFields(event: EventWithoutId): string[] {
     case "EphemeralKeyRegistered":
     case "StealthWithdrawn":
       return [event.eventType, event.txHash, event.stealthAddress];
+
+    case "HookInvocationFailed":
+      return [event.eventType, event.txHash, event.hookContract, event.escrowId];
   }
 }
 

--- a/app/backend/src/ingestion/event-schema.ts
+++ b/app/backend/src/ingestion/event-schema.ts
@@ -6,6 +6,7 @@ export const QUICKEX_EVENT_TOPICS = {
   escrow: "TOPIC_ESCROW",
   privacy: "TOPIC_PRIVACY",
   stealth: "TOPIC_STEALTH",
+  hook: "TOPIC_HOOK",
 } as const;
 
 export type QuickExEventTopic =
@@ -107,6 +108,14 @@ export const QUICKEX_EVENT_SCHEMA_CONTRACTS = {
     schemaVersion: QUICKEX_EVENT_SCHEMA_VERSION,
     compatibleVersions: [QUICKEX_EVENT_SCHEMA_VERSION],
   },
+  HookInvocationFailed: {
+    topic: QUICKEX_EVENT_TOPICS.hook,
+    eventName: "HookInvocationFailed",
+    indexedFields: ["hook_contract", "escrow_id"],
+    payloadKeys: ["reason", "schema_version", "timestamp"],
+    schemaVersion: QUICKEX_EVENT_SCHEMA_VERSION,
+    compatibleVersions: [QUICKEX_EVENT_SCHEMA_VERSION],
+  },
 } as const satisfies Record<string, EventSchemaContract>;
 
 export const QUICKEX_EVENT_COMPATIBILITY = Object.fromEntries(
@@ -128,3 +137,4 @@ export const QUICKEX_EVENT_COMPATIBILITY = Object.fromEntries(
     canonicalTopic: QuickExEventTopic;
   }
 >;
+

--- a/app/backend/src/ingestion/soroban-event.parser.ts
+++ b/app/backend/src/ingestion/soroban-event.parser.ts
@@ -14,6 +14,7 @@ import type {
   ContractUpgradedEvent,
   EphemeralKeyRegisteredEvent,
   StealthWithdrawnEvent,
+  HookInvocationFailedEvent,
 } from "./types/contract-event.types";
 import {
   QUICKEX_EVENT_SCHEMA_CONTRACTS,
@@ -214,6 +215,13 @@ export class SorobanEventParser {
             );
           case "StealthWithdrawn":
             return this.parseStealthWithdrawn(
+              topics,
+              dataVal,
+              base,
+              layout.indexedOffset,
+            );
+          case "HookInvocationFailed":
+            return this.parseHookInvocationFailed(
               topics,
               dataVal,
               base,
@@ -443,6 +451,32 @@ export class SorobanEventParser {
       recipient,
       token: this.decodeAddress(map["token"]),
       amount: BigInt(scValToNative(map["amount"])),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hook event parsers
+  // ---------------------------------------------------------------------------
+
+  private parseHookInvocationFailed(
+    topics: xdr.ScVal[],
+    data: xdr.ScVal,
+    base: Omit<
+      HookInvocationFailedEvent,
+      "eventId" | "eventType" | "hookContract" | "escrowId" | "reason"
+    >,
+    indexedOffset: number,
+  ): Omit<HookInvocationFailedEvent, "eventId"> {
+    const hookContract = this.decodeAddress(topics[indexedOffset]);
+    const escrowId = this.decodeBytes32Hex(topics[indexedOffset + 1]);
+    const map = this.dataToMap(data);
+
+    return {
+      eventType: "HookInvocationFailed",
+      ...base,
+      hookContract,
+      escrowId,
+      reason: Number(scValToNative(map["reason"])),
     };
   }
 

--- a/app/backend/src/ingestion/types/contract-event.types.ts
+++ b/app/backend/src/ingestion/types/contract-event.types.ts
@@ -12,7 +12,8 @@ export type SorobanEventType =
   | "AdminChanged"
   | "ContractUpgraded"
   | "EphemeralKeyRegistered"
-  | "StealthWithdrawn";
+  | "StealthWithdrawn"
+  | "HookInvocationFailed";
 
 export interface BaseContractEvent {
   eventType: SorobanEventType;
@@ -100,6 +101,13 @@ export interface StealthWithdrawnEvent extends BaseContractEvent {
   amount: bigint;
 }
 
+export interface HookInvocationFailedEvent extends BaseContractEvent {
+  eventType: "HookInvocationFailed";
+  hookContract: string;
+  escrowId: string;
+  reason: number;
+}
+
 export type QuickExContractEvent =
   | EscrowDepositedEvent
   | EscrowWithdrawnEvent
@@ -109,7 +117,8 @@ export type QuickExContractEvent =
   | AdminChangedEvent
   | ContractUpgradedEvent
   | EphemeralKeyRegisteredEvent
-  | StealthWithdrawnEvent;
+  | StealthWithdrawnEvent
+  | HookInvocationFailedEvent;
 
 export type EscrowEvent =
   | EscrowDepositedEvent

--- a/app/contract/contracts/quickex/src/events.rs
+++ b/app/contract/contracts/quickex/src/events.rs
@@ -25,6 +25,8 @@ pub const EVENT_TOPIC_PRIVACY: &str = "TOPIC_PRIVACY";
 pub const EVENT_TOPIC_STEALTH: &str = "TOPIC_STEALTH";
 #[allow(dead_code)]
 pub const EVENT_TOPIC_ORACLE: &str = "TOPIC_ORACLE";
+#[allow(dead_code)]
+pub const EVENT_TOPIC_HOOK: &str = "TOPIC_HOOK";
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -282,6 +284,12 @@ pub const EVENT_SCHEMAS: &[EventSchema] = &[
         name: "HookAllowlistChanged",
         topics: &[EVENT_TOPIC_ADMIN, "HookAllowlistChanged", "hook_contract"],
         payload_keys: &["allowed", "schema_version", "timestamp"],
+        schema_version: EVENT_SCHEMA_VERSION,
+    },
+    EventSchema {
+        name: "HookInvocationFailed",
+        topics: &[EVENT_TOPIC_HOOK, "HookInvocationFailed", "hook_contract", "escrow_id"],
+        payload_keys: &["reason", "schema_version", "timestamp"],
         schema_version: EVENT_SCHEMA_VERSION,
     },
 ];
@@ -1171,6 +1179,36 @@ pub(crate) fn publish_hook_allowlist_changed(env: &Env, hook_contract: Address, 
         hook_contract,
         schema_version: EVENT_SCHEMA_VERSION,
         allowed,
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent(topics = ["TOPIC_HOOK", "HookInvocationFailed"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HookInvocationFailedEvent {
+    #[topic]
+    pub hook_contract: Address,
+
+    #[topic]
+    pub escrow_id: BytesN<32>,
+
+    pub schema_version: u32,
+    pub reason: u32,
+    pub timestamp: u64,
+}
+
+pub(crate) fn publish_hook_invocation_failed(
+    env: &Env,
+    hook_contract: Address,
+    escrow_id: BytesN<32>,
+    reason: u32,
+) {
+    HookInvocationFailedEvent {
+        hook_contract,
+        escrow_id,
+        schema_version: EVENT_SCHEMA_VERSION,
+        reason,
         timestamp: env.ledger().timestamp(),
     }
     .publish(env);

--- a/app/contract/contracts/quickex/src/hook.rs
+++ b/app/contract/contracts/quickex/src/hook.rs
@@ -1,4 +1,4 @@
-use crate::{errors::QuickexError, storage, types::HookEventKind};
+use crate::{errors::QuickexError, storage, types::{HookEventKind, HookFailureReason}, events};
 use soroban_sdk::{Address, BytesN, Env, IntoVal, Symbol, Vec};
 
 pub fn register_hook(env: &Env, hook_contract: Address) -> Result<(), QuickexError> {
@@ -68,12 +68,35 @@ pub fn invoke_hooks(
             amount.into_val(env),
             fee.into_val(env),
         ];
-        // Swallow result — a failing hook must never abort the primary transaction.
-        let _ = env.try_invoke_contract::<soroban_sdk::Val, soroban_sdk::Val>(
+        let res = env.try_invoke_contract::<soroban_sdk::Val, soroban_sdk::Val>(
             &hook,
             &Symbol::new(env, "on_escrow_event"),
             args,
         );
+        
+        match res {
+            Ok(Ok(_)) => {
+                // Success, do nothing
+            }
+            Ok(Err(_)) => {
+                // Hook returned a custom error
+                events::publish_hook_invocation_failed(
+                    env,
+                    hook.clone(),
+                    escrow_id.clone(),
+                    HookFailureReason::Other as u32,
+                );
+            }
+            Err(_) => {
+                // Hook panicked or aborted
+                events::publish_hook_invocation_failed(
+                    env,
+                    hook.clone(),
+                    escrow_id.clone(),
+                    HookFailureReason::Reverted as u32,
+                );
+            }
+        }
     }
     storage::set_reentrancy_guard(env, &false);
 }

--- a/app/contract/contracts/quickex/src/hook_test.rs
+++ b/app/contract/contracts/quickex/src/hook_test.rs
@@ -76,6 +76,24 @@ impl MaliciousHookContract {
 }
 
 #[contract]
+pub struct PanickingHookContract;
+
+#[contractimpl]
+impl PanickingHookContract {
+    pub fn on_escrow_event(
+        _env: Env,
+        _event_kind: u32,
+        _escrow_id: BytesN<32>,
+        _owner: Address,
+        _token: Address,
+        _amount: i128,
+        _fee: i128,
+    ) {
+        panic!("I am a panicking hook!");
+    }
+}
+
+#[contract]
 pub struct MockOracleContract;
 
 #[contractimpl]
@@ -177,6 +195,76 @@ fn test_reentrant_hook_does_not_break_primary_transaction() {
     client.withdraw(&token_id, &1000i128, &commitment, &owner, &salt);
 
     assert_eq!(token_client.balance(&owner), 9999);
+}
+
+#[test]
+fn test_failing_hook_emits_failure_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _platform_wallet, owner, _) = setup(&env);
+
+    let hook_contract_id = env.register(MaliciousHookContract, ());
+    let hook_client = MaliciousHookContractClient::new(&env, &hook_contract_id);
+    hook_client.init(&client.address);
+    client.register_hook(&hook_contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_client = token::Client::new(&env, &token_id);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    token_admin_client.mint(&owner, &10000);
+
+    let salt = Bytes::from_array(&env, &[2; 32]);
+    let commitment = client.deposit(&token_id, &1000i128, &owner, &salt, &3600, &None);
+    client.withdraw(&token_id, &1000i128, &commitment, &owner, &salt);
+
+    let events = env.events().all();
+    let mut failure_emitted = false;
+    for event in events.iter() {
+        if event.1.contains(&soroban_sdk::IntoVal::into_val(
+            &soroban_sdk::Symbol::new(&env, "HookInvocationFailed"),
+            &env,
+        )) {
+            failure_emitted = true;
+        }
+    }
+    assert!(failure_emitted);
+}
+
+#[test]
+fn test_panicking_hook_emits_failure_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _platform_wallet, owner, _) = setup(&env);
+
+    let hook_contract_id = env.register(PanickingHookContract, ());
+    client.register_hook(&hook_contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_client = token::Client::new(&env, &token_id);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    token_admin_client.mint(&owner, &10000);
+
+    let salt = Bytes::from_array(&env, &[3; 32]);
+    let commitment = client.deposit(&token_id, &1000i128, &owner, &salt, &3600, &None);
+    client.withdraw(&token_id, &1000i128, &commitment, &owner, &salt);
+
+    let events = env.events().all();
+    let mut failure_emitted = false;
+    for event in events.iter() {
+        if event.1.contains(&soroban_sdk::IntoVal::into_val(
+            &soroban_sdk::Symbol::new(&env, "HookInvocationFailed"),
+            &env,
+        )) {
+            failure_emitted = true;
+        }
+    }
+    assert!(failure_emitted);
 }
 
 #[test]

--- a/app/contract/contracts/quickex/src/types.rs
+++ b/app/contract/contracts/quickex/src/types.rs
@@ -261,6 +261,17 @@ pub enum HookEventKind {
     Refund = 3,
 }
 
+/// Hook failure reason codes.
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u32)]
+pub enum HookFailureReason {
+    /// Hook invocation reverted or panicked.
+    Reverted = 1,
+    /// The hook returned an unexpected value or failed otherwise.
+    Other = 2,
+}
+
 /// Privileged roles for contract governance and operations.
 #[contracttype]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]


### PR DESCRIPTION
Closes #669 

**Description:**
Improve observability around hook failures by emitting explicit failure events and reason codes whenever an external hook call is skipped or isolated. 

Tasks completed:
- Defined failure reason codes (`HookFailureReason::Reverted` and `HookFailureReason::Other`) for hook invocation outcomes.
- Emitted hook failure/skipped events without breaking primary flows (modified `invoke_hooks` to swallow errors and emit the new event instead).
- Added tests for reverting (panicking) and non-reverting (custom error) hook failures.
- Updated backend event schemas and indexing parsers to ingest the new `HookInvocationFailed` event seamlessly, maintaining compatibility with the backend infrastructure.