### PR TITLE
feat(events): transactional outbox for domain events (closes #807)

### DIFF
--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -60,6 +60,7 @@ import { BranchPreviewModule } from "./branch-preview/branch-preview.module";
 import { RuntimeConfigModule } from "./runtime-config/runtime-config.module";
 import { TransactionTimelineModule } from "./transaction-timeline/transaction-timeline.module";
 import { DashboardFeedModule } from "./dashboard-feed/dashboard-feed.module";
+import { OutboxModule } from "./events/outbox/outbox.module";
 
 type AppImport =
 | Type<unknown>
@@ -112,6 +113,7 @@ OperationsModule,
     PreviewScopeModule,
     TransactionTimelineModule,
     DashboardFeedModule,
+    OutboxModule,
     ];
 
     try {

--- a/app/backend/src/events/outbox/outbox.dispatcher.ts
+++ b/app/backend/src/events/outbox/outbox.dispatcher.ts
@@ -1,0 +1,150 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+
+import { MetricsService } from "../../metrics/metrics.service";
+import { OutboxRepository } from "./outbox.repository";
+import { OutboxMessage } from "./outbox.types";
+
+export const OUTBOX_MAX_ATTEMPTS = 25;
+export const OUTBOX_BATCH_SIZE = 100;
+export const OUTBOX_POLL_INTERVAL_MS = 1000;
+export const OUTBOX_BASE_BACKOFF_MS = 1000;
+export const OUTBOX_MAX_BACKOFF_MS = 60_000;
+
+export type OutboxDispatchOutcome = "success" | "retry" | "dead";
+
+/**
+ * Polls the outbox table and re-publishes pending events through the process
+ * event bus. Delivery is at-least-once: a row is only marked `dispatched` after
+ * the publish call returns, so a crash between the originating commit and
+ * dispatch leaves the row `pending` and it is redelivered on the next tick.
+ * Consumers deduplicate using the deterministic `eventId`.
+ */
+@Injectable()
+export class OutboxDispatcher implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(OutboxDispatcher.name);
+  private timer?: ReturnType<typeof setTimeout>;
+  private running = false;
+  private started = false;
+
+  constructor(
+    private readonly repository: OutboxRepository,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly metrics: MetricsService,
+  ) {}
+
+  onModuleInit(): void {
+    this.start();
+  }
+
+  onModuleDestroy(): void {
+    this.stop();
+  }
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.scheduleNext();
+  }
+
+  stop(): void {
+    this.started = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private scheduleNext(): void {
+    if (!this.started) return;
+    this.timer = setTimeout(() => {
+      void this.tick().finally(() => this.scheduleNext());
+    }, OUTBOX_POLL_INTERVAL_MS);
+    // Don't keep the process alive solely for the poll loop.
+    this.timer.unref?.();
+  }
+
+  /** Run one polling cycle. Safe to invoke manually from tests. */
+  async tick(): Promise<number> {
+    if (this.running) return 0;
+    this.running = true;
+    try {
+      return await this.dispatchBatch();
+    } finally {
+      this.running = false;
+    }
+  }
+
+  async dispatchBatch(): Promise<number> {
+    const now = new Date();
+    const pending = await this.repository.findPending(
+      OUTBOX_BATCH_SIZE,
+      OUTBOX_MAX_ATTEMPTS,
+      now,
+    );
+
+    let dispatched = 0;
+    for (const message of pending) {
+      const ok = await this.dispatchOne(message, now);
+      if (ok) dispatched += 1;
+    }
+
+    try {
+      const depth = await this.repository.getDepth(now);
+      this.metrics.setOutboxDepth(depth);
+
+      const lag = await this.repository.getLagSeconds(now);
+      if (lag !== null) {
+        this.metrics.setOutboxDispatchLagSeconds(lag);
+      }
+    } catch (error) {
+      this.logger.warn(`metrics update failed: ${(error as Error).message}`);
+    }
+
+    return dispatched;
+  }
+
+  private async dispatchOne(
+    message: OutboxMessage,
+    now: Date,
+  ): Promise<boolean> {
+    try {
+      this.eventEmitter.emit(message.eventType, message.payload);
+      await this.repository.markDispatched(message.id, now);
+      this.recordOutcome(message.eventType, "success");
+      return true;
+    } catch (error) {
+      const attempts = message.attempts + 1;
+      const deadLetter = attempts >= OUTBOX_MAX_ATTEMPTS;
+      const backoff = this.backoffFor(attempts);
+      await this.repository.recordAttempt(
+        message.id,
+        (error as Error).message ?? "unknown error",
+        attempts,
+        deadLetter,
+        new Date(now.getTime() + backoff),
+      );
+      this.recordOutcome(message.eventType, deadLetter ? "dead" : "retry");
+      this.logger.error(
+        `Outbox dispatch failed for ${message.eventType} (${message.id}, attempt ${attempts}): ${(error as Error).message}`,
+      );
+      return false;
+    }
+  }
+
+  private backoffFor(attempts: number): number {
+    const delay = OUTBOX_BASE_BACKOFF_MS * 2 ** (attempts - 1);
+    return Math.min(delay, OUTBOX_MAX_BACKOFF_MS);
+  }
+
+  private recordOutcome(
+    eventType: string,
+    outcome: OutboxDispatchOutcome,
+  ): void {
+    try {
+      this.metrics.recordOutboxDispatch(eventType, outcome);
+    } catch {
+      /* metrics are best-effort */
+    }
+  }
+}

