### PR TITLE
feat(backend): idempotency keys for payment and link mutations (BE-109)

### DIFF
--- a/app/backend/.env.example
+++ b/app/backend/.env.example
@@ -115,3 +115,6 @@ SEED_RESET_EXCLUSIONS=production,mainnet
 SEED_RESET_MAX_RETRIES=3
 SEED_RESET_RETRY_DELAY_MS=60000
 FEATURE_SEED_RESET=true
+# Idempotency Keys (BE-109)
+# How long completed Idempotency-Key records are retained before expiry
+IDEMPOTENCY_RETENTION_HOURS=24

--- a/app/backend/src/common/idempotency/idempotency-store.service.ts
+++ b/app/backend/src/common/idempotency/idempotency-store.service.ts
@@ -1,0 +1,137 @@
+import {
+  Injectable,
+  OnModuleDestroy,
+  OnModuleInit,
+} from "@nestjs/common";
+
+import { AppConfigService } from "../../config/app-config.service";
+
+/**
+ * Lifecycle state of an idempotency record.
+ *
+ * PENDING   — a request holding this key is currently executing.
+ * COMPLETED — the handler finished; responseBody/statusCode are replayable.
+ */
+export type IdempotencyRecordStatus = "PENDING" | "COMPLETED";
+
+export interface IdempotencyRecord {
+  /** SHA-256 fingerprint of method + URL + body used for conflict detection. */
+  fingerprint: string;
+  status: IdempotencyRecordStatus;
+  /** HTTP status code of the completed response (COMPLETED records only). */
+  statusCode?: number;
+  /** Serialized response body of the completed request (COMPLETED only). */
+  responseBody?: unknown;
+  /** Epoch ms after which the key is forgotten (retention window). */
+  expiresAt: number;
+}
+
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * In-process store backing `Idempotency-Key` support on mutating payment and
+ * link endpoints (BE-109).
+ *
+ * Keys expire lazily (checked on access) and via a periodic sweep after the
+ * configurable retention window (`IDEMPOTENCY_RETENTION_HOURS`). Records live
+ * in memory, matching the existing transaction-service idempotency pattern;
+ * deployments running multiple instances should back this store with Redis or
+ * Postgres in a follow-up.
+ */
+@Injectable()
+export class IdempotencyStore implements OnModuleInit, OnModuleDestroy {
+  private readonly records = new Map<string, IdempotencyRecord>();
+  private sweepTimer?: NodeJS.Timeout;
+
+  constructor(private readonly appConfig: AppConfigService) {}
+
+  /** Retention window in milliseconds from configuration. */
+  get retentionMs(): number {
+    return this.appConfig.idempotencyRetentionHours * 60 * 60 * 1000;
+  }
+
+  /**
+   * Register a request for `key`. Returns the existing record when the key is
+   * already present (caller decides between replay and conflict), otherwise
+   * marks the key as PENDING and returns undefined. Expired keys are treated
+   * as fresh.
+   */
+  begin(key: string, fingerprint: string): IdempotencyRecord | undefined {
+    const existing = this.records.get(key);
+    if (existing && existing.expiresAt > Date.now()) {
+      return existing;
+    }
+    // Absent or expired — start a new pending window.
+    this.records.set(key, {
+      fingerprint,
+      status: "PENDING",
+      expiresAt: Date.now() + this.retentionMs,
+    });
+    return undefined;
+  }
+
+  /** Mark a PENDING record as COMPLETED and store its replayable response. */
+  complete(key: string, statusCode: number, responseBody: unknown): void {
+    const existing = this.records.get(key);
+    this.records.set(key, {
+      // Preserve the original fingerprint even when the pending window
+      // expired mid-flight, so later reuse conflicts are still detected.
+      fingerprint: existing?.fingerprint ?? "",
+      status: "COMPLETED",
+      statusCode,
+      responseBody,
+      expiresAt:
+        existing && existing.expiresAt > Date.now()
+          ? existing.expiresAt
+          : Date.now() + this.retentionMs,
+    });
+  }
+
+  /**
+   * Drop a PENDING record so the client can retry the same key after a
+   * failed attempt. COMPLETED records are never removed.
+   */
+  release(key: string): void {
+    const existing = this.records.get(key);
+    if (existing && existing.status === "PENDING") {
+      this.records.delete(key);
+    }
+  }
+
+  /** Read a record without side effects (used by tests and diagnostics). */
+  peek(key: string): IdempotencyRecord | undefined {
+    return this.records.get(key);
+  }
+
+  /** Remove every expired record. */
+  sweepExpired(): number {
+    const now = Date.now();
+    let removed = 0;
+    for (const [key, record] of this.records) {
+      if (record.expiresAt <= now) {
+        this.records.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  size(): number {
+    return this.records.size;
+  }
+
+  onModuleInit(): void {
+    this.sweepTimer = setInterval(
+      () => this.sweepExpired(),
+      SWEEP_INTERVAL_MS,
+    );
+    // Do not keep the process alive just for sweeping.
+    this.sweepTimer.unref?.();
+  }
+
+  onModuleDestroy(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+    }
+  }
+}

--- a/app/backend/src/common/idempotency/idempotency.interceptor.ts
+++ b/app/backend/src/common/idempotency/idempotency.interceptor.ts
@@ -1,0 +1,136 @@
+import {
+  BadRequestException,
+  CallHandler,
+  ConflictException,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from "@nestjs/common";
+import { Request, Response } from "express";
+import { createHash } from "crypto";
+import { Observable, of, throwError } from "rxjs";
+import { catchError, map } from "rxjs/operators";
+
+import { IdempotencyStore } from "./idempotency-store.service";
+
+export const IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+
+/** Maximum accepted length for an idempotency key. */
+export const MAX_IDEMPOTENCY_KEY_LENGTH = 128;
+
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Enforces `Idempotency-Key` semantics on mutating payment and link
+ * endpoints (BE-109).
+ *
+ * - Requests without the header pass through untouched.
+ * - Same key + same body after completion replays the original response
+ *   (including status code) without re-executing the handler.
+ * - Same key with a different body is rejected with a stable 409 conflict.
+ * - A duplicate request arriving while the first is still in flight gets a
+ *   stable 409 as well.
+ * - Failed handlers release the key so clients can retry it.
+ */
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  constructor(private readonly store: IdempotencyStore) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== "http") {
+      return next.handle();
+    }
+
+    const req = context.switchToHttp().getRequest<Request>();
+    const res = context.switchToHttp().getResponse<Response>();
+
+    if (!MUTATING_METHODS.has(req.method.toUpperCase())) {
+      return next.handle();
+    }
+
+    const rawKey = req.header(IDEMPOTENCY_KEY_HEADER);
+    // No header — nothing to enforce; endpoint behaves exactly as before.
+    if (rawKey === undefined) {
+      return next.handle();
+    }
+
+    const key = String(rawKey).trim();
+    if (!key) {
+      throw new BadRequestException({
+        code: "IDEMPOTENCY_KEY_INVALID",
+        message: "Idempotency-Key header must not be empty.",
+      });
+    }
+    if (key.length > MAX_IDEMPOTENCY_KEY_LENGTH) {
+      throw new BadRequestException({
+        code: "IDEMPOTENCY_KEY_INVALID",
+        message: `Idempotency-Key header must not exceed ${MAX_IDEMPOTENCY_KEY_LENGTH} characters.`,
+      });
+    }
+
+    const fingerprint = this.buildFingerprint(req);
+    const existing = this.store.begin(key, fingerprint);
+
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) {
+        throw new ConflictException({
+          code: "IDEMPOTENCY_KEY_REUSED",
+          message:
+            "This Idempotency-Key was already used with a different request.",
+        });
+      }
+      if (existing.status === "PENDING") {
+        throw new ConflictException({
+          code: "IDEMPOTENCY_KEY_IN_PROGRESS",
+          message:
+            "A request with this Idempotency-Key is currently being processed. Retry later to obtain its result.",
+        });
+      }
+      // Completed — replay the original response without re-executing.
+      res.status(existing.statusCode ?? 200);
+      return of(existing.responseBody);
+    }
+
+    // Capture status overrides applied while the handler runs (Nest applies
+    // @HttpCode / default POST 201 when serializing the response), so replays
+    // reproduce the original status code.
+    let capturedStatus: number | undefined;
+    const originalStatus = res.status.bind(res);
+    res.status = ((code: number) => {
+      capturedStatus = code;
+      return originalStatus(code);
+    }) as typeof res.status;
+
+    return next.handle().pipe(
+      map((body) => {
+        this.store.complete(
+          key,
+          capturedStatus ?? res.statusCode ?? 200,
+          body,
+        );
+        return body;
+      }),
+      catchError((err: unknown) => {
+        // Release the key so the client can retry the same key after failure.
+        this.store.release(key);
+        return throwError(() => err);
+      }),
+    );
+  }
+
+  /**
+   * Fingerprint binds a key to method + path + body, so replaying a key on a
+   * different endpoint or payload can never return a mismatched response.
+   */
+  private buildFingerprint(req: Request): string {
+    return createHash("sha256")
+      .update(
+        JSON.stringify({
+          method: req.method.toUpperCase(),
+          url: req.originalUrl,
+          body: req.body ?? null,
+        }),
+      )
+      .digest("hex");
+  }
+}

