### PR TITLE
fix: MOB-59: Gate Debug Screens Behind Development Builds

### DIFF
--- a/app/mobile/__tests__/debug-routes.test.ts
+++ b/app/mobile/__tests__/debug-routes.test.ts
@@ -1,0 +1,51 @@
+// Mock expo-constants so the build config resolves to a production build
+// regardless of the jest-expo default environment.
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: {
+    expoConfig: {
+      version: "1.0.0",
+      extra: { environment: "production" },
+    },
+    nativeBuildVersion: "1",
+  },
+}));
+
+import { resolveDeepLink } from '../utils/deep-link-routing';
+import { IS_DEBUG_BUILD } from '../src/config/build';
+
+/**
+ * Debug screens (deep-link-debug, notification-debug, qa-smoke-checklist,
+ * offline-queue-inspector) expose internal state and allow arbitrary deep
+ * links to be injected. They must only be registered and reachable in
+ * development/internal builds.
+ *
+ * Under a production configuration, IS_DEBUG_BUILD is false, so deep links
+ * targeting debug routes must be rejected.
+ */
+describe('debug routes gating', () => {
+  it('is not a debug build under the production configuration', () => {
+    expect(IS_DEBUG_BUILD).toBe(false);
+  });
+
+  it('rejects deep links targeting debug routes in production builds', () => {
+    const debugLinks = [
+      'https://quickex.to/deep-link-debug',
+      'quickex://deep-link-debug',
+      'https://quickex.to/notification-debug',
+      'https://quickex.to/qa-smoke-checklist',
+      'https://quickex.to/offline-queue-inspector',
+    ];
+
+    for (const link of debugLinks) {
+      const result = resolveDeepLink(link);
+      expect('route' in result).toBe(false);
+      expect(result).toEqual({ error: 'Unsupported or expired QuickEx link.' });
+    }
+  });
+
+  it('still resolves legitimate deep links in production builds', () => {
+    const result = resolveDeepLink('https://quickex.to/jordan?amount=12.5&asset=XLM');
+    expect('route' in result).toBe(true);
+  });
+});

--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -29,6 +29,7 @@ import { WalletSyncBridge } from "../components/wallet/WalletSyncBridge";
 
 import { resolveDeepLink, type DeepLinkRoute } from "@/utils/deep-link-routing";
 import { initializeCrashMonitoring } from "../services/crash-monitoring";
+import { IS_DEBUG_BUILD } from "../src/config/build";
 
 // Initialize crash monitoring as early as possible to catch boot exceptions
 initializeCrashMonitoring();
