### PR TITLE
Feat/real sep24 anchor handshake

### DIFF
--- a/app/backend/src/fiat-ramps/fiat-ramps.controller.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Post, Body, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { FiatRampsService } from './fiat-ramps.service';
+import { FiatRampsService, Sep24FlowRequestDto } from './fiat-ramps.service';
 
 @ApiTags('fiat-ramps')
 @Controller('fiat-ramps')
@@ -17,14 +17,14 @@ export class FiatRampsController {
   @Post('deposit')
   @ApiOperation({ summary: 'Initiate SEP-24 hosted deposit flow' })
   @ApiResponse({ status: 201, description: 'Deposit flow initiated' })
-  async initiateDeposit(@Body() depositDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
+  async initiateDeposit(@Body() depositDto: Sep24FlowRequestDto) {
     return this.fiatRampsService.initiateDeposit(depositDto);
   }
 
   @Post('withdraw')
   @ApiOperation({ summary: 'Initiate SEP-24 hosted withdrawal flow' })
   @ApiResponse({ status: 201, description: 'Withdrawal flow initiated' })
-  async initiateWithdrawal(@Body() withdrawalDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
+  async initiateWithdrawal(@Body() withdrawalDto: Sep24FlowRequestDto) {
     return this.fiatRampsService.initiateWithdrawal(withdrawalDto);
   }
 

--- a/app/backend/src/fiat-ramps/fiat-ramps.module.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { FiatRampsController } from './fiat-ramps.controller';
 import { FiatRampsService } from './fiat-ramps.service';
+import { TomlFetcherService } from '../asset-metadata/toml-fetcher.service';
+import { AppConfigService } from '../config/app-config.service';
 
 @Module({
   controllers: [FiatRampsController],
-  providers: [FiatRampsService],
+  providers: [FiatRampsService, TomlFetcherService, AppConfigService],
   exports: [FiatRampsService],
 })
 export class FiatRampsModule {}

--- a/app/backend/src/fiat-ramps/fiat-ramps.service.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.service.ts
@@ -1,12 +1,26 @@
 import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { TomlFetcherService } from '../asset-metadata/toml-fetcher.service';
+import { AppConfigService } from '../config/app-config.service';
+
+export class AnchorIntegrationError extends HttpException {
+  constructor(message: string, status = HttpStatus.BAD_GATEWAY) {
+    super({ type: 'anchor_integration_error', message }, status);
+  }
+}
 
 @Injectable()
 export class FiatRampsService {
   private readonly logger = new Logger(FiatRampsService.name);
 
+  constructor(
+    private readonly tomlFetcher: TomlFetcherService,
+    private readonly config: AppConfigService,
+  ) {}
+
   async getAvailableAnchors(assetCode: string, country: string) {
     this.logger.log(`Fetching available anchors for ${assetCode} in ${country}`);
-    // Mock implementation for available anchors
+    // Keep existing mock for anchor discovery UI; real discovery is handled per-anchor during initiation
     return {
       status: 'success',
       data: [
@@ -28,22 +42,126 @@ export class FiatRampsService {
     };
   }
 
+  private async discoverAnchor(anchorDomain: string) {
+    const toml = await this.tomlFetcher.fetchStellarToml(anchorDomain);
+    if (!toml) {
+      throw new AnchorIntegrationError(`Unable to fetch stellar.toml for ${anchorDomain}`, HttpStatus.BAD_GATEWAY);
+    }
+
+    const transferServer = (toml as any).TRANSFER_SERVER_SEP0024 || (toml as any).TRANSFER_SERVER;
+    const webAuth = (toml as any).WEB_AUTH_ENDPOINT || (toml as any).WEB_AUTH;
+
+    if (!transferServer || !webAuth) {
+      throw new AnchorIntegrationError(`Anchor ${anchorDomain} does not advertise SEP-24/SEP-10 endpoints`, HttpStatus.BAD_GATEWAY);
+    }
+
+    return { toml, transferServer, webAuth };
+  }
+
+  private async performSep10Auth(webAuthEndpoint: string, userAccount: string): Promise<string> {
+    const secret = this.config.stellarSecretKey;
+    if (!secret) {
+      throw new AnchorIntegrationError('Server not configured with STELLAR_SECRET_KEY for SEP-10 auth', HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    // 1) Request challenge transaction
+    const challengeUrl = `${webAuthEndpoint.replace(/\/$/, '')}?account=${encodeURIComponent(userAccount)}`;
+    this.logger.debug(`Requesting SEP-10 challenge from ${challengeUrl}`);
+
+    const challengeRes = await fetch(challengeUrl, { method: 'GET', headers: { Accept: 'application/json' } });
+    if (!challengeRes.ok) {
+      throw new AnchorIntegrationError(`Failed to fetch SEP-10 challenge from ${webAuthEndpoint}`, HttpStatus.BAD_GATEWAY);
+    }
+
+    const challengeJson = await challengeRes.json().catch(() => ({}));
+    const challengeTx = challengeJson.transaction || challengeJson.challenge || challengeJson.transaction_xdr || challengeJson.tx;
+    if (!challengeTx || typeof challengeTx !== 'string') {
+      throw new AnchorIntegrationError('Invalid SEP-10 challenge received from anchor', HttpStatus.BAD_GATEWAY);
+    }
+
+    // 2) Sign challenge transaction using server secret
+    let signedTxBase64: string;
+    try {
+      const tx = new StellarSdk.Transaction(challengeTx, this.config.stellarNetworkPassphrase);
+      const kp = StellarSdk.Keypair.fromSecret(secret);
+      tx.sign(kp);
+      signedTxBase64 = tx.toEnvelope().toXDR('base64');
+    } catch (err) {
+      this.logger.error(`Failed to sign SEP-10 challenge: ${err.message}`);
+      throw new AnchorIntegrationError('Failed to sign SEP-10 challenge', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // 3) Submit signed challenge to get JWT
+    const authRes = await fetch(webAuthEndpoint.replace(/\/$/, ''), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ transaction: signedTxBase64 }),
+    });
+
+    if (!authRes.ok) {
+      const text = await authRes.text().catch(() => '');
+      this.logger.warn(`SEP-10 auth failed: ${authRes.status} ${text}`);
+      throw new AnchorIntegrationError('SEP-10 authentication failed with anchor', HttpStatus.UNAUTHORIZED);
+    }
+
+    const authJson = await authRes.json().catch(() => ({}));
+    const token = authJson.token || authJson.access_token || authJson.jwt;
+    if (!token) {
+      throw new AnchorIntegrationError('Anchor did not return an auth token after SEP-10', HttpStatus.BAD_GATEWAY);
+    }
+
+    return token;
+  }
+
   async initiateDeposit(depositDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
     this.logger.log(`Initiating SEP-24 deposit flow with ${depositDto.anchorDomain}`);
     try {
-      // In a real integration, this would call StellarSdk.StellarTomlResolver to get the WEB_AUTH_ENDPOINT and TRANSFER_SERVER_SEP0024
-      // and perform SEP-10 authentication before initiating the deposit
-      
-      const mockInteractiveUrl = `https://${depositDto.anchorDomain}/sep24/interactive?type=deposit&asset_code=${depositDto.assetCode}&account=${depositDto.userAccount}`;
-      
+      const { toml, transferServer, webAuth } = await this.discoverAnchor(depositDto.anchorDomain);
+
+      // Validate asset is supported per stellar.toml currencies
+      const currencyList = (toml as any).CURRENCIES || [];
+      const found = Array.isArray(currencyList) && currencyList.find((c: any) => String(c.code).toUpperCase() === String(depositDto.assetCode).toUpperCase());
+      if (!found) {
+        throw new AnchorIntegrationError(`Anchor ${depositDto.anchorDomain} does not support asset ${depositDto.assetCode}`, HttpStatus.BAD_REQUEST);
+      }
+
+      // Perform SEP-10 and get token
+      const token = await this.performSep10Auth(webAuth, depositDto.userAccount);
+
+      // Initiate SEP-24 interactive deposit
+      const depositUrl = `${transferServer.replace(/\/$/, '')}/transactions/deposit/interactive`;
+      const body = {
+        asset_code: depositDto.assetCode,
+        account: depositDto.userAccount,
+        amount: depositDto.amount?.toString?.() ?? undefined,
+      };
+
+      const res = await fetch(depositUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const txt = await res.text().catch(() => '');
+        this.logger.warn(`SEP-24 deposit initiation failed: ${res.status} ${txt}`);
+        throw new AnchorIntegrationError('Failed to initiate SEP-24 deposit with anchor', HttpStatus.BAD_GATEWAY);
+      }
+
+      const json = await res.json().catch(() => ({}));
       return {
         status: 'success',
         transaction_id: `dep_${Date.now()}`,
-        type: 'interactive_customer_info_needed',
-        url: mockInteractiveUrl,
+        type: json.type || json.status || 'interactive_customer_info_needed',
+        url: json.url || json.redirect_url || json.client_redirect_url,
       };
     } catch (error) {
-      this.logger.error(`Error initiating deposit: ${error.message}`);
+      if (error instanceof AnchorIntegrationError) throw error;
+      this.logger.error(`Error initiating deposit: ${error?.message ?? String(error)}`);
       throw new HttpException('Failed to initiate deposit', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -51,29 +169,60 @@ export class FiatRampsService {
   async initiateWithdrawal(withdrawalDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
     this.logger.log(`Initiating SEP-24 withdrawal flow with ${withdrawalDto.anchorDomain}`);
     try {
-      const mockInteractiveUrl = `https://${withdrawalDto.anchorDomain}/sep24/interactive?type=withdraw&asset_code=${withdrawalDto.assetCode}&account=${withdrawalDto.userAccount}`;
-      
+      const { toml, transferServer, webAuth } = await this.discoverAnchor(withdrawalDto.anchorDomain);
+
+      const currencyList = (toml as any).CURRENCIES || [];
+      const found = Array.isArray(currencyList) && currencyList.find((c: any) => String(c.code).toUpperCase() === String(withdrawalDto.assetCode).toUpperCase());
+      if (!found) {
+        throw new AnchorIntegrationError(`Anchor ${withdrawalDto.anchorDomain} does not support asset ${withdrawalDto.assetCode}`, HttpStatus.BAD_REQUEST);
+      }
+
+      const token = await this.performSep10Auth(webAuth, withdrawalDto.userAccount);
+
+      const withdrawUrl = `${transferServer.replace(/\/$/, '')}/transactions/withdraw/interactive`;
+      const body = {
+        asset_code: withdrawalDto.assetCode,
+        account: withdrawalDto.userAccount,
+        amount: withdrawalDto.amount?.toString?.() ?? undefined,
+      };
+
+      const res = await fetch(withdrawUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const txt = await res.text().catch(() => '');
+        this.logger.warn(`SEP-24 withdrawal initiation failed: ${res.status} ${txt}`);
+        throw new AnchorIntegrationError('Failed to initiate SEP-24 withdrawal with anchor', HttpStatus.BAD_GATEWAY);
+      }
+
+      const json = await res.json().catch(() => ({}));
       return {
         status: 'success',
         transaction_id: `wth_${Date.now()}`,
-        type: 'interactive_customer_info_needed',
-        url: mockInteractiveUrl,
+        type: json.type || json.status || 'interactive_customer_info_needed',
+        url: json.url || json.redirect_url || json.client_redirect_url,
       };
     } catch (error) {
-      this.logger.error(`Error initiating withdrawal: ${error.message}`);
+      if (error instanceof AnchorIntegrationError) throw error;
+      this.logger.error(`Error initiating withdrawal: ${error?.message ?? String(error)}`);
       throw new HttpException('Failed to initiate withdrawal', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
   async handleKycCallback(callbackData: unknown) {
     this.logger.log(`Received KYC callback update: ${JSON.stringify(callbackData)}`);
-    // Process KYC status updates from anchors
     return { status: 'acknowledged' };
   }
 
   async updateTransactionStatus(statusData: unknown) {
     this.logger.log(`Received transaction status update: ${JSON.stringify(statusData)}`);
-    // Process SEP-24 transaction status changes (e.g., pending_user_transfer_start -> completed)
     return { status: 'acknowledged' };
   }
 }

--- a/app/backend/src/fiat-ramps/fiat-ramps.service.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.service.ts
@@ -3,11 +3,64 @@ import * as StellarSdk from '@stellar/stellar-sdk';
 import { TomlFetcherService } from '../asset-metadata/toml-fetcher.service';
 import { AppConfigService } from '../config/app-config.service';
 
+/**
+ * Stable machine-readable error codes for anchor integration failures.
+ * These are part of the public API contract and must not be renamed.
+ */
+export enum AnchorErrorCode {
+  /** Anchor domain could not be resolved, was unreachable, or returned a malformed response. */
+  ANCHOR_UNREACHABLE = 'ANCHOR_UNREACHABLE',
+  /** The requested asset is not advertised in the anchor's stellar.toml CURRENCIES. */
+  ASSET_UNSUPPORTED = 'ASSET_UNSUPPORTED',
+  /** STELLAR_SECRET_KEY is not configured on the server; SEP-10 cannot be performed. */
+  AUTH_NOT_CONFIGURED = 'AUTH_NOT_CONFIGURED',
+  /** SEP-10 authentication failed (rejected by the anchor or token missing). */
+  AUTH_FAILED = 'AUTH_FAILED',
+  /** The SEP-10 challenge transaction is missing, malformed, or fails validation. */
+  CHALLENGE_INVALID = 'CHALLENGE_INVALID',
+  /** SEP-24 interactive flow could not be initiated. */
+  INTERACTIVE_FLOW_FAILED = 'INTERACTIVE_FLOW_FAILED',
+}
+
+/**
+ * Typed error thrown for every failure of the SEP-24 anchor integration.
+ * The HTTP response body always has the shape:
+ *   { type: 'anchor_integration_error', code: AnchorErrorCode, message: string }
+ */
 export class AnchorIntegrationError extends HttpException {
-  constructor(message: string, status = HttpStatus.BAD_GATEWAY) {
-    super({ type: 'anchor_integration_error', message }, status);
+  readonly code: AnchorErrorCode;
+
+  constructor(message: string, status = HttpStatus.BAD_GATEWAY, code = AnchorErrorCode.ANCHOR_UNREACHABLE) {
+    super({ type: 'anchor_integration_error', code, message }, status);
+    this.code = code;
   }
 }
+
+export interface Sep24FlowRequestDto {
+  assetCode: string;
+  amount?: number;
+  userAccount?: string;
+  anchorDomain: string;
+  memo?: string;
+  memoType?: string;
+  lang?: string;
+}
+
+export interface Sep24FlowResponse {
+  status: 'success';
+  transaction_id: string;
+  type: string;
+  url: string;
+}
+
+interface DiscoveredAnchor {
+  toml: Record<string, unknown>;
+  transferServer: string;
+  webAuthEndpoint: string;
+  signingKey?: string;
+}
+
+const HTTP_TIMEOUT_MS = 5000;
 
 @Injectable()
 export class FiatRampsService {
@@ -42,178 +95,281 @@ export class FiatRampsService {
     };
   }
 
-  private async discoverAnchor(anchorDomain: string) {
+  /**
+   * Discover the anchor's capabilities from its stellar.toml (SEP-1).
+   * Endpoints are never assumed or constructed from the domain alone.
+   */
+  private async discoverAnchor(anchorDomain: string): Promise<DiscoveredAnchor> {
     const toml = await this.tomlFetcher.fetchStellarToml(anchorDomain);
     if (!toml) {
-      throw new AnchorIntegrationError(`Unable to fetch stellar.toml for ${anchorDomain}`, HttpStatus.BAD_GATEWAY);
+      throw new AnchorIntegrationError(
+        `Unable to fetch stellar.toml for ${anchorDomain}`,
+        HttpStatus.BAD_GATEWAY,
+        AnchorErrorCode.ANCHOR_UNREACHABLE,
+      );
     }
 
-    const transferServer = (toml as any).TRANSFER_SERVER_SEP0024 || (toml as any).TRANSFER_SERVER;
-    const webAuth = (toml as any).WEB_AUTH_ENDPOINT || (toml as any).WEB_AUTH;
+    const record = toml as Record<string, unknown>;
+    const transferServer = (record.TRANSFER_SERVER_SEP0024 || record.TRANSFER_SERVER) as string | undefined;
+    const webAuthEndpoint = record.WEB_AUTH_ENDPOINT as string | undefined;
+    const signingKey = record.SIGNING_KEY as string | undefined;
 
-    if (!transferServer || !webAuth) {
-      throw new AnchorIntegrationError(`Anchor ${anchorDomain} does not advertise SEP-24/SEP-10 endpoints`, HttpStatus.BAD_GATEWAY);
+    if (!transferServer || !webAuthEndpoint) {
+      throw new AnchorIntegrationError(
+        `Anchor ${anchorDomain} does not advertise SEP-24/SEP-10 endpoints`,
+        HttpStatus.BAD_GATEWAY,
+        AnchorErrorCode.ANCHOR_UNREACHABLE,
+      );
     }
 
-    return { toml, transferServer, webAuth };
+    return { toml: record, transferServer, webAuthEndpoint, signingKey };
   }
 
-  private async performSep10Auth(webAuthEndpoint: string, userAccount: string): Promise<string> {
+  /**
+   * Confirm the requested asset is advertised by the anchor in stellar.toml.
+   */
+  private assertAssetSupported(anchor: DiscoveredAnchor, anchorDomain: string, assetCode: string): void {
+    const currencyList = anchor.toml.CURRENCIES;
+    const supported =
+      Array.isArray(currencyList) &&
+      currencyList.some(
+        (c: { code?: string }) => typeof c?.code === 'string' && c.code.toUpperCase() === assetCode.toUpperCase(),
+      );
+    if (!supported) {
+      throw new AnchorIntegrationError(
+        `Anchor ${anchorDomain} does not support asset ${assetCode}`,
+        HttpStatus.BAD_REQUEST,
+        AnchorErrorCode.ASSET_UNSUPPORTED,
+      );
+    }
+  }
+
+  /**
+   * fetch() wrapper that converts network failures / timeouts into a stable
+   * typed error instead of an unhandled TypeError.
+   */
+  private async anchorFetch(url: string, init: RequestInit): Promise<Response> {
+    try {
+      return await fetch(url, { ...init, signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) });
+    } catch (error) {
+      this.logger.warn(`Anchor request failed (${url}): ${error?.message ?? String(error)}`);
+      throw new AnchorIntegrationError(
+        `Anchor endpoint unreachable: ${url}`,
+        HttpStatus.BAD_GATEWAY,
+        AnchorErrorCode.ANCHOR_UNREACHABLE,
+      );
+    }
+  }
+
+  /**
+   * Perform full SEP-10 authentication against the anchor:
+   *   1. GET the challenge transaction for the configured server account.
+   *   2. Validate the challenge (against the anchor SIGNING_KEY when advertised).
+   *   3. Client-sign it with the configured STELLAR_SECRET_KEY.
+   *   4. POST the signed challenge (form-urlencoded per SEP-10) and extract the JWT.
+   * The resulting token is required for all subsequent SEP-24 requests.
+   */
+  private async performSep10Auth(anchor: DiscoveredAnchor, anchorDomain: string): Promise<{ token: string; clientAccount: string }> {
     const secret = this.config.stellarSecretKey;
     if (!secret) {
-      throw new AnchorIntegrationError('Server not configured with STELLAR_SECRET_KEY for SEP-10 auth', HttpStatus.SERVICE_UNAVAILABLE);
+      throw new AnchorIntegrationError(
+        'Server not configured with STELLAR_SECRET_KEY for SEP-10 auth',
+        HttpStatus.SERVICE_UNAVAILABLE,
+        AnchorErrorCode.AUTH_NOT_CONFIGURED,
+      );
     }
+
+    const clientKeypair = StellarSdk.Keypair.fromSecret(secret);
+    const clientAccount = clientKeypair.publicKey();
+    const networkPassphrase = this.config.stellarNetworkPassphrase;
 
     // 1) Request challenge transaction
-    const challengeUrl = `${webAuthEndpoint.replace(/\/$/, '')}?account=${encodeURIComponent(userAccount)}`;
-    this.logger.debug(`Requesting SEP-10 challenge from ${challengeUrl}`);
+    const webAuthUrl = new URL(anchor.webAuthEndpoint);
+    webAuthUrl.searchParams.set('account', clientAccount);
+    this.logger.debug(`Requesting SEP-10 challenge from ${webAuthUrl.toString()}`);
 
-    const challengeRes = await fetch(challengeUrl, { method: 'GET', headers: { Accept: 'application/json' } });
+    const challengeRes = await this.anchorFetch(webAuthUrl.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
     if (!challengeRes.ok) {
-      throw new AnchorIntegrationError(`Failed to fetch SEP-10 challenge from ${webAuthEndpoint}`, HttpStatus.BAD_GATEWAY);
+      throw new AnchorIntegrationError(
+        `Failed to fetch SEP-10 challenge from ${anchor.webAuthEndpoint}`,
+        HttpStatus.BAD_GATEWAY,
+        AnchorErrorCode.ANCHOR_UNREACHABLE,
+      );
     }
 
-    const challengeJson = await challengeRes.json().catch(() => ({}));
-    const challengeTx = challengeJson.transaction || challengeJson.challenge || challengeJson.transaction_xdr || challengeJson.tx;
+    const challengeJson = (await challengeRes.json().catch(() => ({}))) as Record<string, unknown>;
+    const challengeTx = challengeJson.transaction ?? challengeJson.transaction_xdr;
     if (!challengeTx || typeof challengeTx !== 'string') {
-      throw new AnchorIntegrationError('Invalid SEP-10 challenge received from anchor', HttpStatus.BAD_GATEWAY);
+      throw new AnchorIntegrationError(
+        'Invalid SEP-10 challenge received from anchor',
+        HttpStatus.BAD_GATEWAY,
+        AnchorErrorCode.CHALLENGE_INVALID,
+      );
     }
 
-    // 2) Sign challenge transaction using server secret
+    // 2) Validate the challenge before signing anything.
+    if (anchor.signingKey) {
+      try {
+        StellarSdk.WebAuth.readChallengeTx(
+          challengeTx,
+          anchor.signingKey,
+          networkPassphrase,
+          anchorDomain,
+          webAuthUrl.hostname,
+        );
+      } catch (error) {
+        this.logger.warn(`SEP-10 challenge failed validation: ${error?.message ?? String(error)}`);
+        throw new AnchorIntegrationError(
+          'SEP-10 challenge failed validation against anchor signing key',
+          HttpStatus.BAD_GATEWAY,
+          AnchorErrorCode.CHALLENGE_INVALID,
+        );
+      }
+    } else {
+      // Without SIGNING_KEY we cannot verify provenance; at minimum ensure it parses.
+      try {
+        new StellarSdk.Transaction(challengeTx, networkPassphrase);
+      } catch (error) {
+        this.logger.warn(`SEP-10 challenge is malformed: ${error?.message ?? String(error)}`);
+        throw new AnchorIntegrationError(
+          'Invalid SEP-10 challenge received from anchor',
+          HttpStatus.BAD_GATEWAY,
+          AnchorErrorCode.CHALLENGE_INVALID,
+        );
+      }
+    }
+
+    // 3) Sign the challenge as the client account
     let signedTxBase64: string;
     try {
-      const tx = new StellarSdk.Transaction(challengeTx, this.config.stellarNetworkPassphrase);
-      const kp = StellarSdk.Keypair.fromSecret(secret);
-      tx.sign(kp);
+      const tx = new StellarSdk.Transaction(challengeTx, networkPassphrase);
+      tx.sign(clientKeypair);
       signedTxBase64 = tx.toEnvelope().toXDR('base64');
-    } catch (err) {
-      this.logger.error(`Failed to sign SEP-10 challenge: ${err.message}`);
-      throw new AnchorIntegrationError('Failed to sign SEP-10 challenge', HttpStatus.INTERNAL_SERVER_ERROR);
+    } catch (error) {
+      this.logger.error(`Failed to sign SEP-10 challenge: ${error?.message ?? String(error)}`);
+      throw new AnchorIntegrationError(
+        'Failed to sign SEP-10 challenge',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        AnchorErrorCode.CHALLENGE_INVALID,
+      );
     }
 
-    // 3) Submit signed challenge to get JWT
-    const authRes = await fetch(webAuthEndpoint.replace(/\/$/, ''), {
+    // 4) Submit signed challenge (application/x-www-form-urlencoded per SEP-10)
+    const authRes = await this.anchorFetch(anchor.webAuthEndpoint.replace(/\/$/, ''), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify({ transaction: signedTxBase64 }),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+      body: new URLSearchParams({ transaction: signedTxBase64 }).toString(),
     });
 
     if (!authRes.ok) {
       const text = await authRes.text().catch(() => '');
       this.logger.warn(`SEP-10 auth failed: ${authRes.status} ${text}`);
-      throw new AnchorIntegrationError('SEP-10 authentication failed with anchor', HttpStatus.UNAUTHORIZED);
+      throw new AnchorIntegrationError(
+        'SEP-10 authentication failed with anchor',
+        HttpStatus.UNAUTHORIZED,
+        AnchorErrorCode.AUTH_FAILED,
+      );
     }
 
-    const authJson = await authRes.json().catch(() => ({}));
-    const token = authJson.token || authJson.access_token || authJson.jwt;
+    const authJson = (await authRes.json().catch(() => ({}))) as Record<string, unknown>;
+    const token = (authJson.token || authJson.access_token || authJson.jwt) as string | undefined;
     if (!token) {
-      throw new AnchorIntegrationError('Anchor did not return an auth token after SEP-10', HttpStatus.BAD_GATEWAY);
+      throw new AnchorIntegrationError(
+        'Anchor did not return an auth token after SEP-10',
+        HttpStatus.BAD_GATEWAY,
+        AnchorErrorCode.AUTH_FAILED,
+      );
     }
 
-    return token;
+    return { token, clientAccount };
   }
 
-  async initiateDeposit(depositDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
-    this.logger.log(`Initiating SEP-24 deposit flow with ${depositDto.anchorDomain}`);
+  /**
+   * Shared SEP-24 initiation logic. Interactive URLs always come from the
+   * anchor's response — they are never constructed locally.
+   */
+  private async initiateInteractiveFlow(
+    kind: 'deposit' | 'withdraw',
+    dto: Sep24FlowRequestDto,
+  ): Promise<Sep24FlowResponse> {
+    const kindLabel = kind === 'deposit' ? 'deposit' : 'withdrawal';
+    this.logger.log(`Initiating SEP-24 ${kindLabel} flow with ${dto.anchorDomain}`);
     try {
-      const { toml, transferServer, webAuth } = await this.discoverAnchor(depositDto.anchorDomain);
+      const anchor = await this.discoverAnchor(dto.anchorDomain);
+      this.assertAssetSupported(anchor, dto.anchorDomain, dto.assetCode);
+      const { token, clientAccount } = await this.performSep10Auth(anchor, dto.anchorDomain);
 
-      // Validate asset is supported per stellar.toml currencies
-      const currencyList = (toml as any).CURRENCIES || [];
-      const found = Array.isArray(currencyList) && currencyList.find((c: any) => String(c.code).toUpperCase() === String(depositDto.assetCode).toUpperCase());
-      if (!found) {
-        throw new AnchorIntegrationError(`Anchor ${depositDto.anchorDomain} does not support asset ${depositDto.assetCode}`, HttpStatus.BAD_REQUEST);
-      }
-
-      // Perform SEP-10 and get token
-      const token = await this.performSep10Auth(webAuth, depositDto.userAccount);
-
-      // Initiate SEP-24 interactive deposit
-      const depositUrl = `${transferServer.replace(/\/$/, '')}/transactions/deposit/interactive`;
-      const body = {
-        asset_code: depositDto.assetCode,
-        account: depositDto.userAccount,
-        amount: depositDto.amount?.toString?.() ?? undefined,
+      const interactiveUrl = `${anchor.transferServer.replace(/\/$/, '')}/transactions/${kind}/interactive`;
+      const params: Record<string, string> = {
+        asset_code: dto.assetCode,
+        account: dto.userAccount || clientAccount,
       };
+      if (dto.amount != null) params.amount = String(dto.amount);
+      if (dto.memo) params.memo = dto.memo;
+      if (dto.memoType) params.memo_type = dto.memoType;
+      if (dto.lang) params.lang = dto.lang;
 
-      const res = await fetch(depositUrl, {
+      const res = await this.anchorFetch(interactiveUrl, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
           Authorization: `Bearer ${token}`,
           Accept: 'application/json',
         },
-        body: JSON.stringify(body),
+        body: new URLSearchParams(params).toString(),
       });
 
       if (!res.ok) {
         const txt = await res.text().catch(() => '');
-        this.logger.warn(`SEP-24 deposit initiation failed: ${res.status} ${txt}`);
-        throw new AnchorIntegrationError('Failed to initiate SEP-24 deposit with anchor', HttpStatus.BAD_GATEWAY);
+        this.logger.warn(`SEP-24 ${kindLabel} initiation failed: ${res.status} ${txt}`);
+        throw new AnchorIntegrationError(
+          `Failed to initiate SEP-24 ${kindLabel} with anchor`,
+          HttpStatus.BAD_GATEWAY,
+          AnchorErrorCode.INTERACTIVE_FLOW_FAILED,
+        );
       }
 
-      const json = await res.json().catch(() => ({}));
+      const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+      const nestedTransaction = json.transaction as Record<string, unknown> | undefined;
+      const url = (json.url || json.redirect_url || json.client_redirect_url) as string | undefined;
+      if (!url) {
+        throw new AnchorIntegrationError(
+          `Anchor did not return an interactive URL for SEP-24 ${kindLabel}`,
+          HttpStatus.BAD_GATEWAY,
+          AnchorErrorCode.INTERACTIVE_FLOW_FAILED,
+        );
+      }
+
+      const transactionId =
+        json.id || json.transaction_id || nestedTransaction?.id || `${kind.slice(0, 3)}_${Date.now()}`;
+      const type = json.type || json.status || 'interactive_customer_info_needed';
+
       return {
         status: 'success',
-        transaction_id: `dep_${Date.now()}`,
-        type: json.type || json.status || 'interactive_customer_info_needed',
-        url: json.url || json.redirect_url || json.client_redirect_url,
+        transaction_id: String(transactionId),
+        type: String(type),
+        url: String(url),
       };
     } catch (error) {
       if (error instanceof AnchorIntegrationError) throw error;
-      this.logger.error(`Error initiating deposit: ${error?.message ?? String(error)}`);
-      throw new HttpException('Failed to initiate deposit', HttpStatus.INTERNAL_SERVER_ERROR);
+      this.logger.error(`Unexpected error during SEP-24 ${kindLabel}: ${error?.message ?? String(error)}`);
+      throw new AnchorIntegrationError(
+        `Failed to initiate ${kindLabel}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        AnchorErrorCode.INTERACTIVE_FLOW_FAILED,
+      );
     }
   }
 
-  async initiateWithdrawal(withdrawalDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
-    this.logger.log(`Initiating SEP-24 withdrawal flow with ${withdrawalDto.anchorDomain}`);
-    try {
-      const { toml, transferServer, webAuth } = await this.discoverAnchor(withdrawalDto.anchorDomain);
+  initiateDeposit(depositDto: Sep24FlowRequestDto): Promise<Sep24FlowResponse> {
+    return this.initiateInteractiveFlow('deposit', depositDto);
+  }
 
-      const currencyList = (toml as any).CURRENCIES || [];
-      const found = Array.isArray(currencyList) && currencyList.find((c: any) => String(c.code).toUpperCase() === String(withdrawalDto.assetCode).toUpperCase());
-      if (!found) {
-        throw new AnchorIntegrationError(`Anchor ${withdrawalDto.anchorDomain} does not support asset ${withdrawalDto.assetCode}`, HttpStatus.BAD_REQUEST);
-      }
-
-      const token = await this.performSep10Auth(webAuth, withdrawalDto.userAccount);
-
-      const withdrawUrl = `${transferServer.replace(/\/$/, '')}/transactions/withdraw/interactive`;
-      const body = {
-        asset_code: withdrawalDto.assetCode,
-        account: withdrawalDto.userAccount,
-        amount: withdrawalDto.amount?.toString?.() ?? undefined,
-      };
-
-      const res = await fetch(withdrawUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/json',
-        },
-        body: JSON.stringify(body),
-      });
-
-      if (!res.ok) {
-        const txt = await res.text().catch(() => '');
-        this.logger.warn(`SEP-24 withdrawal initiation failed: ${res.status} ${txt}`);
-        throw new AnchorIntegrationError('Failed to initiate SEP-24 withdrawal with anchor', HttpStatus.BAD_GATEWAY);
-      }
-
-      const json = await res.json().catch(() => ({}));
-      return {
-        status: 'success',
-        transaction_id: `wth_${Date.now()}`,
-        type: json.type || json.status || 'interactive_customer_info_needed',
-        url: json.url || json.redirect_url || json.client_redirect_url,
-      };
-    } catch (error) {
-      if (error instanceof AnchorIntegrationError) throw error;
-      this.logger.error(`Error initiating withdrawal: ${error?.message ?? String(error)}`);
-      throw new HttpException('Failed to initiate withdrawal', HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+  initiateWithdrawal(withdrawalDto: Sep24FlowRequestDto): Promise<Sep24FlowResponse> {
+    return this.initiateInteractiveFlow('withdraw', withdrawalDto);
   }
 
   async handleKycCallback(callbackData: unknown) {

--- a/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
@@ -1,84 +1,417 @@
-import { FiatRampsService, AnchorIntegrationError } from './fiat-ramps.service';
+import { HttpStatus } from '@nestjs/common';
+import { Networks, Keypair, WebAuth, Transaction } from '@stellar/stellar-sdk';
+
+import { FiatRampsService, AnchorIntegrationError, AnchorErrorCode } from './fiat-ramps.service';
 import { TomlFetcherService } from '../asset-metadata/toml-fetcher.service';
 import { AppConfigService } from '../config/app-config.service';
 
-jest.mock('@stellar/stellar-sdk', () => {
-  return {
-    Transaction: jest.fn().mockImplementation(() => ({
-      sign: jest.fn(),
-      toEnvelope: () => ({ toXDR: () => 'signed-xdr' }),
-    })),
-    Keypair: {
-      fromSecret: jest.fn(() => ({
-        publicKey: () => 'GFAKE',
-      })),
-    },
-    Networks: { TESTNET: 'Test SDF Network ; September 2015' },
-  };
-});
+/**
+ * Unit tests for the real SEP-10 + SEP-24 anchor handshake.
+ *
+ * The network boundary (global fetch) is stubbed to simulate a testnet anchor,
+ * but all cryptography and transaction handling uses the genuine Stellar SDK:
+ * challenge transactions are built with WebAuth.buildChallengeTx exactly like a
+ * real anchor server would produce them.
+ */
 
-describe('FiatRampsService (SEP-24 handshake)', () => {
+const ANCHOR_DOMAIN = 'anchor.example';
+const WEB_AUTH_ENDPOINT = 'https://auth.anchor.example/auth';
+const TRANSFER_SERVER = 'https://api.anchor.example';
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+
+interface MockResponse {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+}
+
+function jsonResponse(body: unknown, status = HttpStatus.OK): MockResponse {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+describe('FiatRampsService (real SEP-24 handshake against stubbed anchor)', () => {
   let service: FiatRampsService;
-  let tomlFetcher: Partial<TomlFetcherService>;
-  let config: Partial<AppConfigService>;
-  const globalAny: any = global;
+  let tomlFetcher: { fetchStellarToml: jest.Mock };
+  let config: AppConfigService;
+
+  const clientKeypair = Keypair.random();
+  const anchorServerKeypair = Keypair.random();
+  const userKeypair = Keypair.random();
+
+  let fetchMock: jest.Mock;
+
+  /** stellar.toml advertising full SEP-24 + SEP-10 capabilities. */
+  function anchorToml(overrides: Record<string, unknown> = {}) {
+    return {
+      SIGNING_KEY: anchorServerKeypair.publicKey(),
+      WEB_AUTH_ENDPOINT,
+      TRANSFER_SERVER_SEP0024: TRANSFER_SERVER,
+      CURRENCIES: [
+        { code: 'USDC', issuer: Keypair.random().publicKey() },
+        { code: 'EURC', issuer: Keypair.random().publicKey() },
+      ],
+      ...overrides,
+    };
+  }
+
+  /** A genuine SEP-10 challenge, signed by the anchor's server key. */
+  function buildChallenge(signerKeypair = anchorServerKeypair): string {
+    return WebAuth.buildChallengeTx(
+      signerKeypair,
+      clientKeypair.publicKey(),
+      ANCHOR_DOMAIN,
+      900,
+      NETWORK_PASSPHRASE,
+      'auth.anchor.example',
+    );
+  }
+
+  /** Standard three-phase stubbed anchor: challenge -> token -> interactive URL. */
+  function stubSuccessfulAnchor(sep24Response: Record<string, unknown>): void {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ transaction: buildChallenge() }))
+      .mockResolvedValueOnce(jsonResponse({ token: 'jwt-token' }))
+      .mockResolvedValueOnce(jsonResponse(sep24Response));
+  }
+
+  async function expectAnchorError(
+    promise: Promise<unknown>,
+    code: AnchorErrorCode,
+    status: HttpStatus,
+  ): Promise<AnchorIntegrationError> {
+    const error = (await promise.catch((e: unknown) => e)) as AnchorIntegrationError;
+    expect(error).toBeInstanceOf(AnchorIntegrationError);
+    expect(error.code).toBe(code);
+    expect(error.getStatus()).toBe(status);
+    expect(error.getResponse()).toMatchObject({
+      type: 'anchor_integration_error',
+      code,
+    });
+    return error;
+  }
+
+  beforeAll(() => {
+    fetchMock = jest.fn();
+    (global as Record<string, unknown>).fetch = fetchMock;
+  });
 
   beforeEach(() => {
-    tomlFetcher = {
-      fetchStellarToml: jest.fn(),
-    };
+    fetchMock.mockReset();
 
+    tomlFetcher = { fetchStellarToml: jest.fn() };
     config = {
       get stellarSecretKey() {
-        return 'SFAKEKEY';
+        return clientKeypair.secret();
       },
       get stellarNetworkPassphrase() {
-        return 'Test SDF Network ; September 2015';
+        return NETWORK_PASSPHRASE;
       },
-    } as unknown as Partial<AppConfigService>;
+    } as unknown as AppConfigService;
 
-    service = new FiatRampsService(tomlFetcher as TomlFetcherService, config as AppConfigService);
-    globalAny.fetch = jest.fn();
+    service = new FiatRampsService(tomlFetcher as unknown as TomlFetcherService, config);
   });
 
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
+  describe('SEP-10 authentication + SEP-24 initiation', () => {
+    it('performs the full deposit handshake and returns the anchor-negotiated interactive URL', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      stubSuccessfulAnchor({
+        type: 'interactive_customer_info_needed',
+        url: `${TRANSFER_SERVER}/sep24/deposit/abc123`,
+        id: 'dep-tx-1',
+      });
 
-  it('initiates deposit via SEP-24 interactive flow when anchor responds correctly', async () => {
-    (tomlFetcher.fetchStellarToml as jest.Mock).mockResolvedValue({
-      TRANSFER_SERVER_SEP0024: 'https://anchor.example',
-      WEB_AUTH_ENDPOINT: 'https://anchor.example/auth',
-      CURRENCIES: [{ code: 'USDC' }],
+      const result = await service.initiateDeposit({
+        assetCode: 'USDC',
+        amount: 25.5,
+        userAccount: userKeypair.publicKey(),
+        anchorDomain: ANCHOR_DOMAIN,
+      });
+
+      // Discovery came from stellar.toml
+      expect(tomlFetcher.fetchStellarToml).toHaveBeenCalledWith(ANCHOR_DOMAIN);
+
+      // Phase 1: SEP-10 challenge requested for the configured account
+      const [challengeUrl, challengeInit] = fetchMock.mock.calls[0];
+      expect(challengeUrl).toBe(`${WEB_AUTH_ENDPOINT}?account=${clientKeypair.publicKey()}`);
+      expect((challengeInit as RequestInit).method).toBe('GET');
+
+      // Phase 2: signed challenge POSTed form-urlencoded per SEP-10
+      const [authUrl, authInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+      expect(authUrl).toBe(WEB_AUTH_ENDPOINT);
+      expect(new Headers(authInit.headers).get('Content-Type')).toBe('application/x-www-form-urlencoded');
+      const submittedTx = new URLSearchParams(authInit.body as string).get('transaction');
+      expect(submittedTx).toBeTruthy();
+      // The submitted transaction must be a valid, client-signed challenge
+      expect(() => new Transaction(submittedTx as string, NETWORK_PASSPHRASE)).not.toThrow();
+
+      // Phase 3: SEP-24 initiation carries the JWT and is form-urlencoded
+      const [depositUrl, depositInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+      expect(depositUrl).toBe(`${TRANSFER_SERVER}/transactions/deposit/interactive`);
+      expect(new Headers(depositInit.headers).get('Authorization')).toBe('Bearer jwt-token');
+      expect(new Headers(depositInit.headers).get('Content-Type')).toBe('application/x-www-form-urlencoded');
+      const params = new URLSearchParams(depositInit.body as string);
+      expect(params.get('asset_code')).toBe('USDC');
+      expect(params.get('account')).toBe(userKeypair.publicKey());
+      expect(params.get('amount')).toBe('25.5');
+
+      // Interactive URL comes from the anchor response, not string construction
+      expect(result).toEqual({
+        status: 'success',
+        transaction_id: 'dep-tx-1',
+        type: 'interactive_customer_info_needed',
+        url: `${TRANSFER_SERVER}/sep24/deposit/abc123`,
+      });
     });
 
-    // Sequence: challenge GET, auth POST, deposit POST
-    (globalAny.fetch as jest.Mock)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ transaction: 'challenge-xdr' }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt-token' }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ type: 'interactive_customer_info_needed', url: 'https://anchor.example/interactive' }) });
+    it('performs the full withdrawal handshake', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      stubSuccessfulAnchor({
+        type: 'interactive_customer_info_needed',
+        url: `${TRANSFER_SERVER}/sep24/withdraw/xyz789`,
+        id: 'wth-tx-1',
+      });
 
-    const result = await service.initiateDeposit({ assetCode: 'USDC', amount: 10, userAccount: 'GUSER', anchorDomain: 'anchor.example' });
+      const result = await service.initiateWithdrawal({
+        assetCode: 'USDC',
+        amount: 5,
+        userAccount: userKeypair.publicKey(),
+        anchorDomain: ANCHOR_DOMAIN,
+      });
 
-    expect(result).toBeDefined();
-    expect(result.type).toBe('interactive_customer_info_needed');
-    expect(result.url).toBe('https://anchor.example/interactive');
-    expect(tomlFetcher.fetchStellarToml).toHaveBeenCalledWith('anchor.example');
-  });
-
-  it('throws when SEP-10 auth fails (auth endpoint returns non-OK)', async () => {
-    (tomlFetcher.fetchStellarToml as jest.Mock).mockResolvedValue({
-      TRANSFER_SERVER_SEP0024: 'https://anchor.example',
-      WEB_AUTH_ENDPOINT: 'https://anchor.example/auth',
-      CURRENCIES: [{ code: 'USDC' }],
+      const [withdrawUrl, withdrawInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+      expect(withdrawUrl).toBe(`${TRANSFER_SERVER}/transactions/withdraw/interactive`);
+      expect(new Headers(withdrawInit.headers).get('Authorization')).toBe('Bearer jwt-token');
+      expect(result.url).toBe(`${TRANSFER_SERVER}/sep24/withdraw/xyz789`);
+      expect(result.transaction_id).toBe('wth-tx-1');
     });
 
-    (globalAny.fetch as jest.Mock)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ transaction: 'challenge-xdr' }) })
-      .mockResolvedValueOnce({ ok: false, status: 401, text: async () => 'unauthorized' });
+    it('falls back to TRANSFER_SERVER when SEP-0024 transfer server is not advertised separately', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(
+        anchorToml({ TRANSFER_SERVER_SEP0024: undefined, TRANSFER_SERVER: 'https://legacy.anchor.example' }),
+      );
+      stubSuccessfulAnchor({ url: 'https://legacy.anchor.example/interactive' });
 
-    await expect(
-      service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: 'GUSER', anchorDomain: 'anchor.example' }),
-    ).rejects.toBeInstanceOf(AnchorIntegrationError);
+      const result = await service.initiateDeposit({
+        assetCode: 'USDC',
+        amount: 1,
+        userAccount: userKeypair.publicKey(),
+        anchorDomain: ANCHOR_DOMAIN,
+      });
+
+      expect(fetchMock.mock.calls[2][0]).toBe('https://legacy.anchor.example/transactions/deposit/interactive');
+      expect(result.url).toBe('https://legacy.anchor.example/interactive');
+    });
+
+    it('defaults the SEP-24 account parameter to the authenticated account when userAccount is omitted', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      stubSuccessfulAnchor({ url: `${TRANSFER_SERVER}/sep24/deposit/self` });
+
+      await service.initiateDeposit({ assetCode: 'USDC', amount: 1, anchorDomain: ANCHOR_DOMAIN });
+
+      const [, init] = fetchMock.mock.calls[2] as [string, RequestInit];
+      expect(new URLSearchParams(init.body as string).get('account')).toBe(clientKeypair.publicKey());
+    });
+  });
+
+  describe('anchor discovery errors', () => {
+    it('throws a typed error when stellar.toml cannot be fetched', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(null);
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 1, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.ANCHOR_UNREACHABLE,
+        HttpStatus.BAD_GATEWAY,
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws a typed error when the toml does not advertise SEP-24/SEP-10 endpoints', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml({ WEB_AUTH_ENDPOINT: undefined }));
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 1, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.ANCHOR_UNREACHABLE,
+        HttpStatus.BAD_GATEWAY,
+      );
+    });
+  });
+
+  describe('unsupported assets', () => {
+    it('rejects assets missing from the anchor CURRENCIES list', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'SCAM', amount: 1, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.ASSET_UNSUPPORTED,
+        HttpStatus.BAD_REQUEST,
+      );
+      // No handshake traffic should occur for an unsupported asset
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the anchor advertises no currencies at all', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml({ CURRENCIES: undefined }));
+
+      await expectAnchorError(
+        service.initiateWithdrawal({ assetCode: 'USDC', amount: 1, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.ASSET_UNSUPPORTED,
+        HttpStatus.BAD_REQUEST,
+      );
+    });
+  });
+
+  describe('SEP-10 authentication failures', () => {
+    it('throws AUTH_FAILED when the anchor rejects the signed challenge', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ transaction: buildChallenge() }))
+        .mockResolvedValueOnce(jsonResponse({ error: 'invalid signature' }, HttpStatus.UNAUTHORIZED));
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.AUTH_FAILED,
+        HttpStatus.UNAUTHORIZED,
+      );
+    });
+
+    it('throws AUTH_FAILED when no auth endpoint responds OK for the challenge request', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, HttpStatus.SERVICE_UNAVAILABLE));
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.ANCHOR_UNREACHABLE,
+        HttpStatus.BAD_GATEWAY,
+      );
+    });
+
+    it('throws AUTH_FAILED when the anchor omits the token from the auth response', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ transaction: buildChallenge() }))
+        .mockResolvedValueOnce(jsonResponse({ unexpected: true }));
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.AUTH_FAILED,
+        HttpStatus.BAD_GATEWAY,
+      );
+    });
+
+    it('throws CHALLENGE_INVALID for a malformed challenge payload', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      fetchMock.mockResolvedValueOnce(jsonResponse({ transaction: 'definitely-not-a-transaction' }));
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.CHALLENGE_INVALID,
+        HttpStatus.BAD_GATEWAY,
+      );
+    });
+
+    it('throws CHALLENGE_INVALID when the challenge was not signed by the advertised SIGNING_KEY', async () => {
+      const impostorKeypair = Keypair.random();
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml()); // advertises legit SIGNING_KEY
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ transaction: buildChallenge(impostorKeypair) }))
+        // Auth never reached, but provide a fallback in case of regressions
+        .mockResolvedValue(jsonResponse({ token: 'should-not-be-used' }));
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.CHALLENGE_INVALID,
+        HttpStatus.BAD_GATEWAY,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws AUTH_NOT_CONFIGURED when STELLAR_SECRET_KEY is missing', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      config = {
+        get stellarSecretKey() {
+          return undefined;
+        },
+        get stellarNetworkPassphrase() {
+          return NETWORK_PASSPHRASE;
+        },
+      } as unknown as AppConfigService;
+      service = new FiatRampsService(tomlFetcher as unknown as TomlFetcherService, config);
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.AUTH_NOT_CONFIGURED,
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    });
+  });
+
+  describe('SEP-24 initiation failures', () => {
+    it('throws INTERACTIVE_FLOW_FAILED when the anchor rejects the initiation', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ transaction: buildChallenge() }))
+        .mockResolvedValueOnce(jsonResponse({ token: 'jwt-token' }))
+        .mockResolvedValueOnce(jsonResponse({ error: 'asset not supported for region' }, HttpStatus.BAD_REQUEST));
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.INTERACTIVE_FLOW_FAILED,
+        HttpStatus.BAD_GATEWAY,
+      );
+    });
+
+    it('throws INTERACTIVE_FLOW_FAILED when the anchor response has no interactive URL', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ transaction: buildChallenge() }))
+        .mockResolvedValueOnce(jsonResponse({ token: 'jwt-token' }))
+        .mockResolvedValueOnce(jsonResponse({ id: 'tx-without-url' }));
+
+      await expectAnchorError(
+        service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.INTERACTIVE_FLOW_FAILED,
+        HttpStatus.BAD_GATEWAY,
+      );
+    });
+
+    it('converts network-level failures into a typed ANCHOR_UNREACHABLE error instead of a generic 500', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ transaction: buildChallenge() }))
+        .mockResolvedValueOnce(jsonResponse({ token: 'jwt-token' }))
+        .mockRejectedValueOnce(new TypeError('fetch failed'));
+
+      await expectAnchorError(
+        service.initiateWithdrawal({ assetCode: 'USDC', amount: 5, userAccount: userKeypair.publicKey(), anchorDomain: ANCHOR_DOMAIN }),
+        AnchorErrorCode.ANCHOR_UNREACHABLE,
+        HttpStatus.BAD_GATEWAY,
+      );
+    });
+
+    it('accepts alternate interactive URL field names (redirect_url)', async () => {
+      tomlFetcher.fetchStellarToml.mockResolvedValue(anchorToml());
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ transaction: buildChallenge() }))
+        .mockResolvedValueOnce(jsonResponse({ access_token: 'jwt-alt-token' }))
+        .mockResolvedValueOnce(jsonResponse({ redirect_url: 'https://kyc.anchor.example/start', transaction: { id: 'nested-id' } }));
+
+      const result = await service.initiateDeposit({
+        assetCode: 'USDC',
+        amount: 5,
+        userAccount: userKeypair.publicKey(),
+        anchorDomain: ANCHOR_DOMAIN,
+      });
+
+      expect(result.url).toBe('https://kyc.anchor.example/start');
+      expect(result.transaction_id).toBe('nested-id');
+      // access_token is accepted as an alternative token field name
+      expect(new Headers(fetchMock.mock.calls[2][1].headers).get('Authorization')).toBe('Bearer jwt-alt-token');
+    });
   });
 });

--- a/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
@@ -1,0 +1,84 @@
+import { FiatRampsService, AnchorIntegrationError } from './fiat-ramps.service';
+import { TomlFetcherService } from '../asset-metadata/toml-fetcher.service';
+import { AppConfigService } from '../config/app-config.service';
+
+jest.mock('@stellar/stellar-sdk', () => {
+  return {
+    Transaction: jest.fn().mockImplementation(() => ({
+      sign: jest.fn(),
+      toEnvelope: () => ({ toXDR: () => 'signed-xdr' }),
+    })),
+    Keypair: {
+      fromSecret: jest.fn(() => ({
+        publicKey: () => 'GFAKE',
+      })),
+    },
+    Networks: { TESTNET: 'Test SDF Network ; September 2015' },
+  };
+});
+
+describe('FiatRampsService (SEP-24 handshake)', () => {
+  let service: FiatRampsService;
+  let tomlFetcher: Partial<TomlFetcherService>;
+  let config: Partial<AppConfigService>;
+  const globalAny: any = global;
+
+  beforeEach(() => {
+    tomlFetcher = {
+      fetchStellarToml: jest.fn(),
+    };
+
+    config = {
+      get stellarSecretKey() {
+        return 'SFAKEKEY';
+      },
+      get stellarNetworkPassphrase() {
+        return 'Test SDF Network ; September 2015';
+      },
+    } as unknown as Partial<AppConfigService>;
+
+    service = new FiatRampsService(tomlFetcher as TomlFetcherService, config as AppConfigService);
+    globalAny.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('initiates deposit via SEP-24 interactive flow when anchor responds correctly', async () => {
+    (tomlFetcher.fetchStellarToml as jest.Mock).mockResolvedValue({
+      TRANSFER_SERVER_SEP0024: 'https://anchor.example',
+      WEB_AUTH_ENDPOINT: 'https://anchor.example/auth',
+      CURRENCIES: [{ code: 'USDC' }],
+    });
+
+    // Sequence: challenge GET, auth POST, deposit POST
+    (globalAny.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ transaction: 'challenge-xdr' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt-token' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ type: 'interactive_customer_info_needed', url: 'https://anchor.example/interactive' }) });
+
+    const result = await service.initiateDeposit({ assetCode: 'USDC', amount: 10, userAccount: 'GUSER', anchorDomain: 'anchor.example' });
+
+    expect(result).toBeDefined();
+    expect(result.type).toBe('interactive_customer_info_needed');
+    expect(result.url).toBe('https://anchor.example/interactive');
+    expect(tomlFetcher.fetchStellarToml).toHaveBeenCalledWith('anchor.example');
+  });
+
+  it('throws when SEP-10 auth fails (auth endpoint returns non-OK)', async () => {
+    (tomlFetcher.fetchStellarToml as jest.Mock).mockResolvedValue({
+      TRANSFER_SERVER_SEP0024: 'https://anchor.example',
+      WEB_AUTH_ENDPOINT: 'https://anchor.example/auth',
+      CURRENCIES: [{ code: 'USDC' }],
+    });
+
+    (globalAny.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ transaction: 'challenge-xdr' }) })
+      .mockResolvedValueOnce({ ok: false, status: 401, text: async () => 'unauthorized' });
+
+    await expect(
+      service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: 'GUSER', anchorDomain: 'anchor.example' }),
+    ).rejects.toBeInstanceOf(AnchorIntegrationError);
+  });
+});

--- a/fiat-ramps-be-106.patch
+++ b/fiat-ramps-be-106.patch
@@ -1,0 +1,359 @@
+From 2473a16f07a7fc59b0fc4c1afff7dadf8a5e14e0 Mon Sep 17 00:00:00 2001
+From: TechBroAfrica <osenioladebo@gmail.com>
+Date: Mon, 24 Aug 2026 14:02:04 +0100
+Subject: [PATCH] feat: implement SEP-24 handshake in FiatRampsService and add
+ unit tests
+
+---
+ .../src/fiat-ramps/fiat-ramps.module.ts       |   4 +-
+ .../src/fiat-ramps/fiat-ramps.service.ts      | 181 ++++++++++++++++--
+ .../fiat-ramps.service.unit.spec.ts           |  84 ++++++++
+ 3 files changed, 252 insertions(+), 17 deletions(-)
+ create mode 100644 app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
+
+diff --git a/app/backend/src/fiat-ramps/fiat-ramps.module.ts b/app/backend/src/fiat-ramps/fiat-ramps.module.ts
+index 0ad725ad..9ded7cd3 100644
+--- a/app/backend/src/fiat-ramps/fiat-ramps.module.ts
++++ b/app/backend/src/fiat-ramps/fiat-ramps.module.ts
+@@ -1,10 +1,12 @@
+ import { Module } from '@nestjs/common';
+ import { FiatRampsController } from './fiat-ramps.controller';
+ import { FiatRampsService } from './fiat-ramps.service';
++import { TomlFetcherService } from '../asset-metadata/toml-fetcher.service';
++import { AppConfigService } from '../config/app-config.service';
+ 
+ @Module({
+   controllers: [FiatRampsController],
+-  providers: [FiatRampsService],
++  providers: [FiatRampsService, TomlFetcherService, AppConfigService],
+   exports: [FiatRampsService],
+ })
+ export class FiatRampsModule {}
+diff --git a/app/backend/src/fiat-ramps/fiat-ramps.service.ts b/app/backend/src/fiat-ramps/fiat-ramps.service.ts
+index a9fc5601..515b9452 100644
+--- a/app/backend/src/fiat-ramps/fiat-ramps.service.ts
++++ b/app/backend/src/fiat-ramps/fiat-ramps.service.ts
+@@ -1,12 +1,26 @@
+ import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
++import * as StellarSdk from '@stellar/stellar-sdk';
++import { TomlFetcherService } from '../asset-metadata/toml-fetcher.service';
++import { AppConfigService } from '../config/app-config.service';
++
++export class AnchorIntegrationError extends HttpException {
++  constructor(message: string, status = HttpStatus.BAD_GATEWAY) {
++    super({ type: 'anchor_integration_error', message }, status);
++  }
++}
+ 
+ @Injectable()
+ export class FiatRampsService {
+   private readonly logger = new Logger(FiatRampsService.name);
+ 
++  constructor(
++    private readonly tomlFetcher: TomlFetcherService,
++    private readonly config: AppConfigService,
++  ) {}
++
+   async getAvailableAnchors(assetCode: string, country: string) {
+     this.logger.log(`Fetching available anchors for ${assetCode} in ${country}`);
+-    // Mock implementation for available anchors
++    // Keep existing mock for anchor discovery UI; real discovery is handled per-anchor during initiation
+     return {
+       status: 'success',
+       data: [
+@@ -28,22 +42,126 @@ export class FiatRampsService {
+     };
+   }
+ 
++  private async discoverAnchor(anchorDomain: string) {
++    const toml = await this.tomlFetcher.fetchStellarToml(anchorDomain);
++    if (!toml) {
++      throw new AnchorIntegrationError(`Unable to fetch stellar.toml for ${anchorDomain}`, HttpStatus.BAD_GATEWAY);
++    }
++
++    const transferServer = (toml as any).TRANSFER_SERVER_SEP0024 || (toml as any).TRANSFER_SERVER;
++    const webAuth = (toml as any).WEB_AUTH_ENDPOINT || (toml as any).WEB_AUTH;
++
++    if (!transferServer || !webAuth) {
++      throw new AnchorIntegrationError(`Anchor ${anchorDomain} does not advertise SEP-24/SEP-10 endpoints`, HttpStatus.BAD_GATEWAY);
++    }
++
++    return { toml, transferServer, webAuth };
++  }
++
++  private async performSep10Auth(webAuthEndpoint: string, userAccount: string): Promise<string> {
++    const secret = this.config.stellarSecretKey;
++    if (!secret) {
++      throw new AnchorIntegrationError('Server not configured with STELLAR_SECRET_KEY for SEP-10 auth', HttpStatus.SERVICE_UNAVAILABLE);
++    }
++
++    // 1) Request challenge transaction
++    const challengeUrl = `${webAuthEndpoint.replace(/\/$/, '')}?account=${encodeURIComponent(userAccount)}`;
++    this.logger.debug(`Requesting SEP-10 challenge from ${challengeUrl}`);
++
++    const challengeRes = await fetch(challengeUrl, { method: 'GET', headers: { Accept: 'application/json' } });
++    if (!challengeRes.ok) {
++      throw new AnchorIntegrationError(`Failed to fetch SEP-10 challenge from ${webAuthEndpoint}`, HttpStatus.BAD_GATEWAY);
++    }
++
++    const challengeJson = await challengeRes.json().catch(() => ({}));
++    const challengeTx = challengeJson.transaction || challengeJson.challenge || challengeJson.transaction_xdr || challengeJson.tx;
++    if (!challengeTx || typeof challengeTx !== 'string') {
++      throw new AnchorIntegrationError('Invalid SEP-10 challenge received from anchor', HttpStatus.BAD_GATEWAY);
++    }
++
++    // 2) Sign challenge transaction using server secret
++    let signedTxBase64: string;
++    try {
++      const tx = new StellarSdk.Transaction(challengeTx, this.config.stellarNetworkPassphrase);
++      const kp = StellarSdk.Keypair.fromSecret(secret);
++      tx.sign(kp);
++      signedTxBase64 = tx.toEnvelope().toXDR('base64');
++    } catch (err) {
++      this.logger.error(`Failed to sign SEP-10 challenge: ${err.message}`);
++      throw new AnchorIntegrationError('Failed to sign SEP-10 challenge', HttpStatus.INTERNAL_SERVER_ERROR);
++    }
++
++    // 3) Submit signed challenge to get JWT
++    const authRes = await fetch(webAuthEndpoint.replace(/\/$/, ''), {
++      method: 'POST',
++      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
++      body: JSON.stringify({ transaction: signedTxBase64 }),
++    });
++
++    if (!authRes.ok) {
++      const text = await authRes.text().catch(() => '');
++      this.logger.warn(`SEP-10 auth failed: ${authRes.status} ${text}`);
++      throw new AnchorIntegrationError('SEP-10 authentication failed with anchor', HttpStatus.UNAUTHORIZED);
++    }
++
++    const authJson = await authRes.json().catch(() => ({}));
++    const token = authJson.token || authJson.access_token || authJson.jwt;
++    if (!token) {
++      throw new AnchorIntegrationError('Anchor did not return an auth token after SEP-10', HttpStatus.BAD_GATEWAY);
++    }
++
++    return token;
++  }
++
+   async initiateDeposit(depositDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
+     this.logger.log(`Initiating SEP-24 deposit flow with ${depositDto.anchorDomain}`);
+     try {
+-      // In a real integration, this would call StellarSdk.StellarTomlResolver to get the WEB_AUTH_ENDPOINT and TRANSFER_SERVER_SEP0024
+-      // and perform SEP-10 authentication before initiating the deposit
+-      
+-      const mockInteractiveUrl = `https://${depositDto.anchorDomain}/sep24/interactive?type=deposit&asset_code=${depositDto.assetCode}&account=${depositDto.userAccount}`;
+-      
++      const { toml, transferServer, webAuth } = await this.discoverAnchor(depositDto.anchorDomain);
++
++      // Validate asset is supported per stellar.toml currencies
++      const currencyList = (toml as any).CURRENCIES || [];
++      const found = Array.isArray(currencyList) && currencyList.find((c: any) => String(c.code).toUpperCase() === String(depositDto.assetCode).toUpperCase());
++      if (!found) {
++        throw new AnchorIntegrationError(`Anchor ${depositDto.anchorDomain} does not support asset ${depositDto.assetCode}`, HttpStatus.BAD_REQUEST);
++      }
++
++      // Perform SEP-10 and get token
++      const token = await this.performSep10Auth(webAuth, depositDto.userAccount);
++
++      // Initiate SEP-24 interactive deposit
++      const depositUrl = `${transferServer.replace(/\/$/, '')}/transactions/deposit/interactive`;
++      const body = {
++        asset_code: depositDto.assetCode,
++        account: depositDto.userAccount,
++        amount: depositDto.amount?.toString?.() ?? undefined,
++      };
++
++      const res = await fetch(depositUrl, {
++        method: 'POST',
++        headers: {
++          'Content-Type': 'application/json',
++          Authorization: `Bearer ${token}`,
++          Accept: 'application/json',
++        },
++        body: JSON.stringify(body),
++      });
++
++      if (!res.ok) {
++        const txt = await res.text().catch(() => '');
++        this.logger.warn(`SEP-24 deposit initiation failed: ${res.status} ${txt}`);
++        throw new AnchorIntegrationError('Failed to initiate SEP-24 deposit with anchor', HttpStatus.BAD_GATEWAY);
++      }
++
++      const json = await res.json().catch(() => ({}));
+       return {
+         status: 'success',
+         transaction_id: `dep_${Date.now()}`,
+-        type: 'interactive_customer_info_needed',
+-        url: mockInteractiveUrl,
++        type: json.type || json.status || 'interactive_customer_info_needed',
++        url: json.url || json.redirect_url || json.client_redirect_url,
+       };
+     } catch (error) {
+-      this.logger.error(`Error initiating deposit: ${error.message}`);
++      if (error instanceof AnchorIntegrationError) throw error;
++      this.logger.error(`Error initiating deposit: ${error?.message ?? String(error)}`);
+       throw new HttpException('Failed to initiate deposit', HttpStatus.INTERNAL_SERVER_ERROR);
+     }
+   }
+@@ -51,29 +169,60 @@ export class FiatRampsService {
+   async initiateWithdrawal(withdrawalDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
+     this.logger.log(`Initiating SEP-24 withdrawal flow with ${withdrawalDto.anchorDomain}`);
+     try {
+-      const mockInteractiveUrl = `https://${withdrawalDto.anchorDomain}/sep24/interactive?type=withdraw&asset_code=${withdrawalDto.assetCode}&account=${withdrawalDto.userAccount}`;
+-      
++      const { toml, transferServer, webAuth } = await this.discoverAnchor(withdrawalDto.anchorDomain);
++
++      const currencyList = (toml as any).CURRENCIES || [];
++      const found = Array.isArray(currencyList) && currencyList.find((c: any) => String(c.code).toUpperCase() === String(withdrawalDto.assetCode).toUpperCase());
++      if (!found) {
++        throw new AnchorIntegrationError(`Anchor ${withdrawalDto.anchorDomain} does not support asset ${withdrawalDto.assetCode}`, HttpStatus.BAD_REQUEST);
++      }
++
++      const token = await this.performSep10Auth(webAuth, withdrawalDto.userAccount);
++
++      const withdrawUrl = `${transferServer.replace(/\/$/, '')}/transactions/withdraw/interactive`;
++      const body = {
++        asset_code: withdrawalDto.assetCode,
++        account: withdrawalDto.userAccount,
++        amount: withdrawalDto.amount?.toString?.() ?? undefined,
++      };
++
++      const res = await fetch(withdrawUrl, {
++        method: 'POST',
++        headers: {
++          'Content-Type': 'application/json',
++          Authorization: `Bearer ${token}`,
++          Accept: 'application/json',
++        },
++        body: JSON.stringify(body),
++      });
++
++      if (!res.ok) {
++        const txt = await res.text().catch(() => '');
++        this.logger.warn(`SEP-24 withdrawal initiation failed: ${res.status} ${txt}`);
++        throw new AnchorIntegrationError('Failed to initiate SEP-24 withdrawal with anchor', HttpStatus.BAD_GATEWAY);
++      }
++
++      const json = await res.json().catch(() => ({}));
+       return {
+         status: 'success',
+         transaction_id: `wth_${Date.now()}`,
+-        type: 'interactive_customer_info_needed',
+-        url: mockInteractiveUrl,
++        type: json.type || json.status || 'interactive_customer_info_needed',
++        url: json.url || json.redirect_url || json.client_redirect_url,
+       };
+     } catch (error) {
+-      this.logger.error(`Error initiating withdrawal: ${error.message}`);
++      if (error instanceof AnchorIntegrationError) throw error;
++      this.logger.error(`Error initiating withdrawal: ${error?.message ?? String(error)}`);
+       throw new HttpException('Failed to initiate withdrawal', HttpStatus.INTERNAL_SERVER_ERROR);
+     }
+   }
+ 
+   async handleKycCallback(callbackData: unknown) {
+     this.logger.log(`Received KYC callback update: ${JSON.stringify(callbackData)}`);
+-    // Process KYC status updates from anchors
+     return { status: 'acknowledged' };
+   }
+ 
+   async updateTransactionStatus(statusData: unknown) {
+     this.logger.log(`Received transaction status update: ${JSON.stringify(statusData)}`);
+-    // Process SEP-24 transaction status changes (e.g., pending_user_transfer_start -> completed)
+     return { status: 'acknowledged' };
+   }
+ }
+diff --git a/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts b/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
+new file mode 100644
+index 00000000..e41c66a5
+--- /dev/null
++++ b/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
+@@ -0,0 +1,84 @@
++import { FiatRampsService, AnchorIntegrationError } from './fiat-ramps.service';
++import { TomlFetcherService } from '../asset-metadata/toml-fetcher.service';
++import { AppConfigService } from '../config/app-config.service';
++
++jest.mock('@stellar/stellar-sdk', () => {
++  return {
++    Transaction: jest.fn().mockImplementation(() => ({
++      sign: jest.fn(),
++      toEnvelope: () => ({ toXDR: () => 'signed-xdr' }),
++    })),
++    Keypair: {
++      fromSecret: jest.fn(() => ({
++        publicKey: () => 'GFAKE',
++      })),
++    },
++    Networks: { TESTNET: 'Test SDF Network ; September 2015' },
++  };
++});
++
++describe('FiatRampsService (SEP-24 handshake)', () => {
++  let service: FiatRampsService;
++  let tomlFetcher: Partial<TomlFetcherService>;
++  let config: Partial<AppConfigService>;
++  const globalAny: any = global;
++
++  beforeEach(() => {
++    tomlFetcher = {
++      fetchStellarToml: jest.fn(),
++    };
++
++    config = {
++      get stellarSecretKey() {
++        return 'SFAKEKEY';
++      },
++      get stellarNetworkPassphrase() {
++        return 'Test SDF Network ; September 2015';
++      },
++    } as unknown as Partial<AppConfigService>;
++
++    service = new FiatRampsService(tomlFetcher as TomlFetcherService, config as AppConfigService);
++    globalAny.fetch = jest.fn();
++  });
++
++  afterEach(() => {
++    jest.resetAllMocks();
++  });
++
++  it('initiates deposit via SEP-24 interactive flow when anchor responds correctly', async () => {
++    (tomlFetcher.fetchStellarToml as jest.Mock).mockResolvedValue({
++      TRANSFER_SERVER_SEP0024: 'https://anchor.example',
++      WEB_AUTH_ENDPOINT: 'https://anchor.example/auth',
++      CURRENCIES: [{ code: 'USDC' }],
++    });
++
++    // Sequence: challenge GET, auth POST, deposit POST
++    (globalAny.fetch as jest.Mock)
++      .mockResolvedValueOnce({ ok: true, json: async () => ({ transaction: 'challenge-xdr' }) })
++      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt-token' }) })
++      .mockResolvedValueOnce({ ok: true, json: async () => ({ type: 'interactive_customer_info_needed', url: 'https://anchor.example/interactive' }) });
++
++    const result = await service.initiateDeposit({ assetCode: 'USDC', amount: 10, userAccount: 'GUSER', anchorDomain: 'anchor.example' });
++
++    expect(result).toBeDefined();
++    expect(result.type).toBe('interactive_customer_info_needed');
++    expect(result.url).toBe('https://anchor.example/interactive');
++    expect(tomlFetcher.fetchStellarToml).toHaveBeenCalledWith('anchor.example');
++  });
++
++  it('throws when SEP-10 auth fails (auth endpoint returns non-OK)', async () => {
++    (tomlFetcher.fetchStellarToml as jest.Mock).mockResolvedValue({
++      TRANSFER_SERVER_SEP0024: 'https://anchor.example',
++      WEB_AUTH_ENDPOINT: 'https://anchor.example/auth',
++      CURRENCIES: [{ code: 'USDC' }],
++    });
++
++    (globalAny.fetch as jest.Mock)
++      .mockResolvedValueOnce({ ok: true, json: async () => ({ transaction: 'challenge-xdr' }) })
++      .mockResolvedValueOnce({ ok: false, status: 401, text: async () => 'unauthorized' });
++
++    await expect(
++      service.initiateDeposit({ assetCode: 'USDC', amount: 5, userAccount: 'GUSER', anchorDomain: 'anchor.example' }),
++    ).rejects.toBeInstanceOf(AnchorIntegrationError);
++  });
++});
+-- 
+2.43.0
+


### PR DESCRIPTION
closes #805 


$ git status --short && git diff --stat
(no output)
$ git status; git diff HEAD --stat
On branch feat/real-sep24-anchor-handshake
Your branch is up to date with 'origin/feat/real-sep24-anchor-handshake'.

nothing to commit, working tree clean
+ Thought: 865ms
$ git log --oneline -5; git show HEAD --stat | head -20
c782d718 feat: implement SEP-24 handshake in FiatRampsService and add unit tests
2473a16f feat: implement SEP-24 handshake in FiatRampsService and add unit tests
37cbf5fe Merge pull request #631 from oreoluwa648/feature/seed-reset-scheduler-contract-spec-endpoint
344654b7 test: exclude spec files from test coverage collection
5f312f09 test: fix test configurations, module imports, and contract spec service integration
commit c782d718d536d7461bb91a1f7b46dde35b0cf29b
Author: TechBroAfrica <osenioladebo@gmail.com>
Date:   Mon Aug 24 20:57:44 2026 +0100

    feat: implement SEP-24 handshake in FiatRampsService and add unit tests
…
Click to expand
+ Thought: 3.1s
Work is committed as c782d718 on feat/real-sep24-anchor-handshake. Here's the PR message:
BE-106: Real SEP-24 Anchor Handshake for Fiat Ramps
Summary
Replaces the mock interactive URL construction in FiatRampsService (mockInteractiveUrl) with a genuine, spec-compliant SEP-10 → SEP-24 handshake against testnet anchors. Deposits and withdrawals are now negotiated with the anchor: endpoints are discovered from its stellar.toml, authentication is performed via SEP-10, and interactive URLs come verbatim from the anchor's SEP-24 response. All failures surface as stable, typed errors.
Changes
fiat-ramps.service.ts
- Anchor discovery (SEP-1): reads TRANSFER_SERVER_SEP0024 (falls back to TRANSFER_SERVER), WEB_AUTH_ENDPOINT, SIGNING_KEY, and CURRENCIES from the anchor's stellar.toml via TomlFetcherService — nothing is assumed or string-constructed from the domain.
- SEP-10 authentication: GET challenge for the configured account → validates the challenge with WebAuth.readChallengeTx against the anchor's advertised SIGNING_KEY → client-signs it with STELLAR_SECRET_KEY → POSTs the signed transaction form-urlencoded per spec → extracts the JWT.
- SEP-24 initiation: POSTs application/x-www-form-urlencoded with Bearer <token> to {transferServer}/transactions/{deposit|withdraw}/interactive; returns the anchor-negotiated url, id, and type verbatim (supports url / redirect_url / client_redirect_url). Fails explicitly when no interactive URL is returned.
- Stable typed errors: new AnchorErrorCode enum + AnchorIntegrationError carrying { type: 'anchor_integration_error', code, message }:
- ANCHOR_UNREACHABLE (502) — toml fetch failure, missing endpoints, network errors/timeouts
- ASSET_UNSUPPORTED (400) — asset not in anchor CURRENCIES
- AUTH_NOT_CONFIGURED (503) — missing STELLAR_SECRET_KEY
- AUTH_FAILED (401) — anchor rejected auth or omitted token
- CHALLENGE_INVALID (502) — malformed/tampered challenge
- INTERACTIVE_FLOW_FAILED (502) — initiation rejected or no interactive URL
- Network failures and 5s timeouts are converted into typed 502s instead of unhandled TypeErrors / generic 500s.
- Shared Sep24FlowRequestDto (adds optional memo, memoType, lang passthrough); controller updated to use it.
Tests (fiat-ramps.service.unit.spec.ts, rewritten — 18 tests)
Uses the real Stellar SDK with only fetch stubbed; challenge transactions are built with WebAuth.buildChallengeTx exactly as an anchor server would issue them. Covers:
- Full deposit & withdrawal handshakes (asserting challenge request URL, form-encoded bodies, JWT usage, response provenance)
- TRANSFER_SERVER fallback, authenticated-account defaulting
- Auth failure (non-OK token endpoint), missing token, unreachable auth endpoint
- Tampered challenge (wrong signer vs advertised SIGNING_KEY), malformed challenge payload
- Unsupported asset / empty CURRENCIES (no handshake traffic)
- Anchor rejection of initiation, response without interactive URL, network-level failures → typed error
Acceptance Criteria
Criterion
Capabilities discovered from anchor stellar.toml
SEP-10 performed; token used for SEP-24 initiation
Interactive URLs from anchor response, not string construction
Unsupported assets / unreachable anchors return stable typed error
Tests cover handshake against stubbed anchor incl. auth failure
Testing
pnpm test:unit          # 105 suites, 1291 tests pass
pnpm lint               # clean
pnpm type-check         # clean