--- a/app/backend/src/common/idempotency/idempotency.module.ts
+++ b/app/backend/src/common/idempotency/idempotency.module.ts
@@ -1,0 +1,17 @@
+import { Module } from "@nestjs/common";
+
+import { AppConfigModule } from "../../config";
+import { IdempotencyInterceptor } from "./idempotency.interceptor";
+import { IdempotencyStore } from "./idempotency-store.service";
+
+/**
+ * Provides `Idempotency-Key` support for mutating payment and link
+ * endpoints (BE-109). Import this module in any module whose controllers
+ * apply `IdempotencyInterceptor`.
+ */
+@Module({
+  imports: [AppConfigModule],
+  providers: [IdempotencyStore, IdempotencyInterceptor],
+  exports: [IdempotencyStore, IdempotencyInterceptor],
+})
+export class IdempotencyModule {}

--- a/app/backend/src/common/idempotency/idempotency.unit.spec.ts
+++ b/app/backend/src/common/idempotency/idempotency.unit.spec.ts
@@ -1,0 +1,416 @@
+import { CallHandler, ExecutionContext } from "@nestjs/common";
+import { lastValueFrom, Observable, of, throwError } from "rxjs";
+
+import { AppConfigService } from "../../config/app-config.service";
+import { IdempotencyStore } from "./idempotency-store.service";
+import {
+  IdempotencyInterceptor,
+  IDEMPOTENCY_KEY_HEADER,
+} from "./idempotency.interceptor";
+
+describe("IdempotencyStore", () => {
+  const buildStore = (retentionHours = 24): IdempotencyStore =>
+    new IdempotencyStore({
+      idempotencyRetentionHours: retentionHours,
+    } as unknown as AppConfigService);
+
+  it("begins a fresh key as PENDING and returns undefined", () => {
+    const store = buildStore();
+    expect(store.begin("key-1", "fp-1")).toBeUndefined();
+    expect(store.peek("key-1")?.status).toBe("PENDING");
+    expect(store.peek("key-1")?.fingerprint).toBe("fp-1");
+  });
+
+  it("returns the existing record when the key is reused before completion", () => {
+    const store = buildStore();
+    store.begin("key-1", "fp-1");
+    const existing = store.begin("key-1", "fp-other");
+    expect(existing?.status).toBe("PENDING");
+    expect(existing?.fingerprint).toBe("fp-1");
+  });
+
+  it("treats an expired key as fresh on begin()", () => {
+    const store = buildStore(0); // retention of 0ms => immediate expiry
+    store.begin("key-1", "fp-1");
+    expect(store.begin("key-1", "fp-2")).toBeUndefined();
+    expect(store.peek("key-1")?.fingerprint).toBe("fp-2");
+  });
+
+  it("complete() stores a replayable COMPLETED record", () => {
+    const store = buildStore();
+    store.begin("key-1", "fp-1");
+    store.complete("key-1", 201, { ok: true });
+    const record = store.peek("key-1");
+    expect(record?.status).toBe("COMPLETED");
+    expect(record?.statusCode).toBe(201);
+    expect(record?.responseBody).toEqual({ ok: true });
+    expect(record?.fingerprint).toBe("fp-1");
+  });
+
+  it("release() removes only PENDING records", () => {
+    const store = buildStore();
+    store.begin("pending-key", "fp-a");
+    store.begin("done-key", "fp-b");
+    store.complete("done-key", 200, {});
+
+    store.release("pending-key");
+    expect(store.peek("pending-key")).toBeUndefined();
+
+    store.release("done-key");
+    expect(store.peek("done-key")).toBeDefined();
+  });
+
+  it("sweepExpired() removes expired records and keeps live ones", () => {
+    const store = buildStore();
+    store.begin("live", "fp-live");
+    store.begin("stale", "fp-stale");
+
+    // Force the stale record into the past.
+    const stale = store.peek("stale");
+    (store as unknown as { records: Map<string, { expiresAt: number }> })
+      .records.set("stale", {
+        ...(stale as { fingerprint: string; status: "PENDING" }),
+        expiresAt: Date.now() - 1,
+      });
+
+    expect(store.sweepExpired()).toBe(1);
+    expect(store.peek("stale")).toBeUndefined();
+    expect(store.peek("live")).toBeDefined();
+  });
+});
+
+describe("IdempotencyInterceptor", () => {
+  let store: IdempotencyStore;
+  let interceptor: IdempotencyInterceptor;
+  let handlerCalls: number;
+
+  const buildContext = (
+    method: string,
+    url: string,
+    body: unknown,
+    headers: Record<string, string> = {},
+  ): {
+    context: ExecutionContext;
+    res: Record<string, unknown>;
+    req: Record<string, unknown>;
+  } => {
+    // Express header lookups are case-insensitive; emulate that here.
+    const normalizedHeaders: Record<string, string> = {};
+    for (const [name, value] of Object.entries(headers)) {
+      normalizedHeaders[name.toLowerCase()] = value;
+    }
+    const req: Record<string, unknown> = {
+      method,
+      originalUrl: url,
+      body,
+      header: (name: string) => normalizedHeaders[name.toLowerCase()],
+    };
+    const res: Record<string, unknown> = {
+      statusCode: method === "POST" ? 201 : 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+    };
+    const context = {
+      getType: () => "http",
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => res,
+      }),
+    } as unknown as ExecutionContext;
+    return { context, res, req };
+  };
+
+  beforeEach(() => {
+    store = new IdempotencyStore({
+      idempotencyRetentionHours: 24,
+    } as unknown as AppConfigService);
+    interceptor = new IdempotencyInterceptor(store);
+    handlerCalls = 0;
+  });
+
+  const runHandler = (result: unknown) =>
+    ({
+      handle: () => {
+        handlerCalls += 1;
+        return of(result);
+      },
+    }) as unknown as CallHandler;
+
+  /**
+   * Runs the interceptor and returns the thrown HttpException payload
+   * (or undefined when no error occurred). intercept() throws synchronously
+   * for validation/conflict paths and rejects via the observable otherwise,
+   * so both are normalized here.
+   */
+  const interceptError = async (
+    ctx: ExecutionContext,
+    handler: CallHandler = runHandler({}),
+  ): Promise<{ response?: { code?: string } } | undefined> => {
+    try {
+      await lastValueFrom(interceptor.intercept(ctx, handler));
+      return undefined;
+    } catch (err) {
+      return err as { response?: { code?: string } };
+    }
+  };
+
+  it("passes through requests without an Idempotency-Key header", async () => {
+    const { context } = buildContext("POST", "/transactions/compose", { a: 1 });
+    await lastValueFrom(
+      interceptor.intercept(context, runHandler({ done: true })),
+    );
+    expect(handlerCalls).toBe(1);
+    expect(store.size()).toBe(0);
+  });
+
+  it("rejects empty keys with IDEMPOTENCY_KEY_INVALID", async () => {
+    const { context } = buildContext(
+      "POST",
+      "/transactions/compose",
+      { a: 1 },
+      { [IDEMPOTENCY_KEY_HEADER]: "   " },
+    );
+    const err = await interceptError(context);
+    expect(err?.response?.code).toBe("IDEMPOTENCY_KEY_INVALID");
+  });
+
+  it("rejects oversized keys with IDEMPOTENCY_KEY_INVALID", async () => {
+    const { context } = buildContext(
+      "POST",
+      "/transactions/compose",
+      { a: 1 },
+      { [IDEMPOTENCY_KEY_HEADER]: "k".repeat(129) },
+    );
+    const err = await interceptError(context);
+    expect(err?.response?.code).toBe("IDEMPOTENCY_KEY_INVALID");
+  });
+
+  it("executes once and replays the cached response for identical key+body", async () => {
+    const first = buildContext(
+      "POST",
+      "/transactions/submit",
+      { signedXdr: "AAA" },
+      { [IDEMPOTENCY_KEY_HEADER]: "order-1" },
+    );
+    const second = buildContext(
+      "POST",
+      "/transactions/submit",
+      { signedXdr: "AAA" },
+      { [IDEMPOTENCY_KEY_HEADER]: "order-1" },
+    );
+
+    const firstResult = await lastValueFrom(
+      interceptor.intercept(first.context, runHandler({ hash: "H1" })),
+    );
+    expect(firstResult).toEqual({ hash: "H1" });
+
+    // Second request must not reach the handler again.
+    const secondResult = await lastValueFrom(
+      interceptor.intercept(second.context, runHandler({ hash: "NEVER" })),
+    );
+    expect(secondResult).toEqual({ hash: "H1" });
+    expect(handlerCalls).toBe(1);
+  });
+
+  it("replays the original HTTP status code", async () => {
+    const first = buildContext(
+      "POST",
+      "/transactions/compose",
+      { a: 1 },
+      { [IDEMPOTENCY_KEY_HEADER]: "status-key" },
+    );
+    // Simulate Nest applying @HttpCode(202) before emitting the body.
+    const handler = {
+      handle: () =>
+        new Observable((sub) => {
+          (first.res.status as (code: number) => unknown)(202);
+          sub.next({ created: true });
+          sub.complete();
+        }),
+    } as unknown as CallHandler;
+    await lastValueFrom(interceptor.intercept(first.context, handler));
+    expect(store.peek("status-key")?.statusCode).toBe(202);
+
+    const replay = buildContext(
+      "POST",
+      "/transactions/compose",
+      { a: 1 },
+      { [IDEMPOTENCY_KEY_HEADER]: "status-key" },
+    );
+    await lastValueFrom(
+      interceptor.intercept(replay.context, runHandler({ never: true })),
+    );
+    expect((replay.res as { statusCode?: number }).statusCode).toBe(202);
+    // The replay path never invoked the handler (first request used the
+    // deferred handler above, so total handler invocations remain 0).
+    expect(handlerCalls).toBe(0);
+  });
+
+  it("conflicts when the same key is reused with a different body", async () => {
+    const first = buildContext(
+      "POST",
+      "/transactions/submit",
+      { signedXdr: "AAA" },
+      { [IDEMPOTENCY_KEY_HEADER]: "dup-1" },
+    );
+    await lastValueFrom(interceptor.intercept(first.context, runHandler({})));
+
+    const second = buildContext(
+      "POST",
+      "/transactions/submit",
+      { signedXdr: "BBB" }, // different payload, same key
+      { [IDEMPOTENCY_KEY_HEADER]: "dup-1" },
+    );
+    const err = await interceptError(second.context);
+    expect(err?.response?.code).toBe("IDEMPOTENCY_KEY_REUSED");
+    expect(handlerCalls).toBe(1);
+  });
+
+  it("conflicts when the same key is reused on a different endpoint", async () => {
+    const first = buildContext(
+      "POST",
+      "/transactions/compose",
+      { a: 1 },
+      { [IDEMPOTENCY_KEY_HEADER]: "route-key" },
+    );
+    await lastValueFrom(interceptor.intercept(first.context, runHandler({})));
+
+    const second = buildContext(
+      "POST",
+      "/fiat-ramps/deposit",
+      { a: 1 }, // identical body but different route
+      { [IDEMPOTENCY_KEY_HEADER]: "route-key" },
+    );
+    const err = await interceptError(second.context);
+    expect(err?.response?.code).toBe("IDEMPOTENCY_KEY_REUSED");
+  });
+
+  it("reports in-progress conflicts for concurrent duplicate requests", async () => {
+    const { context, req } = buildContext(
+      "POST",
+      "/links/metadata",
+      { amount: 10 },
+      { [IDEMPOTENCY_KEY_HEADER]: "race-key" },
+    );
+    // Seed the store exactly as an in-flight identical request would have.
+    const fingerprint = (
+      interceptor as unknown as {
+        buildFingerprint: (r: unknown) => string;
+      }
+    ).buildFingerprint(req);
+    store.begin("race-key", fingerprint);
+
+    const err = await interceptError(context);
+    expect(err?.response?.code).toBe("IDEMPOTENCY_KEY_IN_PROGRESS");
+  });
+
+  it("serializes concurrent duplicates: in-flight conflict then clean replay", async () => {
+    let resolveFirst!: (value: unknown) => void;
+    const deferredHandler = {
+      handle: () =>
+        new Observable((sub) => {
+          handlerCalls += 1;
+          resolveFirst = (value: unknown) => {
+            sub.next(value);
+            sub.complete();
+          };
+        }),
+    } as unknown as CallHandler;
+
+    const first = buildContext(
+      "POST",
+      "/transactions/submit",
+      { signedXdr: "RACE" },
+      { [IDEMPOTENCY_KEY_HEADER]: "race-2" },
+    );
+    // Subscribing starts execution but leaves the key PENDING.
+    const firstPromise = lastValueFrom(
+      interceptor.intercept(first.context, deferredHandler),
+    );
+
+    const duplicate = buildContext(
+      "POST",
+      "/transactions/submit",
+      { signedXdr: "RACE" },
+      { [IDEMPOTENCY_KEY_HEADER]: "race-2" },
+    );
+    const dupErr = await interceptError(duplicate.context);
+    expect(dupErr?.response?.code).toBe("IDEMPOTENCY_KEY_IN_PROGRESS");
+
+    resolveFirst({ hash: "H-RACE" });
+    await expect(firstPromise).resolves.toEqual({ hash: "H-RACE" });
+
+    // Once completed, an identical retry replays without executing again.
+    const replay = buildContext(
+      "POST",
+      "/transactions/submit",
+      { signedXdr: "RACE" },
+      { [IDEMPOTENCY_KEY_HEADER]: "race-2" },
+    );
+    const replayed = await lastValueFrom(
+      interceptor.intercept(replay.context, runHandler({ never: true })),
+    );
+    expect(replayed).toEqual({ hash: "H-RACE" });
+    expect(handlerCalls).toBe(1);
+  });
+
+  it("releases the key after a failed handler so clients can retry", async () => {
+    const failingHandler = {
+      handle: () => throwError(() => new Error("horizon down")),
+    } as unknown as CallHandler;
+    const first = buildContext(
+      "POST",
+      "/transactions/submit",
+      { x: 1 },
+      { [IDEMPOTENCY_KEY_HEADER]: "retry-key" },
+    );
+
+    await expect(
+      lastValueFrom(interceptor.intercept(first.context, failingHandler)),
+    ).rejects.toThrow("horizon down");
+    expect(store.peek("retry-key")).toBeUndefined();
+
+    // Retry with the same key now executes normally.
+    const retry = buildContext(
+      "POST",
+      "/transactions/submit",
+      { x: 1 },
+      { [IDEMPOTENCY_KEY_HEADER]: "retry-key" },
+    );
+    const result = await lastValueFrom(
+      interceptor.intercept(retry.context, runHandler({ ok: true })),
+    );
+    expect(result).toEqual({ ok: true });
+    expect(handlerCalls).toBe(1);
+  });
+
+  it("ignores non-mutating methods entirely", async () => {
+    const { context } = buildContext(
+      "GET",
+      "/links/metadata",
+      undefined,
+      { [IDEMPOTENCY_KEY_HEADER]: "get-key" },
+    );
+    await lastValueFrom(
+      interceptor.intercept(context, runHandler({ list: [] })),
+    );
+    expect(handlerCalls).toBe(1);
+    expect(store.size()).toBe(0);
+  });
+
+  it("fingerprints include the request URL so different routes conflict", () => {
+    const fpA = (
+      interceptor as unknown as {
+        buildFingerprint: (req: { method: string; originalUrl: string; body: unknown }) => string;
+      }
+    ).buildFingerprint({ method: "POST", originalUrl: "/a", body: { v: 1 } });
+    const fpB = (
+      interceptor as unknown as {
+        buildFingerprint: (req: { method: string; originalUrl: string; body: unknown }) => string;
+      }
+    ).buildFingerprint({ method: "POST", originalUrl: "/b", body: { v: 1 } });
+    expect(fpA).not.toBe(fpB);
+  });
+});

