### PR TITLE
BE-114: Split liveness and readiness probes with dependency checks

### DIFF
--- a/app/backend/docs/openapi.yaml
+++ b/app/backend/docs/openapi.yaml
@@ -102,8 +102,11 @@ paths:
       operationId: getReadiness
       summary: Readiness check
       description: >
-        Returns readiness status including dependency checks (Supabase, environment).
-        Used for readiness probes.
+        Returns readiness status including dependency checks (database, Horizon,
+        Soroban RPC) with per-check timeouts. Used for readiness probes.
+        Returns 503 when a critical dependency has hard-failed; degraded
+        dependencies (e.g. timed out) are reported per-dependency and surface
+        via the `degraded` flag while the service stays ready.
       security: []
       responses:
         "200":
@@ -2389,13 +2392,50 @@ components:
           type: string
           format: date-time
 
+    ReadyCheck:
+      type: object
+      properties:
+        name:
+          type: string
+          example: horizon
+        status:
+          type: string
+          enum: [up, degraded, down]
+          example: up
+        latency:
+          type: string
+          example: "125ms"
+        details:
+          type: array
+          items:
+            type: string
+        lastSuccess:
+          type: string
+          format: date-time
+        error:
+          type: string
+          example: Connection timeout
+        lagSeconds:
+          type: integer
+          example: 5
+
     ReadyResponse:
       type: object
       properties:
         ready:
           type: boolean
+          example: true
+        degraded:
+          type: boolean
+          example: false
+          description: True when a critical dependency is degraded but none have hard-failed
+        timestamp:
+          type: string
+          format: date-time
         checks:
-          type: object
+          type: array
+          items:
+            $ref: "#/components/schemas/ReadyCheck"
 
     PublicStatusComponent:
       type: object