@@ -250,11 +251,18 @@ function AppShell() {
         <Stack.Screen name="escrow/[id]" />
         <Stack.Screen name="listing/[id]" />
         <Stack.Screen name="inbox" />
-        <Stack.Screen name="notification-debug" />
-        <Stack.Screen name="deep-link-debug" />
+        {/* Debug screens are only registered in development/internal builds.
+            In production builds they are absent, so any attempt to reach them
+            resolves to the not-found state. See src/config/build.ts. */}
+        {IS_DEBUG_BUILD ? (
+          <>
+            <Stack.Screen name="notification-debug" />
+            <Stack.Screen name="deep-link-debug" />
+            <Stack.Screen name="qa-smoke-checklist" />
+            <Stack.Screen name="offline-queue-inspector" />
+          </>
+        ) : null}
         <Stack.Screen name="link-error" />
-        <Stack.Screen name="qa-smoke-checklist" />
-        <Stack.Screen name="offline-queue-inspector" />
         <Stack.Screen name="contacts" />
         <Stack.Screen name="add-contact" />
         <Stack.Screen name="edit-contact" />

--- a/app/mobile/app/settings.tsx
+++ b/app/mobile/app/settings.tsx
@@ -29,6 +29,7 @@ import {
   APP_VERSION,
   BUILD_METADATA,
   BUILD_TAG,
+  IS_DEBUG_BUILD,
   STELLAR_NETWORK,
 } from "../src/config/build";
 
@@ -434,7 +435,7 @@ export default function SettingsScreen() {
 
         <EnvironmentSwitcher />
 
-        {Platform.OS !== "web" ? (
+        {Platform.OS !== "web" && IS_DEBUG_BUILD ? (
           <View style={styles.section}>
             <Text style={[styles.sectionTitle, { color: theme.textPrimary }]}>
               Debug

--- a/app/mobile/src/config/build.ts
+++ b/app/mobile/src/config/build.ts
@@ -9,6 +9,19 @@ export const BUILD_NUMBER = String(
 export const BUILD_TAG = String(extra.buildTag ?? '');
 export const APP_ENVIRONMENT = String(extra.environment ?? 'production');
 export const STELLAR_NETWORK = String(extra.stellarNetwork ?? 'mainnet');
+
+/**
+ * Whether this build is a development or internal (non-production) build.
+ *
+ * Debug screens (deep-link-debug, notification-debug, qa-smoke-checklist,
+ * offline-queue-inspector) expose internal state and allow arbitrary deep
+ * links to be injected, so they must only be registered and reachable in
+ * development or internal builds. Production builds gate them out entirely.
+ *
+ * A build is considered "debug" when it is not a production build. This covers
+ * local development (`dev`), staging, shared testnet, and branch previews.
+ */
+export const IS_DEBUG_BUILD = APP_ENVIRONMENT !== 'production';
 export const BUILD_METADATA = `${APP_VERSION}+${BUILD_NUMBER}`;
 export const API_URL = String(
   extra.apiUrl ?? process.env['EXPO_PUBLIC_API_URL'] ?? 'http://localhost:3000'

--- a/app/mobile/utils/deep-link-routing.ts
+++ b/app/mobile/utils/deep-link-routing.ts
@@ -1,7 +1,20 @@
 import { parsePaymentLink } from './parse-payment-link';
+import { IS_DEBUG_BUILD } from '../src/config/build';
 
 const QUICKEX_HOSTS = ['quickex.to', 'www.quickex.to'];
 const QUICKEX_SCHEME = 'quickex';
+
+/**
+ * Debug routes that expose internal state or allow arbitrary deep links to be
+ * injected. They are only reachable in development/internal builds; in
+ * production builds deep links targeting them are rejected.
+ */
+const DEBUG_ROUTES = new Set([
+  '/deep-link-debug',
+  '/notification-debug',
+  '/qa-smoke-checklist',
+  '/offline-queue-inspector',
+]);
 
 export interface DeepLinkRoute {
   pathname: string;
@@ -92,6 +105,23 @@ export function resolveDeepLink(raw: string): DeepLinkResolution {
   const trimmed = raw.trim();
   if (!trimmed) {
     return { ignored: true };
+  }
+
+  // Reject deep links targeting debug routes in production builds. Debug
+  // routes are not registered there, so they must never be routable.
+  if (!IS_DEBUG_BUILD) {
+    try {
+      const url = new URL(trimmed);
+      const segments = url.pathname.replace(/^\/+/, '').split('/').filter(Boolean);
+      const firstSegment = segments[0] ? `/${segments[0]}` : '';
+      // The scheme form (quickex://deep-link-debug) puts the route in the host.
+      const hostSegment = url.hostname ? `/${url.hostname}` : '';
+      if (DEBUG_ROUTES.has(firstSegment) || DEBUG_ROUTES.has(hostSegment)) {
+        return { error: 'Unsupported or expired QuickEx link.' };
+      }
+    } catch {
+      // fall through to normal resolution
+    }
   }
 
   const paymentResult = parsePaymentLink(trimmed);


### PR DESCRIPTION
## Summary
Implemented changes for issue #849. The agent reached its turn budget after producing this draft; repository CI must validate the result.

## Changed files
- `app/mobile/__tests__/debug-routes.test.ts`
- `app/mobile/app/_layout.tsx`
- `app/mobile/app/settings.tsx`
- `app/mobile/src/config/build.ts`
- `app/mobile/utils/deep-link-routing.ts`

## Test plan
Run all repository CI checks and review the changed behavior.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #849