--- a/app/backend/src/config/app-config.service.ts
+++ b/app/backend/src/config/app-config.service.ts
@@ -351,6 +351,15 @@ export class AppConfigService {
     return this.configService.get("ABUSE_SIGNAL_HASH_SALT", { infer: true });
   }
 
+  /**
+   * Retention window (hours) for completed idempotency key records (BE-109)
+   */
+  get idempotencyRetentionHours(): number {
+    return this.configService.get("IDEMPOTENCY_RETENTION_HOURS", {
+      infer: true,
+    });
+  }
+
   // ====================================================================
   // NEW ACCESSORS FOR BOOTSTRAP PAYLOAD
   // ====================================================================

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -425,8 +425,7 @@ export const envSchema = Joi.object({
     .min(1)
     .max(365)
     .default(90)
-    .description("Days to retain abuse signals before auto-pruning"),
-  ABUSE_SIGNAL_SCORE_THRESHOLD: Joi.number()
+    .description("Days to retain abuse signals before auto-pruning"),  ABUSE_SIGNAL_SCORE_THRESHOLD: Joi.number()
     .integer()
     .min(0)
     .max(100)
@@ -439,6 +438,16 @@ export const envSchema = Joi.object({
     .empty("")
     .default("default-abuse-salt")
     .description("Salt for IP/UA hashing in abuse signals"),
+
+  // ── Idempotency Keys (BE-109) ───────────────────────────────────────────
+  IDEMPOTENCY_RETENTION_HOURS: Joi.number()
+    .integer()
+    .min(1)
+    .max(168)
+    .default(24)
+    .description(
+      "How long completed Idempotency-Key records are retained before expiry",
+    ),
 
   PREVIEW_INACTIVITY_THRESHOLD_MS: Joi.number()
     .integer()
@@ -525,6 +534,7 @@ export interface EnvConfig {
   ABUSE_SIGNAL_SCORE_THRESHOLD: number;
   ABUSE_SIGNAL_GEO_ENABLED: boolean;
   ABUSE_SIGNAL_HASH_SALT: string;
+  IDEMPOTENCY_RETENTION_HOURS: number;
   PREVIEW_INACTIVITY_THRESHOLD_MS: number;
   PREVIEW_MAX_AGE_MS: number;
 }

--- a/app/backend/src/fiat-ramps/fiat-ramps.controller.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.controller.ts
@@ -1,8 +1,19 @@
-import { Controller, Get, Post, Body, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Controller, Get, Post, Body, Query, UseInterceptors } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiHeader } from '@nestjs/swagger';
 import { FiatRampsService } from './fiat-ramps.service';
+import {
+  IdempotencyInterceptor,
+  IDEMPOTENCY_KEY_HEADER,
+} from '../common/idempotency/idempotency.interceptor';
 
 @ApiTags('fiat-ramps')
+@ApiHeader({
+  name: IDEMPOTENCY_KEY_HEADER,
+  description:
+    'Optional. Supply a unique key to make deposit/withdraw mutations idempotent: retries with the same key and body return the original response; reuse with a different body is rejected.',
+  required: false,
+})
+@UseInterceptors(IdempotencyInterceptor)
 @Controller('fiat-ramps')
 export class FiatRampsController {
   constructor(private readonly fiatRampsService: FiatRampsService) {}

--- a/app/backend/src/fiat-ramps/fiat-ramps.module.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { FiatRampsController } from './fiat-ramps.controller';
 import { FiatRampsService } from './fiat-ramps.service';
+import { IdempotencyModule } from '../common/idempotency/idempotency.module';
 
 @Module({
+  imports: [IdempotencyModule],
   controllers: [FiatRampsController],
   providers: [FiatRampsService],
   exports: [FiatRampsService],

--- a/app/backend/src/links/bulk-payment-links.controller.ts
+++ b/app/backend/src/links/bulk-payment-links.controller.ts
@@ -8,9 +8,13 @@ import {
   UseInterceptors,
   UploadedFile,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiConsumes } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiConsumes, ApiHeader } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { BulkPaymentLinksService } from './bulk-payment-links.service';
+import {
+  IdempotencyInterceptor,
+  IDEMPOTENCY_KEY_HEADER,
+} from '../common/idempotency/idempotency.interceptor';
 import {
   BulkPaymentLinkRequestDto,
   BulkPaymentLinkResponseDto,
@@ -22,6 +26,13 @@ interface UploadedFile {
 }
 
 @ApiTags('links')
+@ApiHeader({
+  name: IDEMPOTENCY_KEY_HEADER,
+  description:
+    'Optional. Supply a unique key to make bulk generation idempotent: retries with the same key and body return the original response; reuse with a different body is rejected.',
+  required: false,
+})
+@UseInterceptors(IdempotencyInterceptor)
 @Controller('links/bulk')
 export class BulkPaymentLinksController {
   constructor(private readonly bulkPaymentLinksService: BulkPaymentLinksService) {}

--- a/app/backend/src/links/links.controller.ts
+++ b/app/backend/src/links/links.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   BadRequestException,
   UseGuards,
+  UseInterceptors,
 } from "@nestjs/common";
 import {
   ApiTags,
@@ -18,6 +19,10 @@ import { LinksService } from "./links.service";
 import { LinkMetadataRequestDto, LinkMetadataResponseDto } from "../dto";
 import { LinkValidationError } from "./errors";
 import { ApiKeyGuard } from "../auth/guards/api-key.guard";
+import {
+  IdempotencyInterceptor,
+  IDEMPOTENCY_KEY_HEADER,
+} from "../common/idempotency/idempotency.interceptor";
 
 @ApiTags("links")
 @ApiHeader({
@@ -26,7 +31,14 @@ import { ApiKeyGuard } from "../auth/guards/api-key.guard";
     "Optional API key for higher rate limits (120 req/min vs 20 req/min)",
   required: false,
 })
+@ApiHeader({
+  name: IDEMPOTENCY_KEY_HEADER,
+  description:
+    "Optional. Supply a unique key to make this mutation idempotent: retries with the same key and body return the original response; reuse with a different body is rejected.",
+  required: false,
+})
 @UseGuards(ApiKeyGuard)
+@UseInterceptors(IdempotencyInterceptor)
 @Controller("links")
 export class LinksController {
   constructor(private readonly linksService: LinksService) {}

--- a/app/backend/src/links/links.module.ts
+++ b/app/backend/src/links/links.module.ts
@@ -20,6 +20,7 @@ import { PrivacyModule } from "../privacy/privacy.module";
 import { TransactionsModule } from "../transactions/transactions.module";
 import { AuditModule } from "../audit/audit.module";
 import { MetricsModule } from "../metrics/metrics.module";
+import { IdempotencyModule } from "../common/idempotency/idempotency.module";
 
 @Module({
   controllers: [
@@ -56,6 +57,7 @@ import { MetricsModule } from "../metrics/metrics.module";
     TransactionsModule,
     AuditModule,
     MetricsModule,
+    IdempotencyModule,
     forwardRef(() => JobQueueModule),
   ],
 })

--- a/app/backend/src/links/recurring-payments.controller.ts
+++ b/app/backend/src/links/recurring-payments.controller.ts
@@ -8,9 +8,14 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery, ApiHeader } from '@nestjs/swagger';
 import { RecurringPaymentsService } from './recurring-payments.service';
+import {
+  IdempotencyInterceptor,
+  IDEMPOTENCY_KEY_HEADER,
+} from '../common/idempotency/idempotency.interceptor';
 import {
   CreateRecurringPaymentLinkDto,
   UpdateRecurringPaymentLinkDto,
@@ -22,6 +27,13 @@ import {
 } from './dto/recurring-payment.dto';
 
 @ApiTags('recurring-payments')
+@ApiHeader({
+  name: IDEMPOTENCY_KEY_HEADER,
+  description:
+    'Optional. Supply a unique key to make create/update/execute mutations idempotent: retries with the same key and body return the original response; reuse with a different body is rejected.',
+  required: false,
+})
+@UseInterceptors(IdempotencyInterceptor)
 @Controller('links/recurring')
 export class RecurringPaymentsController {
   constructor(private readonly service: RecurringPaymentsService) {}

--- a/app/backend/src/transactions/transactions.controller.ts
+++ b/app/backend/src/transactions/transactions.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   Req,
   UseGuards,
+  UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from "@nestjs/common";
@@ -27,6 +28,10 @@ import { RequiresFlag } from "../feature-flags/requires-flag.decorator";
 import { ComposeTransactionDto, SimulateOperationDto, SubmitSignedTransactionDto } from "./dto/compose-transaction.dto";
 import { TransactionsService } from "./transaction.service";
 import { ContractMethodAllowlistGuard } from "../contracts/contract-method-allowlist.guard";
+import {
+  IdempotencyInterceptor,
+  IDEMPOTENCY_KEY_HEADER,
+} from "../common/idempotency/idempotency.interceptor";
 
 function correlationIdOf(req: Request): string | undefined {
   return (req as unknown as Record<string, unknown>)["correlationId"] as
@@ -40,7 +45,14 @@ function correlationIdOf(req: Request): string | undefined {
   description: "Optional API key for higher rate limits",
   required: false,
 })
+@ApiHeader({
+  name: IDEMPOTENCY_KEY_HEADER,
+  description:
+    "Optional. Supply a unique key to make this mutation idempotent: retries with the same key and body return the original response; reuse with a different body is rejected.",
+  required: false,
+})
 @UseGuards(ApiKeyGuard)
+@UseInterceptors(IdempotencyInterceptor)
 @Controller("transactions")
 export class TransactionsController {
   constructor(

--- a/app/backend/src/transactions/transactions.module.ts
+++ b/app/backend/src/transactions/transactions.module.ts
@@ -10,6 +10,7 @@ import { MetricsModule } from "../metrics/metrics.module";
 import { FeatureFlagsModule } from "../feature-flags/feature-flags.module";
 import { ContractsModule } from "../contracts/contracts.module";
 import { AuditModule } from "../audit/audit.module";
+import { IdempotencyModule } from "../common/idempotency/idempotency.module";
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { AuditModule } from "../audit/audit.module";
     FeatureFlagsModule,
     ContractsModule,
     AuditModule,
+    IdempotencyModule,
   ],
   controllers: [TransactionsController],
   providers: [

--- a/app/backend/test/idempotency-keys.e2e-spec.ts
+++ b/app/backend/test/idempotency-keys.e2e-spec.ts
@@ -1,0 +1,134 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import {
+  BadRequestException,
+  INestApplication,
+  ValidationPipe,
+} from "@nestjs/common";
+import { EventEmitterModule } from "@nestjs/event-emitter";
+import { ThrottlerModule } from "@nestjs/throttler";
+import * as request from "supertest";
+import { LinksModule } from "../src/links/links.module";
+import { LinksService } from "../src/links/links.service";
+import { mapValidationErrors } from "../src/common/utils/validation-error.mapper";
+import { AppConfigService } from "../src/config";
+import { GlobalHttpExceptionFilter } from "../src/common/filters/global-http-exception.filter";
+
+const KEY_HEADER = "Idempotency-Key";
+
+describe("Idempotency keys (BE-109, e2e)", () => {
+  let app: INestApplication;
+  let generateMetadataSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        EventEmitterModule.forRoot(),
+        ThrottlerModule.forRoot([
+          {
+            ttl: 60000,
+            limit: 20,
+          },
+        ]),
+        LinksModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        exceptionFactory: (errors) => {
+          const mapped = mapValidationErrors(errors);
+
+          return new BadRequestException({
+            code: "VALIDATION_ERROR",
+            message: mapped.message,
+            fields: mapped.fields,
+          });
+        },
+      }),
+    );
+
+    app.useGlobalFilters(
+      new GlobalHttpExceptionFilter({
+        isProduction: false,
+      } as AppConfigService),
+    );
+    await app.init();
+
+    const linksService = app.get(LinksService);
+    generateMetadataSpy = jest.spyOn(linksService, "generateMetadata");
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  describe("POST /links/metadata with Idempotency-Key", () => {
+    const payload = { amount: 100, memo: "Idem", asset: "XLM" };
+
+    it("replays the original response without re-executing on retry", async () => {
+      const first = await request(app.getHttpServer())
+        .post("/links/metadata")
+        .set(KEY_HEADER, "e2e-key-1")
+        .send(payload)
+        .expect(200);
+      expect(first.body.success).toBe(true);
+      expect(generateMetadataSpy).toHaveBeenCalledTimes(1);
+
+      const replay = await request(app.getHttpServer())
+        .post("/links/metadata")
+        .set(KEY_HEADER, "e2e-key-1")
+        .send(payload)
+        .expect(200);
+
+      // Identical response body, but the handler ran only once.
+      expect(replay.body).toEqual(first.body);
+      expect(generateMetadataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects the same key used with a different body (409)", async () => {
+      await request(app.getHttpServer())
+        .post("/links/metadata")
+        .set(KEY_HEADER, "e2e-conflict-1")
+        .send(payload)
+        .expect(200);
+
+      const conflict = await request(app.getHttpServer())
+        .post("/links/metadata")
+        .set(KEY_HEADER, "e2e-conflict-1")
+        .send({ amount: 999, memo: "Different", asset: "XLM" })
+        .expect(409);
+
+      expect(conflict.body.error?.code).toBe("IDEMPOTENCY_KEY_REUSED");
+      // The conflicting request never reached the handler.
+      expect(generateMetadataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats requests without a key as ordinary mutations", async () => {
+      await request(app.getHttpServer())
+        .post("/links/metadata")
+        .send(payload)
+        .expect(200);
+      await request(app.getHttpServer())
+        .post("/links/metadata")
+        .send(payload)
+        .expect(200);
+      // No key — both executions are expected.
+      expect(generateMetadataSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("rejects an empty Idempotency-Key header with 400", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/links/metadata")
+        .set(KEY_HEADER, "   ")
+        .send(payload)
+        .expect(400);
+      expect(res.body.error?.code).toBe("IDEMPOTENCY_KEY_INVALID");
+    });
+  });
+});


### PR DESCRIPTION
## Overview

Implements **BE-109 — Idempotency Keys for Payment and Link Mutations** (#808).

Mutating endpoints in the transactions, fiat-ramps, and links modules now honor an optional `Idempotency-Key` header. Clients that retry a request (network timeouts, mobile flakiness, double clicks) get the original response replayed instead of triggering duplicate payments or link creation.

Behavior:

- **Same key + same body → replay.** The original response body *and* HTTP status code are returned without re-executing the handler.
- **Same key + different body → stable 409 conflict** (`IDEMPOTENCY_KEY_REUSED`). Keys are fingerprint-bound to method + path + body (SHA-256), so reuse on any other endpoint/payload can never return a mismatched response.
- **Concurrent same-key requests → stable 409** (`IDEMPOTENCY_KEY_IN_PROGRESS`) while the first is still executing.
- **Failed handlers release the key**, so clients can safely retry after an error.
- **Keys expire** after a configurable retention window (`IDEMPOTENCY_RETENTION_HOURS`, default `24h`, clamped to 1–168h) via lazy checks plus periodic sweeping.

Design notes: implemented as a NestJS `IdempotencyInterceptor` + in-process TTL store under `src/common/idempotency`, mirroring the repo's existing middleware/config conventions and the prior ad-hoc idempotency logic inside `TransactionService.submitSignedTransaction` (which remains untouched; migrating it onto the shared interceptor can be a follow-up). The store is in-memory by design for this iteration — matching the existing transaction-service pattern — and should be backed by Redis/Postgres before multi-instance production deployments.

## Related Issue

Closes #808

## Changes

### Added

- **[ADD]** `app/backend/src/common/idempotency/idempotency.interceptor.ts` — enforces `Idempotency-Key` semantics on mutating methods (POST/PUT/PATCH/DELETE); validates key format, computes the request fingerprint, replays completed responses, raises conflicts, releases keys on failure.
- **[ADD]** `app/backend/src/common/idempotency/idempotency-store.service.ts` — TTL-backed in-memory record store (`PENDING`/`COMPLETED`) with retention expiry, sweep timer, and lifecycle hooks.
- **[ADD]** `app/backend/src/common/idempotency/idempotency.module.ts` — module exporting the store + interceptor for feature-module imports.
- **[ADD]** `app/backend/src/common/idempotency/idempotency.unit.spec.ts` — 18 unit specs: store begin/complete/release/expiry/sweep; interceptor passthrough, invalid/oversized keys, replay (incl. status code), body/route conflicts, concurrent duplicates, retry-after-failure.
- **[ADD]** `app/backend/test/idempotency-keys.e2e-spec.ts` — HTTP-level specs over `/links/metadata`: identical retry replays byte-for-byte with the handler executing exactly once, conflicting body returns 409 with `IDEMPOTENCY_KEY_REUSED`, key-less requests behave unchanged, empty keys rejected with 400.

### Modified

- **[MODIFY]** `app/backend/src/transactions/transactions.controller.ts` + `transactions.module.ts` — guard `compose`/`submit` payment mutations; document the header in Swagger.
- **[MODIFY]** `app/backend/src/fiat-ramps/fiat-ramps.controller.ts` + `fiat-ramps.module.ts` — guard `deposit`/`withdraw` flows.
- **[MODIFY]** `app/backend/src/links/links.controller.ts`, `bulk-payment-links.controller.ts`, `recurring-payments.controller.ts` + `links.module.ts` — guard link creation/bulk generation/recurring mutations.
- **[MODIFY]** `app/backend/src/config/env.schema.ts` — new `IDEMPOTENCY_RETENTION_HOURS` env var (Joi: integer 1–168, default 24) and typed `EnvConfig` field.
- **[MODIFY]** `app/backend/src/config/app-config.service.ts` — `idempotencyRetentionHours` accessor following existing getter conventions.
- **[MODIFY]** `app/backend/.env.example` — documents `IDEMPOTENCY_RETENTION_HOURS`.

## Verification Results

```
pnpm type-check            → clean (tsc --noEmit)
pnpm lint                  → clean
Unit suite                 → Tests: 1330 passed, 1330 total (includes 18 new idempotency specs)
Idempotency unit specs     → Tests: 18 passed, 18 total
Idempotency e2e specs      → Tests: 4 passed, 4 total
```

Full backend e2e run shows 73 failures across smoke/DI-heavy suites (`smoke.e2e-spec`, `smoke-soroban-horizon`, `app.e2e-spec`, `preview-scope-isolation.e2e-spec`, `contract-registry.e2e-spec`); these require live Soroban RPC/Horizon/Supabase credentials and reproduce identically (73 failures) on a clean checkout of `main` with this branch stashed.

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Idempotency-Key honored on payment mutation endpoints | ✅ |
| Same key + body returns original response without re-execution | ✅ |
| Same key + different body returns stable conflict error | ✅ (409 `IDEMPOTENCY_KEY_REUSED`) |
| Concurrent same-key requests handled deterministically | ✅ (409 `IDEMPOTENCY_KEY_IN_PROGRESS`) |
| Keys expire after configurable retention window | ✅ (`IDEMPOTENCY_RETENTION_HOURS`) |
| Failed requests do not poison the key | ✅ (key released on handler error) |
| Tests cover replay, conflicting reuse, and concurrency | ✅ (unit + e2e) |