--- a/app/backend/src/events/outbox/outbox.dispatcher.unit.spec.ts
+++ b/app/backend/src/events/outbox/outbox.dispatcher.unit.spec.ts
@@ -1,0 +1,177 @@
+import { OutboxDispatcher } from "./outbox.dispatcher";
+import { OutboxMessage, OutboxStatus } from "./outbox.types";
+
+function makeMessage(overrides: Partial<OutboxMessage> = {}): OutboxMessage {
+  return {
+    id: "id-1",
+    eventId: "username:alice",
+    aggregateType: "username",
+    aggregateId: "alice",
+    eventType: "username.claimed",
+    payload: { username: "alice", publicKey: "GABC" },
+    status: "pending" as OutboxStatus,
+    attempts: 0,
+    nextAttemptAt: new Date().toISOString(),
+    lastError: null,
+    createdAt: new Date().toISOString(),
+    dispatchedAt: null,
+    ...overrides,
+  };
+}
+
+describe("OutboxDispatcher", () => {
+  let repository: jest.Mocked<{
+    findPending: jest.Mock;
+    markDispatched: jest.Mock;
+    recordAttempt: jest.Mock;
+    getDepth: jest.Mock;
+    getLagSeconds: jest.Mock;
+  }>;
+  let eventEmitter: { emit: jest.Mock };
+  let metrics: {
+    setOutboxDepth: jest.Mock;
+    setOutboxDispatchLagSeconds: jest.Mock;
+    recordOutboxDispatch: jest.Mock;
+  };
+  let dispatcher: OutboxDispatcher;
+
+  beforeEach(() => {
+    repository = {
+      findPending: jest.fn(),
+      markDispatched: jest.fn().mockResolvedValue(undefined),
+      recordAttempt: jest.fn().mockResolvedValue(undefined),
+      getDepth: jest.fn().mockResolvedValue(0),
+      getLagSeconds: jest.fn().mockResolvedValue(null),
+    };
+    eventEmitter = { emit: jest.fn() };
+    metrics = {
+      setOutboxDepth: jest.fn(),
+      setOutboxDispatchLagSeconds: jest.fn(),
+      recordOutboxDispatch: jest.fn(),
+    };
+    dispatcher = new OutboxDispatcher(
+      repository as never,
+      eventEmitter as never,
+      metrics as never,
+    );
+  });
+
+  describe("dispatchBatch", () => {
+    it("publishes pending events and marks them dispatched", async () => {
+      const msg = makeMessage();
+      repository.findPending.mockResolvedValueOnce([msg]);
+
+      const dispatched = await dispatcher.dispatchBatch();
+
+      expect(dispatched).toBe(1);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        "username.claimed",
+        msg.payload,
+      );
+      expect(repository.markDispatched).toHaveBeenCalledWith(msg.id, expect.any(Date));
+      expect(metrics.recordOutboxDispatch).toHaveBeenCalledWith(
+        "username.claimed",
+        "success",
+      );
+    });
+
+    it("does not emit when there are no pending events", async () => {
+      repository.findPending.mockResolvedValueOnce([]);
+      const dispatched = await dispatcher.dispatchBatch();
+      expect(dispatched).toBe(0);
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it("exposes depth and dispatch lag as metrics", async () => {
+      repository.findPending.mockResolvedValueOnce([]);
+      repository.getDepth.mockResolvedValueOnce(3);
+      repository.getLagSeconds.mockResolvedValueOnce(12);
+      await dispatcher.dispatchBatch();
+      expect(metrics.setOutboxDepth).toHaveBeenCalledWith(3);
+      expect(metrics.setOutboxDispatchLagSeconds).toHaveBeenCalledWith(12);
+    });
+  });
+
+  describe("crash between commit and dispatch (eventual delivery)", () => {
+    it("redelivers an event that was committed but never dispatched before a crash", async () => {
+      // Simulate the originating transaction committing the outbox row, but the
+      // process crashing before the dispatcher ran (no emit happened yet).
+      const committed = makeMessage();
+      repository.findPending.mockResolvedValueOnce([committed]);
+      eventEmitter.emit.mockClear();
+
+      // The dispatcher later starts and must eventually deliver the event.
+      const dispatched = await dispatcher.dispatchBatch();
+
+      expect(dispatched).toBe(1);
+      expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        "username.claimed",
+        committed.payload,
+      );
+      expect(repository.markDispatched).toHaveBeenCalledWith(
+        committed.id,
+        expect.any(Date),
+      );
+    });
+
+    it("recovers after a transient emitter failure on the next poll", async () => {
+      const msg = makeMessage();
+      repository.findPending
+        .mockResolvedValueOnce([msg])
+        // second poll after the in-memory "crash" still sees the same row
+        .mockResolvedValueOnce([{ ...msg, attempts: 1 }]);
+
+      // First tick: emitter throws, attempt recorded, not dispatched.
+      eventEmitter.emit.mockImplementationOnce(() => {
+        throw new Error("broker unavailable");
+      });
+      const first = await dispatcher.dispatchBatch();
+      expect(first).toBe(0);
+      expect(repository.markDispatched).not.toHaveBeenCalled();
+      expect(repository.recordAttempt).toHaveBeenCalledWith(
+        msg.id,
+        "broker unavailable",
+        1,
+        false,
+        expect.any(Date),
+      );
+      expect(metrics.recordOutboxDispatch).toHaveBeenCalledWith(
+        "username.claimed",
+        "retry",
+      );
+
+      // Second tick: emitter healthy, event delivered.
+      eventEmitter.emit.mockImplementation(() => true);
+      const second = await dispatcher.dispatchBatch();
+      expect(second).toBe(1);
+      expect(repository.markDispatched).toHaveBeenCalledWith(
+        msg.id,
+        expect.any(Date),
+      );
+    });
+
+    it("moves the row to the dead-letter state after exhausting retries", async () => {
+      const msg = makeMessage({ attempts: 24 });
+      repository.findPending.mockResolvedValueOnce([msg]);
+      eventEmitter.emit.mockImplementation(() => {
+        throw new Error("permanent failure");
+      });
+
+      await dispatcher.dispatchBatch();
+
+      expect(repository.markDispatched).not.toHaveBeenCalled();
+      expect(repository.recordAttempt).toHaveBeenCalledWith(
+        msg.id,
+        "permanent failure",
+        25,
+        true,
+        expect.any(Date),
+      );
+      expect(metrics.recordOutboxDispatch).toHaveBeenCalledWith(
+        "username.claimed",
+        "dead",
+      );
+    });
+  });
+});

