### PR TITLE
refactor(contract): consolidate privacy API surface onto canonical Pr…

### DIFF
--- a/app/contract/contracts/quickex/src/lib.rs
+++ b/app/contract/contracts/quickex/src/lib.rs
@@ -144,9 +144,7 @@ impl QuickexContract {
     /// * `account` - The account to configure
     /// * `privacy_level` - Numeric level (0 = off, higher = more privacy; interpretation is application-specific)
     pub fn enable_privacy(env: Env, account: Address, privacy_level: u32) -> bool {
-        set_privacy_level(&env, &account, privacy_level);
-        add_privacy_history(&env, &account, privacy_level);
-        true
+        privacy::enable_privacy(&env, account, privacy_level)
     }
 
     /// Get the current numeric privacy level for an account.
@@ -157,7 +155,7 @@ impl QuickexContract {
     /// * `env` - The contract environment
     /// * `account` - The account to query
     pub fn privacy_status(env: Env, account: Address) -> Option<u32> {
-        get_privacy_level(&env, &account)
+        privacy::privacy_status(&env, account)
     }
 
     /// Get the history of privacy level changes for an account.

--- a/app/contract/contracts/quickex/src/privacy.rs
+++ b/app/contract/contracts/quickex/src/privacy.rs
@@ -103,5 +103,5 @@ pub fn set_privacy(env: &Env, owner: Address, enabled: bool) -> Result<(), Quick
 /// Under the consolidated privacy model, privacy is enabled if and only if
 /// the account's canonical privacy level is greater than 0.
 pub fn get_privacy(env: &Env, owner: Address) -> bool {
-    get_privacy_level(env, &owner).map_or(false, |level| level > 0)
+    get_privacy_level(env, &owner).is_some_and( |level| level > 0)
 }

--- a/app/contract/contracts/quickex/src/privacy.rs
+++ b/app/contract/contracts/quickex/src/privacy.rs
@@ -1,56 +1,107 @@
 use crate::errors::QuickexError;
 use crate::events::publish_privacy_toggled;
-use crate::storage::{DataKey, PRIVACY_ENABLED_KEY};
+use crate::storage::{add_privacy_history, DataKey, PRIVACY_ENABLED_KEY};
 use soroban_sdk::{Address, Env, Symbol};
 
-fn legacy_privacy_key(env: &Env, owner: &Address) -> (Symbol, Address) {
+fn legacy_symbol_privacy_key(env: &Env, owner: &Address) -> (Symbol, Address) {
     (Symbol::new(env, PRIVACY_ENABLED_KEY), owner.clone())
 }
 
-fn typed_privacy_key(owner: &Address) -> DataKey {
+fn deprecated_typed_privacy_key(owner: &Address) -> DataKey {
     DataKey::PrivacyEnabled(owner.clone())
 }
 
-fn read_privacy_flag(env: &Env, owner: &Address) -> bool {
-    let typed_key = typed_privacy_key(owner);
-    if let Some(enabled) = env.storage().persistent().get(&typed_key) {
-        return enabled;
+/// Read the canonical privacy level for an account, performing lazy migration from deprecated storage keys.
+///
+/// **Canonical Representation**:
+/// - `DataKey::PrivacyLevel(account) -> u32` is the single authoritative privacy state.
+/// - Level `0` represents privacy disabled (off).
+/// - Level `>0` represents privacy enabled (on), with level `1` as the default tier for boolean calls.
+/// - Returns `None` if privacy has never been configured for the account.
+pub fn get_privacy_level(env: &Env, account: &Address) -> Option<u32> {
+    let canonical_key = DataKey::PrivacyLevel(account.clone());
+    if let Some(level) = env.storage().persistent().get::<_, u32>(&canonical_key) {
+        return Some(level);
     }
 
-    env.storage()
-        .persistent()
-        .get(&legacy_privacy_key(env, owner))
-        .unwrap_or(false)
+    // Lazy migration path for deprecated typed boolean key
+    let typed_key = deprecated_typed_privacy_key(account);
+    if let Some(enabled) = env.storage().persistent().get::<_, bool>(&typed_key) {
+        let level = if enabled { 1u32 } else { 0u32 };
+        env.storage().persistent().set(&canonical_key, &level);
+        env.storage().persistent().remove(&typed_key);
+        return Some(level);
+    }
+
+    // Lazy migration path for legacy Symbol-based key: (Symbol("privacy_enabled"), Address)
+    let legacy_key = legacy_symbol_privacy_key(env, account);
+    if let Some(enabled) = env.storage().persistent().get::<_, bool>(&legacy_key) {
+        let level = if enabled { 1u32 } else { 0u32 };
+        env.storage().persistent().set(&canonical_key, &level);
+        env.storage().persistent().remove(&legacy_key);
+        return Some(level);
+    }
+
+    None
 }
 
-/// Enable or disable privacy for an account.
+/// Set the canonical privacy level for an account, cleaning up deprecated storage keys if present.
+pub fn set_privacy_level(env: &Env, account: Address, level: u32) {
+    let canonical_key = DataKey::PrivacyLevel(account.clone());
+    env.storage().persistent().set(&canonical_key, &level);
+
+    // Clean up deprecated keys if present
+    let typed_key = deprecated_typed_privacy_key(&account);
+    if env.storage().persistent().has(&typed_key) {
+        env.storage().persistent().remove(&typed_key);
+    }
+
+    let legacy_key = legacy_symbol_privacy_key(env, &account);
+    if env.storage().persistent().has(&legacy_key) {
+        env.storage().persistent().remove(&legacy_key);
+    }
+}
+
+/// Enable a numeric privacy level for an account (level-based API).
 ///
-/// Reads the current state first and returns [`QuickexError::PrivacyAlreadySet`]
-/// if the requested value matches the current value. Otherwise persists the new
-/// state and publishes a [`crate::events::publish_privacy_toggled`] event.
+/// Sets the canonical privacy level and appends the new level to history.
+pub fn enable_privacy(env: &Env, account: Address, privacy_level: u32) -> bool {
+    set_privacy_level(env, account.clone(), privacy_level);
+    add_privacy_history(env, &account, privacy_level);
+    publish_privacy_toggled(env, account, privacy_level > 0);
+    true
+}
+
+/// Return the numeric privacy level for an account.
+pub fn privacy_status(env: &Env, account: Address) -> Option<u32> {
+    get_privacy_level(env, &account)
+}
+
+/// Enable or disable boolean privacy for an account.
+///
+/// Reimplemented as a thin shim over the canonical numeric level representation.
+/// Setting `enabled = true` maps to canonical privacy level `1`.
+/// Setting `enabled = false` maps to canonical privacy level `0`.
+/// Returns [`QuickexError::PrivacyAlreadySet`] if the requested boolean state matches current.
 pub fn set_privacy(env: &Env, owner: Address, enabled: bool) -> Result<(), QuickexError> {
     owner.require_auth();
 
-    let current = read_privacy_flag(env, &owner);
+    let current = get_privacy(env, owner.clone());
     if current == enabled {
         return Err(QuickexError::PrivacyAlreadySet);
     }
 
-    let typed_key = typed_privacy_key(&owner);
-    env.storage().persistent().set(&typed_key, &enabled);
-
-    let legacy_key = legacy_privacy_key(env, &owner);
-    if env.storage().persistent().has(&legacy_key) {
-        env.storage().persistent().remove(&legacy_key);
-    }
-
+    let target_level = if enabled { 1u32 } else { 0u32 };
+    set_privacy_level(env, owner.clone(), target_level);
+    add_privacy_history(env, &owner, target_level);
     publish_privacy_toggled(env, owner, enabled);
     Ok(())
 }
 
 /// Return the current boolean privacy state for an account.
 ///
-/// Defaults to `false` if never set.
+/// Under the consolidated privacy model, privacy is enabled if and only if
+/// the account's canonical privacy level is greater than 0.
 pub fn get_privacy(env: &Env, owner: Address) -> bool {
-    read_privacy_flag(env, &owner)
+    get_privacy_level(env, &owner).map_or(false, |level| level > 0)
 }

--- a/app/contract/contracts/quickex/src/storage.rs
+++ b/app/contract/contracts/quickex/src/storage.rs
@@ -15,14 +15,15 @@
 //! | [`ContractVersion`](DataKey::ContractVersion) | `u32` | Stored schema/version marker for upgrade migrations. |
 //! | [`Admin`](DataKey::Admin) | `Address`     | Contract admin address. Set during initialisation, transferable by admin. |
 //! | [`Paused`](DataKey::Paused) | `bool`       | Global pause flag. When true, critical operations may be blocked. |
-//! | [`PrivacyLevel`](DataKey::PrivacyLevel) | `u32`  | Numeric privacy level per account (0 = off). Used by `enable_privacy`. |
+//! | [`PrivacyLevel`](DataKey::PrivacyLevel) | `u32`  | Canonical numeric privacy level per account (0 = off, >0 = on). Single authoritative privacy state. |
 //! | [`PrivacyHistory`](DataKey::PrivacyHistory) | `Vec<u32>` | Per-account history of privacy level changes (chronological). |
 //!
 //! ## Related Keys (legacy compatibility)
 //!
 //! | Key                    | Format                    | Value Type | Description |
 //! |------------------------|---------------------------|------------|-------------|
-//! | `privacy_enabled`      | `(Symbol, Address)`       | `bool`     | Legacy boolean privacy on/off key. Read as a fallback and migrated to [`DataKey::PrivacyEnabled`] on write. |
+//! | `PrivacyEnabled`       | `DataKey::PrivacyEnabled(Address)` | `bool` | Deprecated boolean privacy key. Migrated lazily to [`DataKey::PrivacyLevel`] on read/write. |
+//! | `privacy_enabled`      | `(Symbol, Address)`       | `bool`     | Legacy Symbol-based privacy key. Migrated lazily to [`DataKey::PrivacyLevel`] on read/write. |
 //!
 //! ## Relations
 //!
@@ -31,7 +32,7 @@
 //!   status, and created_at.
 //! - **Admin ↔ Paused**: Admin can set the paused flag. Both are singleton keys.
 //! - **PrivacyLevel ↔ PrivacyHistory**: Same account may have both; level is current, history is append-only.
-//! - **PrivacyLevel / PrivacyHistory ↔ PrivacyEnabled**: Separate APIs; level-based vs boolean. Both persist per `Address`.
+//! - **PrivacyLevel (Canonical)**: Authoritative privacy representation for both boolean and level-based APIs.
 //!
 //! ## Backwards Compatibility
 //!
@@ -737,16 +738,14 @@ pub fn is_paused(env: &Env) -> bool {
 // Privacy helpers (level-based API)
 // -----------------------------------------------------------------------------
 
-/// Set privacy level for an account.
+/// Set canonical privacy level for an account.
 pub fn set_privacy_level(env: &Env, account: &Address, level: u32) {
-    let key = DataKey::PrivacyLevel(account.clone());
-    env.storage().persistent().set(&key, &level);
+    crate::privacy::set_privacy_level(env, account.clone(), level);
 }
 
-/// Get privacy level for an account.
+/// Get canonical privacy level for an account, with lazy migration for deprecated boolean keys.
 pub fn get_privacy_level(env: &Env, account: &Address) -> Option<u32> {
-    let key = DataKey::PrivacyLevel(account.clone());
-    env.storage().persistent().get(&key)
+    crate::privacy::get_privacy_level(env, account)
 }
 
 /// Add to privacy history for an account.

--- a/app/contract/contracts/quickex/src/storage.rs
+++ b/app/contract/contracts/quickex/src/storage.rs
@@ -738,16 +738,6 @@ pub fn is_paused(env: &Env) -> bool {
 // Privacy helpers (level-based API)
 // -----------------------------------------------------------------------------
 
-/// Set canonical privacy level for an account.
-pub fn set_privacy_level(env: &Env, account: &Address, level: u32) {
-    crate::privacy::set_privacy_level(env, account.clone(), level);
-}
-
-/// Get canonical privacy level for an account, with lazy migration for deprecated boolean keys.
-pub fn get_privacy_level(env: &Env, account: &Address) -> Option<u32> {
-    crate::privacy::get_privacy_level(env, account)
-}
-
 /// Add to privacy history for an account.
 ///
 /// **Contract**: Pushes `level` to the front of the history (newest first).

--- a/app/contract/contracts/quickex/src/test.rs
+++ b/app/contract/contracts/quickex/src/test.rs
@@ -625,6 +625,7 @@ fn test_legacy_privacy_flag_is_read_and_migrated_on_write() {
     let account = Address::generate(&env);
     let legacy_key = (Symbol::new(&env, PRIVACY_ENABLED_KEY), account.clone());
     let typed_key = DataKey::PrivacyEnabled(account.clone());
+    let canonical_key = DataKey::PrivacyLevel(account.clone());
 
     env.as_contract(&client.address, || {
         env.storage().persistent().set(&legacy_key, &true);
@@ -632,16 +633,69 @@ fn test_legacy_privacy_flag_is_read_and_migrated_on_write() {
 
     client.initialize(&admin);
 
+    // Read lazily migrates legacy symbol key to canonical PrivacyLevel(1)
     assert!(client.get_privacy(&account));
-
-    client.set_privacy(&account, &false);
-    assert!(!client.get_privacy(&account));
+    assert_eq!(client.privacy_status(&account), Some(1));
 
     env.as_contract(&client.address, || {
         assert!(!env.storage().persistent().has(&legacy_key));
-        let stored: bool = env.storage().persistent().get(&typed_key).unwrap();
-        assert!(!stored);
+        let stored_level: u32 = env.storage().persistent().get(&canonical_key).unwrap();
+        assert_eq!(stored_level, 1);
     });
+
+    // set_privacy(false) sets canonical PrivacyLevel to 0 and cleans up typed/legacy keys
+    client.set_privacy(&account, &false);
+    assert!(!client.get_privacy(&account));
+    assert_eq!(client.privacy_status(&account), Some(0));
+
+    env.as_contract(&client.address, || {
+        assert!(!env.storage().persistent().has(&legacy_key));
+        assert!(!env.storage().persistent().has(&typed_key));
+        let stored_level: u32 = env.storage().persistent().get(&canonical_key).unwrap();
+        assert_eq!(stored_level, 0);
+    });
+}
+
+#[test]
+fn test_privacy_api_consolidation_and_non_contradiction() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let account = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    // 1. Fresh account: no privacy configured
+    assert!(!client.get_privacy(&account));
+    assert_eq!(client.privacy_status(&account), None);
+    assert_eq!(client.privacy_history(&account).len(), 0);
+
+    // 2. Set privacy via boolean API (set_privacy true -> canonical level 1)
+    client.set_privacy(&account, &true);
+    assert!(client.get_privacy(&account));
+    assert_eq!(client.privacy_status(&account), Some(1));
+
+    // 3. Set level via level API (enable_privacy 3 -> canonical level 3)
+    client.enable_privacy(&account, &3);
+    assert!(client.get_privacy(&account));
+    assert_eq!(client.privacy_status(&account), Some(3));
+
+    // 4. Disable level via level API (enable_privacy 0 -> canonical level 0)
+    client.enable_privacy(&account, &0);
+    assert!(!client.get_privacy(&account));
+    assert_eq!(client.privacy_status(&account), Some(0));
+
+    // 5. Re-enable via boolean API
+    client.set_privacy(&account, &true);
+    assert!(client.get_privacy(&account));
+    assert_eq!(client.privacy_status(&account), Some(1));
+
+    // 6. Verify full history (newest first)
+    let history = client.privacy_history(&account);
+    assert_eq!(history.len(), 4);
+    assert_eq!(history.get(0), Some(1));
+    assert_eq!(history.get(1), Some(0));
+    assert_eq!(history.get(2), Some(3));
+    assert_eq!(history.get(3), Some(1));
 }
 
 /// Regression suite: create and verify amount commitment — core commitment flow.


### PR DESCRIPTION
Closes #862 
### 🎯 Goal
Consolidate `contracts/quickex/src/lib.rs` overlapping privacy APIs (`enable_privacy` / `privacy_status` / `privacy_history` vs `set_privacy` / `get_privacy`) onto a single canonical representation so that both APIs operate on consistent state and cannot report contradictory privacy statuses.

### 🛠️ Key Changes
1. **Canonical State**: Standardized on `DataKey::PrivacyLevel(Address) -> u32` as the single authoritative privacy representation.
   - Level `0` = Privacy disabled
   - Level `>0` = Privacy enabled (defaulting to level `1` for boolean toggles)
2. **Shim Implementations**:
   - `set_privacy(owner, enabled)`: Sets canonical level `1` when `enabled == true`, and `0` when `enabled == false`.
   - `get_privacy(owner)`: Evaluates `level > 0` over `privacy_status`.
   - `enable_privacy(account, level)`: Updates canonical `PrivacyLevel` and appends to `PrivacyHistory`.
3. **Lazy Data Migration**:
   - Migrates legacy storage entries (`DataKey::PrivacyEnabled(account)` and legacy symbol key `(Symbol("privacy_enabled"), account)`) lazily to `DataKey::PrivacyLevel(account)` on read/write and removes old keys.
4. **Verification & Tests**:
   - Added unit tests in `test.rs` verifying cross-API consistency, non-contradiction, history ordering, and legacy storage lazy migration.

### 🧪 Acceptance Criteria Compliance
- [x] Single authoritative privacy representation chosen (`PrivacyLevel`) and documented.
- [x] Redundant entrypoints reimplemented as thin, consistent shims over canonical state.
- [x] Implemented non-contradictory state reporting across both views (`get_privacy` & `privacy_status`).
- [x] Defined and tested lazy migration path for accounts with deprecated storage state.
- [x] Added unit tests proving cross-style consistency and migration behavior.