### PR TITLE
feat(exports): deliver completed exports via templated email through notifications module

### DIFF
--- a/app/backend/src/job-queue/handlers/__tests__/export-generation.handler.unit.spec.ts
+++ b/app/backend/src/job-queue/handlers/__tests__/export-generation.handler.unit.spec.ts
@@ -1,0 +1,227 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import {
+  ExportGenerationHandler,
+  PermanentJobError,
+} from "../export-generation.handler";
+import { SupabaseService } from "../../../supabase/supabase.service";
+import { NotificationService } from "../../../notifications/notification.service";
+import { Job, CancellationToken, JobStatus } from "../../types";
+import { ExportGenerationPayload } from "../../types/job-payloads.types";
+import type { ExportCompletedPayload } from "../../../notifications/types/notification.types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Chainable, awaitable supabase query builder stub. */
+function makeQueryBuilder(data: Record<string, unknown>[]) {
+  const result = { data, error: null };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const builder: any = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(result));
+  builder.select = jest.fn().mockReturnThis();
+  builder.eq = jest.fn().mockReturnThis();
+  return Object.assign(builder, {
+    then: (
+      resolve: (value: { data: Record<string, unknown>[]; error: null }) => void,
+      reject: (reason?: unknown) => void,
+    ) => Promise.resolve(result).then(resolve, reject),
+  });
+}
+
+function makeSupabaseMock(data: Record<string, unknown>[]) {
+  return {
+    getClient: jest.fn().mockReturnValue({
+      from: jest.fn().mockReturnValue(makeQueryBuilder(data)),
+    }),
+  };
+}
+
+function makeJob(
+  overrides: Partial<ExportGenerationPayload> = {},
+): Job<ExportGenerationPayload> {
+  return {
+    id: "job-42",
+    type: "EXPORT_GENERATION" as unknown as Job<ExportGenerationPayload>["type"],
+    payload: {
+      userId: "GUSER123",
+      exportType: "transactions",
+      filters: {},
+      format: "csv",
+      deliveryMethod: "email",
+      ...overrides,
+    },
+    status: JobStatus.PENDING,
+    attempts: 0,
+    maxAttempts: 5,
+    createdAt: new Date(),
+    scheduledAt: new Date(),
+    startedAt: null,
+    completedAt: null,
+    failureReason: null,
+    visibilityTimeout: null,
+  };
+}
+
+function makeCancellationToken(): CancellationToken {
+  return {
+    throwIfCancelled: jest.fn(),
+    isCancelled: jest.fn().mockReturnValue(false),
+  };
+}
+
+describe("ExportGenerationHandler – email delivery (BE-101)", () => {
+  let handler: ExportGenerationHandler;
+  let notificationService: jest.Mocked<NotificationService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExportGenerationHandler,
+        {
+          provide: SupabaseService,
+          useValue: makeSupabaseMock([{ id: 1 }, { id: 2 }]),
+        },
+        {
+          provide: NotificationService,
+          useValue: {
+            deliverExportEmail: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get<ExportGenerationHandler>(ExportGenerationHandler);
+    notificationService = module.get(NotificationService);
+  });
+
+  describe("execute – email delivery succeeds", () => {
+    it("routes the completed export through the notifications module", async () => {
+      notificationService.deliverExportEmail.mockResolvedValue({
+        delivered: true,
+        templateVersionId: "tpl-version-7",
+      });
+
+      await expect(
+        handler.execute(makeJob(), makeCancellationToken()),
+      ).resolves.toBeUndefined();
+
+      expect(notificationService.deliverExportEmail).toHaveBeenCalledTimes(1);
+
+      const payload = notificationService.deliverExportEmail.mock
+        .calls[0][0] as ExportCompletedPayload;
+      expect(payload.eventType).toBe("export.completed");
+      expect(payload.recipientPublicKey).toBe("GUSER123");
+      expect(payload.exportType).toBe("transactions");
+      expect(payload.format).toBe("csv");
+      expect(payload.recordCount).toBe(2);
+      expect(payload.jobId).toBe("job-42");
+      expect(payload.eventId).toBe("export:job-42");
+    });
+
+    it("completes the job when the templated email is delivered", async () => {
+      notificationService.deliverExportEmail.mockResolvedValue({
+        delivered: true,
+        templateVersionId: "tpl-version-7",
+      });
+
+      const job = makeJob({ deliveryMethod: "email", format: "json" });
+
+      await expect(
+        handler.execute(job, makeCancellationToken()),
+      ).resolves.toBeUndefined();
+      expect(notificationService.deliverExportEmail).toHaveBeenCalled();
+    });
+  });
+
+  describe("execute – provider/template failure handling", () => {
+    it("throws so the failure is surfaced on the export job record when sending fails", async () => {
+      notificationService.deliverExportEmail.mockResolvedValue({
+        delivered: false,
+        error: "SendGrid 500: upstream unavailable",
+      });
+
+      await expect(
+        handler.execute(makeJob(), makeCancellationToken()),
+      ).rejects.toThrow(/Email delivery failed.*SendGrid 500/);
+    });
+
+    it("throws when no enabled email preference exists for the user", async () => {
+      notificationService.deliverExportEmail.mockResolvedValue({
+        delivered: false,
+        error: "No enabled email channel preference with an email address found for GUSER123",
+      });
+
+      await expect(
+        handler.execute(makeJob(), makeCancellationToken()),
+      ).rejects.toThrow(/No enabled email channel preference/);
+    });
+
+    it("propagates errors thrown by the notifications module", async () => {
+      notificationService.deliverExportEmail.mockRejectedValue(
+        new Error("preferences lookup failed"),
+      );
+
+      await expect(
+        handler.execute(makeJob(), makeCancellationToken()),
+      ).rejects.toThrow(/Export generation failed.*preferences lookup failed/);
+    });
+  });
+
+  describe("execute – non-email delivery methods are untouched", () => {
+    it("does not send an email for download deliveries", async () => {
+      const job = makeJob({ deliveryMethod: "download" });
+
+      await expect(
+        handler.execute(job, makeCancellationToken()),
+      ).resolves.toBeUndefined();
+      expect(notificationService.deliverExportEmail).not.toHaveBeenCalled();
+    });
+
+    it("does not send an email for webhook deliveries", async () => {
+      const job = makeJob({ deliveryMethod: "webhook" });
+
+      await expect(
+        handler.execute(job, makeCancellationToken()),
+      ).resolves.toBeUndefined();
+      expect(notificationService.deliverExportEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("validate", () => {
+    it("passes for a valid email delivery payload", async () => {
+      const payload: ExportGenerationPayload = {
+        userId: "GUSER123",
+        exportType: "payments",
+        filters: {},
+        format: "csv",
+        deliveryMethod: "email",
+      };
+
+      await expect(handler.validate(payload)).resolves.toBeUndefined();
+    });
+
+    it("throws PermanentJobError for an invalid payload", async () => {
+      const payload = {
+        userId: "",
+        exportType: "unknown",
+        filters: {},
+        format: "xml",
+        deliveryMethod: "fax",
+      } as unknown as ExportGenerationPayload;
+
+      await expect(handler.validate(payload)).rejects.toThrow(
+        PermanentJobError,
+      );
+    });
+  });
+
+  describe("onFailure", () => {
+    it("does not throw after permanent failure", async () => {
+      await expect(
+        handler.onFailure(makeJob(), new Error("exhausted")),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/app/backend/src/job-queue/handlers/export-generation.handler.ts
+++ b/app/backend/src/job-queue/handlers/export-generation.handler.ts
@@ -11,6 +11,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { JobHandler, Job, CancellationToken } from '../types';
 import { ExportGenerationPayload } from '../types/job-payloads.types';
 import { SupabaseService } from '../../supabase/supabase.service';
+import { NotificationService } from '../../notifications/notification.service';
+import { ExportCompletedPayload } from '../../notifications/types/notification.types';
 
 /**
  * Error thrown for permanent job failures (no retry)
@@ -36,6 +38,7 @@ export class ExportGenerationHandler implements JobHandler<ExportGenerationPaylo
 
   constructor(
     private readonly supabase: SupabaseService,
+    private readonly notificationService: NotificationService,
   ) {}
 
   /**
@@ -75,7 +78,16 @@ export class ExportGenerationHandler implements JobHandler<ExportGenerationPaylo
       );
 
       // Deliver export via specified method
-      await this.deliverExport(userId, exportType, exportData, format, deliveryMethod, cancellationToken);
+      await this.deliverExport(
+        userId,
+        exportType,
+        exportData,
+        format,
+        deliveryMethod,
+        records.length,
+        job.id,
+        cancellationToken,
+      );
 
       this.logger.log(
         `Export delivered successfully via ${deliveryMethod} (jobId: ${job.id})`,
@@ -229,13 +241,18 @@ export class ExportGenerationHandler implements JobHandler<ExportGenerationPaylo
    * Deliver export via specified method
    * 
    * Supports webhook, email, and download link delivery methods.
+   * Email delivery is routed through the notifications module and its
+   * versioned template system (BE-101).
    * 
    * @param userId - User ID requesting the export
    * @param exportType - Type of export
    * @param exportData - Export data as string
    * @param format - Export format
    * @param deliveryMethod - How to deliver the export
+   * @param recordCount - Number of records included in the export
+   * @param jobId - ID of the export generation job
    * @param cancellationToken - Token to check for cancellation
+   * @throws Error when email delivery fails (surfaced on the export job record)
    */
   private async deliverExport(
     userId: string,
@@ -243,6 +260,8 @@ export class ExportGenerationHandler implements JobHandler<ExportGenerationPaylo
     exportData: string,
     format: string,
     deliveryMethod: 'webhook' | 'email' | 'download',
+    recordCount: number,
+    jobId: string,
     cancellationToken: CancellationToken,
   ): Promise<void> {
     cancellationToken.throwIfCancelled();
@@ -254,11 +273,40 @@ export class ExportGenerationHandler implements JobHandler<ExportGenerationPaylo
         this.logger.log(`Webhook delivery not yet implemented for user ${userId}`);
         break;
 
-      case 'email':
-        // TODO: Implement email delivery
-        // For now, just log
-        this.logger.log(`Email delivery not yet implemented for user ${userId}`);
+      case 'email': {
+        const payload: ExportCompletedPayload = {
+          eventType: 'export.completed',
+          eventId: `export:${jobId}`,
+          recipientPublicKey: userId,
+          title: `Your ${exportType} export is ready`,
+          body: `Your ${format.toUpperCase()} export of ${recordCount} ${recordCount === 1 ? 'record' : 'records'} has been generated and is attached to this delivery.`,
+          occurredAt: new Date().toISOString(),
+          exportType,
+          format,
+          recordCount,
+          jobId,
+          metadata: {
+            jobId,
+            exportType,
+            format,
+            recordCount,
+            sizeBytes: Buffer.byteLength(exportData, 'utf8'),
+          },
+        };
+
+        const result = await this.notificationService.deliverExportEmail(payload);
+
+        if (!result.delivered) {
+          const errorMessage = `Email delivery failed for export (jobId: ${jobId}): ${result.error ?? 'unknown error'}`;
+          this.logger.error(errorMessage);
+          throw new Error(errorMessage);
+        }
+
+        this.logger.log(
+          `Export email delivered via template version ${result.templateVersionId ?? 'fallback'} (jobId: ${jobId})`,
+        );
         break;
+      }
 
       case 'download':
         // TODO: Implement download link generation (store in S3/Supabase Storage)

--- a/app/backend/src/notifications/__tests__/notification.service.unit.spec.ts
+++ b/app/backend/src/notifications/__tests__/notification.service.unit.spec.ts
@@ -6,9 +6,12 @@ import { NotificationLogRepository } from "../notification-log.repository";
 import { InAppNotificationRepository } from "../in-app-notification.repository";
 import { TemplateVersionService } from "../template-versioning/template-version.service";
 import { NOTIFICATION_PROVIDERS } from "../providers/notification-provider.interface";
+// Real renderer used so template variable substitution is exercised end-to-end
+const realRenderer = new TemplateVersionService(null as never);
 import type {
   NotificationPreference,
   NotificationPayload,
+  ExportCompletedPayload,
 } from "../types/notification.types";
 import type { EscrowDepositedEvent } from "../../ingestion/types/contract-event.types";
 
@@ -67,6 +70,24 @@ function makePayload(
     sender: "GSENDER",
     ...overrides,
   } as NotificationPayload;
+}
+
+function makeExportPayload(
+  overrides: Partial<ExportCompletedPayload> = {},
+): ExportCompletedPayload {
+  return {
+    eventType: "export.completed",
+    eventId: "export:job-1",
+    recipientPublicKey: PUBLIC_KEY,
+    title: "Your transactions export is ready",
+    body: "Your CSV export of 42 records has been generated.",
+    occurredAt: new Date().toISOString(),
+    exportType: "transactions",
+    format: "csv",
+    recordCount: 42,
+    jobId: "job-1",
+    ...overrides,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -421,6 +442,142 @@ describe("NotificationService", () => {
 
       await service.retryFailedNotifications();
       expect(emailProvider.send).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // deliverExportEmail (BE-101)
+  // -------------------------------------------------------------------------
+
+  describe("deliverExportEmail", () => {
+    beforeEach(() => {
+      service.rateLimiter.reset();
+      logRepo.isAlreadySent.mockResolvedValue(false);
+      templateService.renderActiveTemplateForEventType.mockImplementation(
+        async (_eventType: string, data: Record<string, unknown>) => ({
+          title: realRenderer.render(
+            "Export ready: {{exportType}} ({{recordCount}} records)",
+            data,
+          ),
+          body: realRenderer.render("Rendered export body for {{format}}", data),
+          templateVersionId: "tpl-version-7",
+        }),
+      );
+      prefsRepo.getEnabledPreferences.mockResolvedValue([makeEmailPref()]);
+    });
+
+    it("renders the active versioned template and sends it via the email provider", async () => {
+      const result = await service.deliverExportEmail(makeExportPayload());
+
+      expect(
+        templateService.renderActiveTemplateForEventType,
+      ).toHaveBeenCalledWith(
+        "export.completed",
+        expect.objectContaining({ recipientPublicKey: PUBLIC_KEY, jobId: "job-1" }),
+      );
+
+      // The provider must receive the rendered template output, not the inline strings
+      expect(emailProvider.send).toHaveBeenCalledWith(
+        makeEmailPref(),
+        expect.objectContaining({
+          title: "Export ready: transactions (42 records)",
+          body: "Rendered export body for csv",
+        }),
+      );
+
+      expect(result).toEqual({
+        delivered: true,
+        templateVersionId: "tpl-version-7",
+        error: undefined,
+      });
+
+      // Template version id is persisted on the notification log
+      expect(logRepo.createPending).toHaveBeenCalledWith(
+        PUBLIC_KEY,
+        "email",
+        "export.completed",
+        "export:job-1",
+        "tpl-version-7",
+      );
+      expect(logRepo.markSent).toHaveBeenCalled();
+    });
+
+    it("falls back to inline title/body when no active template version exists", async () => {
+      templateService.renderActiveTemplateForEventType.mockResolvedValue(null);
+
+      const result = await service.deliverExportEmail(makeExportPayload());
+
+      expect(result.delivered).toBe(true);
+      expect(result.templateVersionId).toBeUndefined();
+      expect(emailProvider.send).toHaveBeenCalledWith(
+        makeEmailPref(),
+        expect.objectContaining({
+          title: "Your transactions export is ready",
+          body: "Your CSV export of 42 records has been generated.",
+        }),
+      );
+    });
+
+    it("returns delivered:false and records failure when the provider rejects", async () => {
+      emailProvider.send.mockRejectedValue(new Error("SendGrid 500"));
+
+      const result = await service.deliverExportEmail(makeExportPayload());
+
+      expect(result.delivered).toBe(false);
+      expect(result.error).toContain("SendGrid 500");
+      expect(logRepo.markFailed).toHaveBeenCalledWith(
+        PUBLIC_KEY,
+        "email",
+        "export.completed",
+        "export:job-1",
+        "SendGrid 500",
+      );
+      expect(logRepo.markSent).not.toHaveBeenCalled();
+    });
+
+    it("returns delivered:false when the user has no enabled email preference", async () => {
+      prefsRepo.getEnabledPreferences.mockResolvedValue([]);
+
+      const result = await service.deliverExportEmail(makeExportPayload());
+
+      expect(result.delivered).toBe(false);
+      expect(result.error).toMatch(/No enabled email channel preference/i);
+      expect(emailProvider.send).not.toHaveBeenCalled();
+    });
+
+    it("returns delivered:false when an email preference exists without an address", async () => {
+      prefsRepo.getEnabledPreferences.mockResolvedValue([
+        makeEmailPref({ email: undefined }),
+      ]);
+
+      const result = await service.deliverExportEmail(makeExportPayload());
+
+      expect(result.delivered).toBe(false);
+      expect(result.error).toMatch(/No enabled email channel preference/i);
+      expect(emailProvider.send).not.toHaveBeenCalled();
+    });
+
+    it("returns delivered:false when preferences cannot be loaded", async () => {
+      prefsRepo.getEnabledPreferences.mockRejectedValue(new Error("DB down"));
+
+      const result = await service.deliverExportEmail(makeExportPayload());
+
+      expect(result.delivered).toBe(false);
+      expect(result.error).toContain("DB down");
+      expect(emailProvider.send).not.toHaveBeenCalled();
+    });
+
+    it("uses only the email channel even when other channels are enabled", async () => {
+      prefsRepo.getEnabledPreferences.mockResolvedValue([
+        makeEmailPref(),
+        makeEmailPref({ id: "pref-2", channel: "in_app" }),
+      ]);
+
+      const result = await service.deliverExportEmail(makeExportPayload());
+
+      expect(result.delivered).toBe(true);
+      expect(inAppRepo.create).not.toHaveBeenCalled();
+      expect(emailProvider.send).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/backend/src/notifications/notification.service.ts
+++ b/app/backend/src/notifications/notification.service.ts
@@ -20,6 +20,7 @@ import type {
   UsernameClaimedPayload,
   AutoReconciliationSucceededNotificationPayload,
   PaymentLinkExpiredPayload,
+  ExportCompletedPayload,
 } from "./types/notification.types";
 
 import {
@@ -43,6 +44,23 @@ import { InAppNotificationRepository } from "./in-app-notification.repository";
 import { TemplateVersionService } from "./template-versioning/template-version.service";
 
 const MAX_ATTEMPTS = 3;
+
+/** Outcome of a single channel delivery attempt. */
+export interface ChannelDeliveryResult {
+  /** Whether the notification reached (or was already delivered to) the channel. */
+  ok: boolean;
+  /** Populated when the delivery did not succeed. */
+  error?: string;
+  /** Provider message id when available. */
+  messageId?: string;
+}
+
+/** Outcome of an export email delivery request. */
+export interface ExportEmailDeliveryResult {
+  delivered: boolean;
+  templateVersionId?: string;
+  error?: string;
+}
 
 @Injectable()
 export class NotificationService implements OnModuleInit {
@@ -288,7 +306,7 @@ export class NotificationService implements OnModuleInit {
     pref: NotificationPreference,
     payload: NotificationPayload,
     templateVersionId?: string,
-  ): Promise<void> {
+  ): Promise<ChannelDeliveryResult> {
     const { publicKey, channel } = pref;
     const { eventType, eventId } = payload;
 
@@ -299,9 +317,14 @@ export class NotificationService implements OnModuleInit {
       eventId,
     );
 
-    if (alreadySent) return;
+    if (alreadySent) return { ok: true };
 
-    if (!this.rateLimiter.allow(publicKey, channel)) return;
+    if (!this.rateLimiter.allow(publicKey, channel)) {
+      return {
+        ok: false,
+        error: `Rate limit exceeded for ${publicKey} on channel ${channel}`,
+      };
+    }
 
     // ✅ IN-APP CHANNEL
     if (channel === "in_app") {
@@ -320,27 +343,30 @@ export class NotificationService implements OnModuleInit {
         });
 
         await this.logRepo.markSent(publicKey, channel, eventType, eventId);
+        return { ok: true };
       } catch (err) {
+        const message = (err as Error).message;
         await this.logRepo.markFailed(
           publicKey,
           channel,
           eventType,
           eventId,
-          (err as Error).message,
+          message,
         );
+        return { ok: false, error: message };
       }
-
-      return;
     }
 
     // webhook async handling
     if (channel === "webhook" && this.jobQueueService) {
       await this.enqueueWebhookJob(pref, payload, templateVersionId);
-      return;
+      return { ok: true };
     }
 
     const provider = this.providerMap.get(channel);
-    if (!provider) return;
+    if (!provider) {
+      return { ok: false, error: `No provider registered for channel ${channel}` };
+    }
 
     await this.logRepo.createPending(publicKey, channel, eventType, eventId, templateVersionId);
     await this.logRepo.createPending(publicKey, channel, eventType, eventId, payload.previewScope);
@@ -357,15 +383,80 @@ export class NotificationService implements OnModuleInit {
         result.httpStatus,
         result.responseBody,
       );
+
+      return { ok: true, messageId: result.messageId };
     } catch (err) {
+      const message = (err as Error).message;
       await this.logRepo.markFailed(
         publicKey,
         channel,
         eventType,
         eventId,
-        (err as Error).message,
+        message,
       );
+      return { ok: false, error: message };
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // EXPORT EMAIL DELIVERY (BE-101)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Deliver a completed-export notification email.
+   *
+   * Routes through the existing notifications pipeline: the recipient's enabled
+   * email preference is resolved, the active versioned template for
+   * `export.completed` is rendered, and the configured email provider sends it.
+   *
+   * Unlike {@link dispatch}, this returns the delivery outcome so callers
+   * (e.g. the export generation job handler) can surface failures instead of
+   * having them swallowed.
+   */
+  async deliverExportEmail(
+    payload: ExportCompletedPayload,
+  ): Promise<ExportEmailDeliveryResult> {
+    let emailPref: NotificationPreference | undefined;
+
+    try {
+      const preferences = await this.prefsRepo.getEnabledPreferences(
+        payload.recipientPublicKey,
+      );
+      emailPref = preferences.find((pref) => pref.channel === "email");
+    } catch (err) {
+      const message = `Failed to load notification preferences: ${(err as Error).message}`;
+      this.logger.error(message);
+      return { delivered: false, error: message };
+    }
+
+    if (!emailPref || !emailPref.email) {
+      return {
+        delivered: false,
+        error: `No enabled email channel preference with an email address found for ${payload.recipientPublicKey}`,
+      };
+    }
+
+    const renderedTemplate =
+      await this.templateVersionService.renderActiveTemplateForEventType(
+        payload.eventType,
+        payload as unknown as Record<string, unknown>,
+      );
+
+    const templatedPayload: ExportCompletedPayload = renderedTemplate
+      ? { ...payload, title: renderedTemplate.title, body: renderedTemplate.body }
+      : payload;
+
+    const result = await this.sendToChannel(
+      emailPref,
+      templatedPayload,
+      renderedTemplate?.templateVersionId,
+    );
+
+    return {
+      delivered: result.ok,
+      templateVersionId: renderedTemplate?.templateVersionId,
+      error: result.error,
+    };
   }
 
   // ---------------------------------------------------------------------------

--- a/app/backend/src/notifications/types/notification.types.ts
+++ b/app/backend/src/notifications/types/notification.types.ts
@@ -29,7 +29,8 @@ export type NotificationEventType =
   | "recurring.link.resumed"
   | "recurring.link.completed"
   | "auto_reconciliation.succeeded"
-  | "payment.link.expired";
+  | "payment.link.expired"
+  | "export.completed";
 
 export type PaymentLinkExpiredEvent = "payment.link.expired";
 
@@ -154,6 +155,18 @@ export interface AutoReconciliationSucceededNotificationPayload extends BaseNoti
   confidence: number;
 }
 
+export interface ExportCompletedPayload extends BaseNotificationPayload {
+  eventType: "export.completed";
+  /** Type of data contained in the export (transactions, links, payments). */
+  exportType: string;
+  /** Export file format (csv or json). */
+  format: string;
+  /** Number of records included in the export. */
+  recordCount: number;
+  /** ID of the export generation job this notification belongs to. */
+  jobId: string;
+}
+
 export type NotificationPayload =
   | EscrowDepositedPayload
   | EscrowWithdrawnPayload
@@ -165,7 +178,8 @@ export type NotificationPayload =
   | RecurringPaymentFailedPayload
   | RecurringLinkStatusPayload
   | AutoReconciliationSucceededNotificationPayload
-  | PaymentLinkExpiredPayload;
+  | PaymentLinkExpiredPayload
+  | ExportCompletedPayload;
 
 // ---------------------------------------------------------------------------
 // User preferences


### PR DESCRIPTION
Implements BE-101 (#800). Export generation jobs targeting the email delivery method now route through NotificationService.deliverExportEmail, which renders the active versioned template for the export.completed event type and sends via the existing email provider pipeline.

- Add export.completed event type and ExportCompletedPayload
- sendToChannel now reports per-delivery outcome instead of swallowing errors
- Handler throws on delivery failure so it is recorded on the export job record
- Tests cover template rendering and provider failure handling

closes: #800 