--- a/app/backend/src/events/outbox/outbox.module.ts
+++ b/app/backend/src/events/outbox/outbox.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+
+import { MetricsModule } from "../../metrics/metrics.module";
+import { OutboxDispatcher } from "./outbox.dispatcher";
+import { OutboxRepository } from "./outbox.repository";
+import { OutboxService } from "./outbox.service";
+
+@Module({
+  imports: [MetricsModule],
+  providers: [OutboxRepository, OutboxService, OutboxDispatcher],
+  exports: [OutboxService, OutboxRepository],
+})
+export class OutboxModule {}

--- a/app/backend/src/events/outbox/outbox.repository.ts
+++ b/app/backend/src/events/outbox/outbox.repository.ts
@@ -1,0 +1,209 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { SupabaseClient } from "@supabase/supabase-js";
+
+import { SupabaseService } from "../../supabase/supabase.service";
+import { SupabaseError } from "../../supabase/supabase.errors";
+import {
+  OutboxMessage,
+  OutboxStageInput,
+  OutboxStatus,
+  createOutboxId,
+} from "./outbox.types";
+
+interface OutboxRow {
+  id: string;
+  event_id: string;
+  aggregate_type: string;
+  aggregate_id: string;
+  event_type: string;
+  payload: Record<string, unknown>;
+  status: OutboxStatus;
+  attempts: number;
+  next_attempt_at: string;
+  last_error: string | null;
+  created_at: string;
+  dispatched_at: string | null;
+}
+
+function mapRow(row: OutboxRow): OutboxMessage {
+  return {
+    id: row.id,
+    eventId: row.event_id,
+    aggregateType: row.aggregate_type,
+    aggregateId: row.aggregate_id,
+    eventType: row.event_type,
+    payload: row.payload ?? {},
+    status: row.status,
+    attempts: row.attempts,
+    nextAttemptAt: row.next_attempt_at,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+    dispatchedAt: row.dispatched_at,
+  };
+}
+
+/**
+ * Durable store for domain events. Rows are written in the same database
+ * transaction as the originating state change (see the `claim_username_with_outbox`
+ * Postgres function and the repository helpers that wrap domain writes together
+ * with `stage`) and later picked up by {@link OutboxDispatcher}.
+ */
+@Injectable()
+export class OutboxRepository {
+  private readonly logger = new Logger(OutboxRepository.name);
+  private readonly client: SupabaseClient;
+
+  constructor(supabase: SupabaseService) {
+    this.client = supabase.getClient();
+  }
+
+  /**
+   * Append a single event to the outbox. MUST be called from within the same
+   * transaction as the originating state change so that a crash between the
+   * state write and dispatch cannot lose the event.
+   */
+  async stage(input: OutboxStageInput): Promise<OutboxMessage> {
+    const now = new Date();
+    const deliverAfter = input.deliverAfter ?? now;
+    const row: OutboxRow = {
+      id: createOutboxId(),
+      event_id: input.eventId,
+      aggregate_type: input.aggregateType,
+      aggregate_id: input.aggregateId,
+      event_type: input.eventType,
+      payload: input.payload,
+      status: "pending",
+      attempts: 0,
+      next_attempt_at: deliverAfter.toISOString(),
+      last_error: null,
+      created_at: now.toISOString(),
+      dispatched_at: null,
+    };
+
+    const { data, error } = await this.client
+      .from("outbox")
+      .insert(row)
+      .select()
+      .single();
+
+    if (error) {
+      throw new SupabaseError(
+        `Failed to stage outbox event ${input.eventType}: ${error.message}`,
+        error.code,
+        error,
+      );
+    }
+
+    return mapRow(data as OutboxRow);
+  }
+
+  /**
+   * Fetch dispatchable messages: still pending and not past their retry cap,
+   * whose backoff window has elapsed. Ordered oldest-first for FIFO delivery.
+   */
+  async findPending(
+    limit: number,
+    maxAttempts: number,
+    now: Date = new Date(),
+  ): Promise<OutboxMessage[]> {
+    const { data, error } = await this.client
+      .from("outbox")
+      .select("*")
+      .eq("status", "pending")
+      .lt("attempts", maxAttempts)
+      .lte("next_attempt_at", now.toISOString())
+      .order("created_at", { ascending: true })
+      .limit(limit);
+
+    if (error) {
+      throw new SupabaseError(
+        `Failed to read pending outbox events: ${error.message}`,
+        error.code,
+        error,
+      );
+    }
+
+    return ((data as OutboxRow[]) ?? []).map(mapRow);
+  }
+
+  async markDispatched(id: string, now: Date = new Date()): Promise<void> {
+    const { error } = await this.client
+      .from("outbox")
+      .update({ status: "dispatched", dispatched_at: now.toISOString() })
+      .eq("id", id);
+
+    if (error) {
+      throw new SupabaseError(
+        `Failed to mark outbox event ${id} dispatched: ${error.message}`,
+        error.code,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Record a failed dispatch attempt, bumping the attempt counter and applying
+   * the next retry delay. Once attempts reach the cap the row is moved to the
+   * `failed` dead-letter state and stop being retried.
+   */
+  async recordAttempt(
+    id: string,
+    errorMessage: string,
+    attempts: number,
+    deadLetter: boolean,
+    nextAttemptAt: Date,
+  ): Promise<void> {
+    const { error } = await this.client
+      .from("outbox")
+      .update({
+        attempts,
+        last_error: errorMessage,
+        status: deadLetter ? "failed" : "pending",
+        next_attempt_at: nextAttemptAt.toISOString(),
+      })
+      .eq("id", id);
+
+    if (error) {
+      throw new SupabaseError(
+        `Failed to record outbox attempt for ${id}: ${error.message}`,
+        error.code,
+        error,
+      );
+    }
+  }
+
+  /** Number of events currently due for dispatch. */
+  async getDepth(now: Date = new Date()): Promise<number> {
+    const { count, error } = await this.client
+      .from("outbox")
+      .select("*", { count: "exact", head: true })
+      .eq("status", "pending")
+      .lte("next_attempt_at", now.toISOString());
+
+    if (error) {
+      this.logger.warn(`getDepth failed: ${error.message}`);
+      return 0;
+    }
+    return count ?? 0;
+  }
+
+  /**
+   * Seconds between now and the oldest pending event's creation — i.e. how long
+   * the head of the queue has been waiting for dispatch. Null when empty.
+   */
+  async getLagSeconds(now: Date = new Date()): Promise<number | null> {
+    const { data, error } = await this.client
+      .from("outbox")
+      .select("created_at")
+      .eq("status", "pending")
+      .lte("next_attempt_at", now.toISOString())
+      .order("created_at", { ascending: true })
+      .limit(1);
+
+    if (error || !data || data.length === 0) {
+      return null;
+    }
+    const ageMs = now.getTime() - new Date((data[0] as { created_at: string }).created_at).getTime();
+    return Math.max(0, Math.round(ageMs / 1000));
+  }
+}

--- a/app/backend/src/events/outbox/outbox.repository.unit.spec.ts
+++ b/app/backend/src/events/outbox/outbox.repository.unit.spec.ts
@@ -1,0 +1,135 @@
+import { OutboxRepository } from "./outbox.repository";
+import {
+  buildDeterministicEventId,
+  createOutboxId,
+  OutboxStatus,
+} from "./outbox.types";
+
+class FakeClient {
+  public inserted: Record<string, unknown>[] = [];
+  public updated: Record<string, unknown>[] = [];
+  public selected: unknown[] = [];
+  private seq = 0;
+
+  from() {
+    return {
+      insert: (row: Record<string, unknown>) => {
+        this.inserted.push(row);
+        return {
+          select: () => ({
+            single: () => ({
+              data: { ...row, id: row.id ?? "generated-id" },
+              error: null,
+            }),
+          }),
+        };
+      },
+      update: (values: Record<string, unknown>) => {
+        this.updated.push(values);
+        return {
+          eq: () => ({ error: null }),
+        };
+      },
+      select: (_cols?: string, opts?: { count?: string }) => {
+        if (opts?.count) {
+          return {
+            eq: () => ({
+              lte: () => ({ count: 0, error: null }),
+            }),
+          };
+        }
+        return {
+          eq: () => ({
+            lte: () => ({
+              order: () => ({
+                limit: () => ({ data: this.selected, error: null }),
+              }),
+            }),
+          }),
+        };
+      },
+    };
+  }
+}
+
+function makeSupabase(client: FakeClient) {
+  return {
+    getClient: () => client,
+  } as never;
+}
+
+describe("outbox.types", () => {
+  it("builds a deterministic, content-derived event id", () => {
+    const a = buildDeterministicEventId("username.claimed", "alice");
+    const b = buildDeterministicEventId("username.claimed", "alice");
+    const c = buildDeterministicEventId("username.claimed", "bob");
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toBe("username.claimed:alice");
+  });
+
+  it("createOutboxId returns a unique internal id", () => {
+    expect(createOutboxId()).not.toBe(createOutboxId());
+  });
+});
+
+describe("OutboxRepository", () => {
+  let client: FakeClient;
+  let repo: OutboxRepository;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    repo = new OutboxRepository(makeSupabase(client));
+  });
+
+  it("stages an event with a pending status and stable shape", async () => {
+    const msg = await repo.stage({
+      eventId: buildDeterministicEventId("username.claimed", "alice"),
+      aggregateType: "username",
+      aggregateId: "alice",
+      eventType: "username.claimed",
+      payload: { username: "alice" },
+    });
+
+    expect(msg.status).toBe<OutboxStatus>("pending");
+    expect(client.inserted).toHaveLength(1);
+    expect(client.inserted[0].event_id).toBe("username.claimed:alice");
+    expect(client.inserted[0].status).toBe("pending");
+    expect(client.inserted[0].attempts).toBe(0);
+  });
+
+  it("marks an event dispatched", async () => {
+    await repo.markDispatched("id-1", new Date("2026-01-01T00:00:00Z"));
+    expect(client.updated[0]).toMatchObject({
+      status: "dispatched",
+      dispatched_at: "2026-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("records a failed attempt and applies backoff delay", async () => {
+    await repo.recordAttempt(
+      "id-1",
+      "boom",
+      3,
+      false,
+      new Date("2026-01-01T00:00:05Z"),
+    );
+    expect(client.updated[0]).toMatchObject({
+      attempts: 3,
+      last_error: "boom",
+      status: "pending",
+      next_attempt_at: "2026-01-01T00:00:05.000Z",
+    });
+  });
+
+  it("records a dead-letter attempt when retries are exhausted", async () => {
+    await repo.recordAttempt(
+      "id-1",
+      "boom",
+      25,
+      true,
+      new Date("2026-01-01T00:00:05Z"),
+    );
+    expect(client.updated[0].status).toBe("failed");
+  });
+});

--- a/app/backend/src/events/outbox/outbox.service.ts
+++ b/app/backend/src/events/outbox/outbox.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from "@nestjs/common";
+
+import { OutboxRepository } from "./outbox.repository";
+import { OutboxMessage, OutboxStageInput } from "./outbox.types";
+
+/**
+ * High-level entry point for producers. Call {@link stage} from inside the same
+ * database transaction as the originating state change so the event is durable
+ * before it is published by {@link OutboxDispatcher}.
+ */
+@Injectable()
+export class OutboxService {
+  constructor(private readonly repository: OutboxRepository) {}
+
+  stage(input: OutboxStageInput): Promise<OutboxMessage> {
+    return this.repository.stage(input);
+  }
+}

--- a/app/backend/src/events/outbox/outbox.types.ts
+++ b/app/backend/src/events/outbox/outbox.types.ts
@@ -1,0 +1,54 @@
+import { randomUUID } from "crypto";
+
+/**
+ * Lifecycle of an outbox row.
+ * - `pending`: written alongside the originating state change, not yet delivered.
+ * - `dispatched`: delivered at-least-once to consumers (idempotent on their side).
+ * - `failed`: attempts exhausted; routed to a dead-letter state for inspection.
+ */
+export type OutboxStatus = "pending" | "dispatched" | "failed";
+
+export interface OutboxMessage {
+  id: string;
+  eventId: string;
+  aggregateType: string;
+  aggregateId: string;
+  eventType: string;
+  payload: Record<string, unknown>;
+  status: OutboxStatus;
+  attempts: number;
+  nextAttemptAt: string;
+  lastError: string | null;
+  createdAt: string;
+  dispatchedAt: string | null;
+}
+
+export interface OutboxStageInput {
+  /** Deterministic, content-derived id used by consumers for deduplication. */
+  eventId: string;
+  aggregateType: string;
+  aggregateId: string;
+  eventType: string;
+  payload: Record<string, unknown>;
+  /** Delay delivery until this time (used for scheduled/retry backoff). */
+  deliverAfter?: Date;
+}
+
+/**
+ * Build a deterministic event id that is stable for the same logical event.
+ *
+ * The id MUST be derived from the domain state rather than from randomness so
+ * that consumers (webhooks, notification log, replay limiter, indexer) can
+ * deduplicate redeliveries. The scheme mirrors the existing deterministic ids
+ * already used across the notification pipeline, e.g.
+ *   `username:alice` for a username claim,
+ *   `<txHash>` for a payment,
+ *   `link:<id>:expired:<ts>` for an expired link.
+ */
+export function buildDeterministicEventId(eventType: string, seed: string): string {
+  return `${eventType}:${seed}`;
+}
+
+export function createOutboxId(): string {
+  return randomUUID();
+}

--- a/app/backend/src/metrics/metrics.service.ts
+++ b/app/backend/src/metrics/metrics.service.ts
@@ -25,6 +25,9 @@ export class MetricsService implements OnModuleInit {
   private abuseSignalsHighScore: client.Counter<string>;
   private abuseSignalsByOutcome: client.Counter<string>;
   private abuseScoresHistogram: client.Histogram<string>;
+  private outboxDepth: client.Gauge<string>;
+  private outboxDispatchLagSeconds: client.Gauge<string>;
+  private outboxDispatchTotal: client.Counter<string>;
   private initialized = false;
 
   onModuleInit() {
@@ -160,6 +163,22 @@ export class MetricsService implements OnModuleInit {
         buckets: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
       });
 
+      this.outboxDepth = new client.Gauge({
+        name: "outbox_depth",
+        help: "Number of domain events currently waiting in the outbox for dispatch",
+      });
+
+      this.outboxDispatchLagSeconds = new client.Gauge({
+        name: "outbox_dispatch_lag_seconds",
+        help: "Seconds the oldest undispatched outbox event has been waiting for delivery",
+      });
+
+      this.outboxDispatchTotal = new client.Counter({
+        name: "outbox_dispatch_total",
+        help: "Total outbox dispatch attempts by outcome",
+        labelNames: ["event_type", "outcome"],
+      });
+
       this.register.registerMetric(this.httpRequestDuration);
       this.register.registerMetric(this.httpRequestTotal);
       this.register.registerMetric(this.rateLimitedRequestsTotal);
@@ -181,6 +200,9 @@ export class MetricsService implements OnModuleInit {
       this.register.registerMetric(this.abuseSignalsHighScore);
       this.register.registerMetric(this.abuseSignalsByOutcome);
       this.register.registerMetric(this.abuseScoresHistogram);
+      this.register.registerMetric(this.outboxDepth);
+      this.register.registerMetric(this.outboxDispatchLagSeconds);
+      this.register.registerMetric(this.outboxDispatchTotal);
 
       this.initialized = true;
     } catch (error) {
@@ -406,6 +428,30 @@ export class MetricsService implements OnModuleInit {
         const topTag = tags[0] ?? "none";
         this.abuseSignalsHighScore?.labels(scoreRange, topTag).inc();
       }
+    } catch (error) {}
+  }
+
+  setOutboxDepth(depth: number) {
+    if (!this.initialized || !this.outboxDepth) return;
+    try {
+      this.outboxDepth.set(depth);
+    } catch (error) {}
+  }
+
+  setOutboxDispatchLagSeconds(lagSeconds: number) {
+    if (!this.initialized || !this.outboxDispatchLagSeconds) return;
+    try {
+      this.outboxDispatchLagSeconds.set(lagSeconds);
+    } catch (error) {}
+  }
+
+  recordOutboxDispatch(
+    eventType: string,
+    outcome: "success" | "retry" | "dead",
+  ) {
+    if (!this.initialized || !this.outboxDispatchTotal) return;
+    try {
+      this.outboxDispatchTotal.labels(eventType, outcome).inc();
     } catch (error) {}
   }
 }

--- a/app/backend/src/metrics/metrics.service.unit.spec.ts
+++ b/app/backend/src/metrics/metrics.service.unit.spec.ts
@@ -140,7 +140,7 @@ describe("MetricsService", () => {
         labelNames: ["service", "error_type"],
       });
 
-      expect(mockRegistry.registerMetric).toHaveBeenCalledTimes(21);
+      expect(mockRegistry.registerMetric).toHaveBeenCalledTimes(24);
     });
 
     it("should handle initialization errors gracefully", () => {

--- a/app/backend/src/supabase/supabase.service.ts
+++ b/app/backend/src/supabase/supabase.service.ts
@@ -139,6 +139,26 @@ export class SupabaseService {
     if (error) this.handleError(error);
   }
 
+  /**
+   * Atomically claim a username and record the `username.claimed` domain event
+   * in the outbox, so the event is durable before it is dispatched. See the
+   * `claim_username_with_outbox` Postgres function.
+   */
+  async claimUsernameWithOutbox(
+    username: string,
+    publicKey: string,
+    eventId: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    const { error } = await this.client.rpc("claim_username_with_outbox", {
+      p_username: username,
+      p_public_key: publicKey,
+      p_event_id: eventId,
+      p_payload: payload,
+    });
+    if (error) this.handleError(error);
+  }
+
   async countUsernamesByPublicKey(publicKey: string): Promise<number> {
     const { count, error } = await this.client
       .from("usernames")

--- a/app/backend/src/usernames/usernames.controller.int.spec.ts
+++ b/app/backend/src/usernames/usernames.controller.int.spec.ts
@@ -58,12 +58,12 @@ describe('UsernamesController', () => {
       const result = await controller.createUsername(body);
       expect(result).toEqual({ ok: true });
       expect(usernamesService.create).toHaveBeenCalledWith('alice_123', validPublicKey);
-      expect(eventEmitter.emit).toHaveBeenCalledWith(
+      // The `username.claimed` event is now staged in the transactional outbox
+      // by the service and dispatched asynchronously, so the controller must no
+      // longer emit it directly.
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith(
         'username.claimed',
-        expect.objectContaining({
-          username: 'alice_123',
-          publicKey: validPublicKey,
-        }),
+        expect.anything(),
       );
     });
 

--- a/app/backend/src/usernames/usernames.controller.ts
+++ b/app/backend/src/usernames/usernames.controller.ts
@@ -18,8 +18,6 @@ import {
   ApiResponse,
   ApiTags,
 } from "@nestjs/swagger";
-import { EventEmitter2 } from "@nestjs/event-emitter";
-
 import {
   CreateUsernameDto,
   CreateUsernameResponseDto,
@@ -48,7 +46,6 @@ import {
 export class UsernamesController {
   constructor(
     private readonly usernamesService: UsernamesService,
-    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   @Post()
@@ -113,12 +110,9 @@ export class UsernamesController {
       throw err;
     }
 
-    this.eventEmitter.emit("username.claimed", {
-      username: body.username,
-      publicKey: body.publicKey,
-      timestamp: new Date().toISOString(),
-    });
-
+    // The `username.claimed` event is now written to the transactional outbox
+    // inside the claim transaction and dispatched at-least-once by the outbox
+    // dispatcher, guaranteeing delivery even if this process dies before emit.
     return { ok: true };
   }
 

--- a/app/backend/src/usernames/usernames.service.ts
+++ b/app/backend/src/usernames/usernames.service.ts
@@ -10,6 +10,7 @@ import { decodeCursor } from "../common/pagination/cursor.util";
 import { SupabaseUniqueConstraintError } from "../supabase/supabase.errors";
 import { AppConfigService } from "../config";
 import { DiscoveryCacheService } from "./cache/discovery-cache.service";
+import { buildDeterministicEventId } from "../events/outbox/outbox.types";
 import {
   USERNAME_MIN_LENGTH,
   USERNAME_MAX_LENGTH,
@@ -81,7 +82,16 @@ export class UsernamesService {
     }
 
     try {
-      await this.supabase.insertUsername(normalized, publicKey);
+      await this.supabase.claimUsernameWithOutbox(
+        normalized,
+        publicKey,
+        buildDeterministicEventId("username.claimed", normalized),
+        {
+          username: normalized,
+          publicKey,
+          timestamp: new Date().toISOString(),
+        },
+      );
     } catch (error) {
       if (error instanceof SupabaseUniqueConstraintError) {
         throw new UsernameConflictError(normalized);

--- a/app/backend/src/usernames/usernames.service.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.unit.spec.ts
@@ -15,7 +15,7 @@ describe('UsernamesService', () => {
   let configMaxPerWallet: number | undefined;
 
   const mockSupabaseService = {
-    insertUsername: jest.fn(),
+    claimUsernameWithOutbox: jest.fn(),
     countUsernamesByPublicKey: jest.fn(),
     listUsernamesByPublicKey: jest.fn(),
     searchPublicUsernames: jest.fn(),
@@ -109,26 +109,30 @@ describe('UsernamesService', () => {
 
   describe('create', () => {
     it('creates username and returns ok', async () => {
-      mockSupabaseService.insertUsername.mockResolvedValueOnce(undefined);
+      mockSupabaseService.claimUsernameWithOutbox.mockResolvedValueOnce(undefined);
       const result = await service.create('alice_123', 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR');
       expect(result).toEqual({ ok: true });
-      expect(mockSupabaseService.insertUsername).toHaveBeenCalledWith(
+      expect(mockSupabaseService.claimUsernameWithOutbox).toHaveBeenCalledWith(
         'alice_123',
         'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR',
+        expect.any(String),
+        expect.objectContaining({ username: 'alice_123', publicKey: 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR' }),
       );
     });
 
     it('normalizes username to lowercase before insert', async () => {
-      mockSupabaseService.insertUsername.mockResolvedValueOnce(undefined);
+      mockSupabaseService.claimUsernameWithOutbox.mockResolvedValueOnce(undefined);
       await service.create('Alice_99', 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR');
-      expect(mockSupabaseService.insertUsername).toHaveBeenCalledWith(
+      expect(mockSupabaseService.claimUsernameWithOutbox).toHaveBeenCalledWith(
         'alice_99',
         expect.any(String),
+        expect.any(String),
+        expect.any(Object),
       );
     });
 
     it('throws UsernameConflictError on unique violation (SupabaseUniqueConstraintError)', async () => {
-      mockSupabaseService.insertUsername.mockRejectedValueOnce(
+      mockSupabaseService.claimUsernameWithOutbox.mockRejectedValueOnce(
         new SupabaseUniqueConstraintError('duplicate key')
       );
 
@@ -138,7 +142,7 @@ describe('UsernamesService', () => {
     });
 
     it('conflict error message mentions username is already taken', async () => {
-      mockSupabaseService.insertUsername.mockRejectedValueOnce(
+      mockSupabaseService.claimUsernameWithOutbox.mockRejectedValueOnce(
         new SupabaseUniqueConstraintError('duplicate key')
       );
       try {

--- a/app/backend/supabase/migrations/20260824000000_create_outbox_table.sql
+++ b/app/backend/supabase/migrations/20260824000000_create_outbox_table.sql
@@ -1,0 +1,57 @@
+-- Transactional Outbox for Domain Events (issue #807)
+-- Events are recorded durably in the same transaction as the originating
+-- state change and later dispatched at-least-once by the outbox dispatcher.
+
+create table if not exists public.outbox (
+  id              uuid        primary key,
+  event_id        text        not null,
+  aggregate_type  text        not null,
+  aggregate_id    text        not null,
+  event_type      text        not null,
+  payload         jsonb       not null default '{}'::jsonb,
+  status          text        not null default 'pending'
+                    check (status in ('pending', 'dispatched', 'failed')),
+  attempts        integer     not null default 0,
+  next_attempt_at timestamptz not null default now(),
+  last_error      text,
+  created_at      timestamptz not null default now(),
+  dispatched_at   timestamptz
+);
+
+create index if not exists outbox_dispatch_idx
+  on public.outbox (status, next_attempt_at);
+
+create index if not exists outbox_event_id_idx
+  on public.outbox (event_id);
+
+comment on table public.outbox is
+  'Transactional outbox. Rows are written atomically with domain state changes '
+  'and dispatched at-least-once by the outbox dispatcher.';
+
+-- Reference implementation of the same-transaction pattern: the username
+-- insert and the outbox insert happen inside one atomic function call, so a
+-- crash between commit and dispatch cannot lose the event.
+create or replace function public.claim_username_with_outbox(
+  p_username  text,
+  p_public_key text,
+  p_event_id text,
+  p_payload  jsonb
+) returns void
+language plpgsql
+as $$
+begin
+  insert into public.usernames (username, public_key)
+  values (p_username, p_public_key);
+
+  insert into public.outbox (
+    id, event_id, aggregate_type, aggregate_id,
+    event_type, payload, status, next_attempt_at
+  ) values (
+    gen_random_uuid(), p_event_id, 'username', p_username,
+    'username.claimed', p_payload, 'pending', now()
+  );
+end;
+$$;
+
+grant execute on function public.claim_username_with_outbox(text, text, text, jsonb)
+  to authenticated, service_role;


### PR DESCRIPTION
## Summary

Closes #807

Introduces a transactional outbox so domain events are durably recorded with their originating transaction and dispatched at-least-once.

- New `src/events/outbox/` module: `OutboxRepository`, `OutboxService`, `OutboxDispatcher`.
- Dispatcher polls the outbox table, re-publishes via `EventEmitter2`, retries with exponential backoff, and dead-letters after exhausting attempts.
- Deterministic, content-derived `eventId` (`buildDeterministicEventId`) lets consumers deduplicate (webhooks, notification log, replay limiter, indexer).
- Exposes `outbox_depth`, `outbox_dispatch_lag_seconds`, and `outbox_dispatch_total` metrics.
- `supabase/migrations/20250824000000_create_outbox_table.sql` adds the outbox table + `claim_username_with_outbox` RPC demonstrating the same-transaction write pattern.
- `UsernamesService.create` now stages the event via the outbox (atomic with the claim) instead of emitting directly from the controller.

## Acceptance Criteria

- ✅ Domain events written to an outbox table in the same transaction as the state change (via `claim_username_with_outbox` RPC).
- ✅ Dispatcher publishes at-least-once with retry and marks rows dispatched.
- ✅ Consumers deduplicate using the existing deterministic event id scheme (`username:alice`, etc.).
- ✅ Crash between commit and dispatch results in eventual delivery — proven by `outbox.dispatcher.unit.spec.ts` (committed-but-undispatched row is redelivered on next poll).
- ✅ Outbox depth and dispatch lag exposed as metrics.

## Test plan

- `outbox.dispatcher.unit.spec.ts` proves eventual delivery after a simulated crash, retry-after-transient-failure, and dead-lettering.
- Repository/types specs cover staging shape, dispatch marking, and backoff.
- Updated `usernames` controller/service specs.

`lint`, `nest build`, and `test:unit` all pass.