--- a/app/backend/src/health/health-response.dto.ts
+++ b/app/backend/src/health/health-response.dto.ts
@@ -15,8 +15,8 @@ export class ReadyCheckDto {
   @ApiProperty({ example: "supabase" })
   name!: string;
 
-  @ApiProperty({ enum: ["up", "down"] })
-  status!: "up" | "down";
+  @ApiProperty({ enum: ["up", "degraded", "down"] })
+  status!: "up" | "degraded" | "down";
 
   @ApiProperty({ example: "125ms", required: false })
   latency?: string;
@@ -37,6 +37,13 @@ export class ReadyCheckDto {
 export class ReadyResponseDto {
   @ApiProperty({ example: true })
   ready!: boolean;
+
+  @ApiProperty({
+    example: false,
+    description:
+      "True when a critical dependency is degraded (e.g. timed out) but none have hard-failed",
+  })
+  degraded!: boolean;
 
   @ApiProperty({ example: "2024-01-01T00:00:00.000Z", description: "Timestamp of the readiness check" })
   timestamp!: string;

--- a/app/backend/src/health/health.controller.ts
+++ b/app/backend/src/health/health.controller.ts
@@ -29,7 +29,7 @@ export class HealthController {
   @ApiOperation({
     summary: "Readiness check",
     description:
-      "Returns application readiness status including dependency checks (Supabase, environment). Used for readiness probes.",
+      "Returns readiness status including dependency checks (database, Horizon, Soroban RPC) with per-check timeouts. Used for readiness probes. Returns 503 when a critical dependency has hard-failed.",
   })
   @ApiResponse({ status: 200, type: ReadyResponseDto })
   @ApiResponse({

--- a/app/backend/src/health/health.service.ts
+++ b/app/backend/src/health/health.service.ts
@@ -8,6 +8,8 @@ import { JobRepository } from "../job-queue/job.repository";
 import { CursorRepository } from "../ingestion/cursor.repository";
 import { SorobanRpcService } from "../transactions/soroban-rpc.service";
 
+export type DependencyStatus = "up" | "degraded" | "down";
+
 @Injectable()
 export class HealthService {
   private readonly logger = new Logger(HealthService.name);
@@ -24,11 +26,15 @@ export class HealthService {
     private readonly sorobanRpcService: SorobanRpcService,
   ) {}
 
+  private isTimeoutError(err: unknown): boolean {
+    return err instanceof Error && err.message === "Timeout";
+  }
+
   /**
    * Performs a simple ping to Supabase to verify connectivity.
    */
   async checkSupabase(): Promise<{
-    status: "up" | "down";
+    status: DependencyStatus;
     latency?: number;
     details?: string;
     lastSuccess?: string;
@@ -63,7 +69,10 @@ export class HealthService {
       this.logger.warn(
         `Supabase health check failed or timed out: ${safeMessage}`,
       );
-      return { status: "down", details: safeMessage };
+      return {
+        status: this.isTimeoutError(err) ? "degraded" : "down",
+        details: safeMessage,
+      };
     }
   }
 
@@ -122,7 +131,7 @@ export class HealthService {
    * Checks job queue health by verifying database connectivity and job processing.
    */
   async checkQueue(): Promise<{
-    status: "up" | "down";
+    status: DependencyStatus;
     latency?: number;
     details?: string;
     lastSuccess?: string;
@@ -151,7 +160,7 @@ export class HealthService {
       const safeMessage = sanitizeErrorMessage((err as Error).message);
       this.logger.warn(`Queue health check failed: ${safeMessage}`);
       return {
-        status: "down",
+        status: this.isTimeoutError(err) ? "degraded" : "down",
         details: safeMessage,
       };
     }
@@ -161,7 +170,7 @@ export class HealthService {
    * Checks Horizon reachability with timeout.
    */
   async checkHorizon(): Promise<{
-    status: "up" | "down";
+    status: DependencyStatus;
     latency?: number;
     details?: string;
     lastSuccess?: string;
@@ -195,7 +204,7 @@ export class HealthService {
       const safeMessage = sanitizeErrorMessage((err as Error).message);
       this.logger.warn(`Horizon health check failed: ${safeMessage}`);
       return {
-        status: "down",
+        status: this.isTimeoutError(err) ? "degraded" : "down",
         details: safeMessage,
       };
     }
@@ -205,7 +214,7 @@ export class HealthService {
    * Checks Soroban RPC reachability with timeout.
    */
   async checkSorobanRpc(): Promise<{
-    status: "up" | "down";
+    status: DependencyStatus;
     latency?: number;
     details?: string;
     lastSuccess?: string;
@@ -233,7 +242,7 @@ export class HealthService {
       const safeMessage = sanitizeErrorMessage((err as Error).message);
       this.logger.warn(`Soroban RPC health check failed: ${safeMessage}`);
       return {
-        status: "down",
+        status: this.isTimeoutError(err) ? "degraded" : "down",
         details: safeMessage,
       };
     }
@@ -359,12 +368,22 @@ export class HealthService {
         this.checkIngestionLag(),
       ]);
 
-    // Critical dependencies: database, migrations, queue, horizon
-    const criticalChecks = [supabase, migrations, queue, horizon];
-    const ready = criticalChecks.every((check) => check.status === "up");
+    // Critical dependencies: database, migrations, queue, horizon, soroban RPC.
+    // A hard failure (down) means the app cannot serve traffic safely.
+    // A degraded dependency (e.g. timed out) is reported separately so that
+    // transient slowness is distinguishable from a real outage.
+    const criticalChecks = [supabase, migrations, queue, horizon, sorobanRpc];
+    const hasHardFailure = criticalChecks.some(
+      (check) => check.status === "down",
+    );
+    const degraded = criticalChecks.some(
+      (check) => check.status === "degraded",
+    );
+    const ready = !hasHardFailure;
 
     return {
       ready,
+      degraded,
       timestamp: new Date().toISOString(),
       checks: [
         {

--- a/app/backend/src/health/health.service.unit.spec.ts
+++ b/app/backend/src/health/health.service.unit.spec.ts
@@ -1,0 +1,240 @@
+import { HealthService } from "./health.service";
+
+describe("HealthService", () => {
+  let service: HealthService;
+  let fetchSpy: jest.SpyInstance;
+
+  let supabase: {
+    checkHealth: jest.Mock;
+    getClient: jest.Mock;
+  };
+  let horizon: { getBaseUrl: jest.Mock };
+  let config: {
+    supabaseUrl: string;
+    supabaseAnonKey: string;
+    network: string;
+    isPaymentSigningConfigured: boolean;
+  };
+  let jobQueueService: Record<string, jest.Mock>;
+  let jobRepository: { listJobs: jest.Mock };
+  let cursorRepository: { getCursor: jest.Mock };
+  let sorobanRpc: { getNetworkPassphrase: jest.Mock };
+
+  function healthySupabaseClient() {
+    const resolveNoError = jest.fn().mockResolvedValue({ error: null });
+    return {
+      from: jest.fn(() => ({
+        select: jest.fn(() => ({
+          order: jest.fn(() => ({ limit: resolveNoError })),
+          limit: resolveNoError,
+        })),
+      })),
+    };
+  }
+
+  function failingSupabaseClient() {
+    const resolveError = jest
+      .fn()
+      .mockResolvedValue({ error: { message: "db unreachable" } });
+    return {
+      from: jest.fn(() => ({
+        select: jest.fn(() => ({
+          order: jest.fn(() => ({ limit: resolveError })),
+          limit: resolveError,
+        })),
+      })),
+    };
+  }
+
+  function buildService(): HealthService {
+    return new HealthService(
+      supabase as never,
+      horizon as never,
+      config as never,
+      jobQueueService as never,
+      jobRepository as never,
+      cursorRepository as never,
+      sorobanRpc as never,
+    );
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    supabase = {
+      checkHealth: jest.fn().mockResolvedValue(true),
+      getClient: jest.fn(healthySupabaseClient),
+    };
+    horizon = {
+      getBaseUrl: jest.fn().mockReturnValue("https://horizon.example.com"),
+    };
+    config = {
+      supabaseUrl: "https://db.example.com",
+      supabaseAnonKey: "anon-key",
+      network: "testnet",
+      isPaymentSigningConfigured: false,
+    };
+    jobQueueService = {};
+    jobRepository = { listJobs: jest.fn().mockResolvedValue([]) };
+    cursorRepository = { getCursor: jest.fn().mockResolvedValue(null) };
+    sorobanRpc = {
+      getNetworkPassphrase: jest
+        .fn()
+        .mockResolvedValue("Test SDF Network ; September 2015"),
+    };
+
+    fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: true, status: 200 } as Response);
+
+    service = buildService();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe("liveness (getHealthStatus)", () => {
+    it("reports the process is alive without touching any external service", async () => {
+      const status = await service.getHealthStatus();
+
+      expect(status).toEqual({
+        status: "ok",
+        version: expect.any(String),
+        uptime: expect.any(Number),
+      });
+
+      expect(supabase.checkHealth).not.toHaveBeenCalled();
+      expect(supabase.getClient).not.toHaveBeenCalled();
+      expect(horizon.getBaseUrl).not.toHaveBeenCalled();
+      expect(sorobanRpc.getNetworkPassphrase).not.toHaveBeenCalled();
+      expect(jobRepository.listJobs).not.toHaveBeenCalled();
+      expect(cursorRepository.getCursor).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("readiness (getReadinessStatus) — all healthy", () => {
+    it("reports ready with every dependency up", async () => {
+      const result = await service.getReadinessStatus();
+
+      expect(result.ready).toBe(true);
+      expect(result.degraded).toBe(false);
+
+      const names = result.checks.map((c) => c.name);
+      expect(names).toEqual(
+        expect.arrayContaining([
+          "supabase",
+          "environment",
+          "migrations",
+          "queue",
+          "horizon",
+          "soroban_rpc",
+          "ingestion",
+        ]),
+      );
+
+      for (const check of result.checks) {
+        expect(check.status).toBe("up");
+      }
+    });
+  });
+
+  describe("readiness — each critical dependency failing independently", () => {
+    const cases: Array<{
+      name: string;
+      checkName: string;
+      fail: () => void;
+    }> = [
+      {
+        name: "database (supabase)",
+        checkName: "supabase",
+        fail: () => supabase.checkHealth.mockResolvedValue(false),
+      },
+      {
+        name: "migrations",
+        checkName: "migrations",
+        fail: () => supabase.getClient.mockImplementation(failingSupabaseClient),
+      },
+      {
+        name: "job queue",
+        checkName: "queue",
+        fail: () =>
+          jobRepository.listJobs.mockRejectedValue(new Error("queue down")),
+      },
+      {
+        name: "horizon",
+        checkName: "horizon",
+        fail: () =>
+          fetchSpy.mockRejectedValue(new Error("connection refused")),
+      },
+      {
+        name: "soroban rpc",
+        checkName: "soroban_rpc",
+        fail: () =>
+          sorobanRpc.getNetworkPassphrase.mockRejectedValue(
+            new Error("rpc 503 unavailable"),
+          ),
+      },
+    ];
+
+    it.each(cases)(
+      "is not ready when $name is down",
+      async ({ checkName, fail }) => {
+        fail();
+
+        const result = await service.getReadinessStatus();
+
+        expect(result.ready).toBe(false);
+
+        const failed = result.checks.find((c) => c.name === checkName);
+        expect(failed?.status).toBe("down");
+        expect(failed?.error).toBeDefined();
+      },
+    );
+  });
+
+  describe("readiness — degraded vs hard failure", () => {
+    it("marks a timed-out dependency as degraded but stays ready", async () => {
+      sorobanRpc.getNetworkPassphrase.mockRejectedValue(new Error("Timeout"));
+
+      const result = await service.getReadinessStatus();
+
+      expect(result.ready).toBe(true);
+      expect(result.degraded).toBe(true);
+
+      const soroban = result.checks.find((c) => c.name === "soroban_rpc");
+      expect(soroban?.status).toBe("degraded");
+    });
+
+    it("distinguishes a timed-out dependency (degraded) from a hard failure (down)", async () => {
+      fetchSpy.mockRejectedValue(new Error("Timeout"));
+      sorobanRpc.getNetworkPassphrase.mockRejectedValue(
+        new Error("rpc unreachable"),
+      );
+
+      const result = await service.getReadinessStatus();
+
+      expect(result.ready).toBe(false);
+      expect(result.degraded).toBe(true);
+
+      const horizonCheck = result.checks.find((c) => c.name === "horizon");
+      const sorobanCheck = result.checks.find((c) => c.name === "soroban_rpc");
+      expect(horizonCheck?.status).toBe("degraded");
+      expect(sorobanCheck?.status).toBe("down");
+    });
+
+    it("reports degraded per-dependency status even when still ready", async () => {
+      fetchSpy.mockRejectedValue(new Error("Timeout"));
+
+      const result = await service.getReadinessStatus();
+
+      expect(result.ready).toBe(true);
+      expect(result.degraded).toBe(true);
+
+      const horizonCheck = result.checks.find((c) => c.name === "horizon");
+      expect(horizonCheck?.status).toBe("degraded");
+    });
+  });
+});

--- a/app/backend/src/rc-validation/dto/rc-report.dto.ts
+++ b/app/backend/src/rc-validation/dto/rc-report.dto.ts
@@ -79,8 +79,8 @@ export class RcSmokeCheckDto {
   @ApiProperty({ example: "horizon" })
   name!: string;
 
-  @ApiProperty({ enum: ["up", "down"], example: "up" })
-  status!: "up" | "down";
+  @ApiProperty({ enum: ["up", "degraded", "down"], example: "up" })
+  status!: "up" | "degraded" | "down";
 
   @ApiProperty({ required: false, example: "Horizon returned 503" })
   error?: string;

--- a/app/backend/test/app.e2e-spec.ts
+++ b/app/backend/test/app.e2e-spec.ts
@@ -42,6 +42,7 @@ describe("App endpoints", () => {
         }),
         getReadinessStatus: jest.fn().mockResolvedValue({
           ready: true,
+          degraded: false,
           checks: [
             {
               name: "supabase",
@@ -133,6 +134,7 @@ describe("App endpoints", () => {
       .expect(200)
       .expect({
         ready: true,
+        degraded: false,
         checks: [
           { name: "supabase", status: "up", latency: "10ms" },
           {
@@ -147,6 +149,7 @@ describe("App endpoints", () => {
   it("GET /ready returns 503 when unhealthy", async () => {
     healthService.getReadinessStatus.mockResolvedValueOnce({
       ready: false,
+      degraded: false,
       timestamp: new Date().toISOString(),
       checks: [
         {


### PR DESCRIPTION
Closes #813

## Summary
Splits liveness and readiness semantics so the process being alive is distinct from its ability to serve traffic. Readiness now gates on the database, Horizon, and Soroban RPC reachability (with per-check timeouts), reports per-dependency status, and distinguishes degraded dependencies from hard failures. Liveness (`GET /health`) never touches external services.

## Changes
- `HealthService`: timeouts are classified as `degraded`; definitive errors as `down`; Soroban RPC added to critical readiness checks; readiness response includes a `degraded` flag.
- `health-response.dto.ts` / `rc-report.dto.ts`: status enums accept `degraded`; `ReadyResponseDto` exposes `degraded`.
- `health.controller.ts` + `docs/openapi.yaml`: readiness docs updated.
- New `health.service.unit.spec.ts` covering each dependency failing independently, plus degraded-vs-down behavior.

## Acceptance criteria
- [x] Separate liveness and readiness endpoints with distinct semantics
- [x] Readiness checks database, Soroban RPC, and Horizon reachability with per-check timeouts
- [x] Readiness reports per-dependency status; degraded distinguishable from hard failures
- [x] Liveness never depends on external services
- [x] Tests cover each dependency failing independently

## Verification
- `tsc --noEmit`, `eslint`, `nest build` pass
- Unit suite: 105 suites / 1283 tests pass (incl. 10 new)
- `test/app.e2e-spec.ts`: 15 pass