### PR TITLE
feat(contract): add canonical smoke scenario export (SC-W7-10) #674

### DIFF
--- a/app/backend/src/contracts/contracts.module.ts
+++ b/app/backend/src/contracts/contracts.module.ts
@@ -18,6 +18,8 @@ import { DeploymentArtifactsController } from './deployment-artifacts.controller
 import { DeploymentArtifactsService } from './deployment-artifacts.service';
 import { ContractSpecController } from './contract-spec.controller';
 import { ContractSpecService } from './contract-spec.service';
+import { SmokeScenariosController } from './smoke-scenarios/smoke-scenarios.controller';
+import { SmokeScenariosService } from './smoke-scenarios/smoke-scenarios.service';
 
 @Module({
   imports: [ApiKeysModule, AuditModule, SupabaseModule],
@@ -28,6 +30,7 @@ import { ContractSpecService } from './contract-spec.service';
     ContractAllowlistController,
     DeploymentArtifactsController,
     ContractSpecController, // Add new controller
+    SmokeScenariosController,
   ],
   providers: [
     ContractRegistryService,
@@ -39,6 +42,7 @@ import { ContractSpecService } from './contract-spec.service';
     ContractMethodAllowlistGuard,
     DeploymentArtifactsService,
     ContractSpecService, // Add new service
+    SmokeScenariosService,
   ],
   exports: [
     ContractRegistryService,
@@ -46,6 +50,7 @@ import { ContractSpecService } from './contract-spec.service';
     ContractAllowlistService,
     ContractMethodAllowlistGuard,
     ContractSpecService, // Export new service
+    SmokeScenariosService,
   ],
 })
 export class ContractsModule {}

--- a/app/backend/src/contracts/smoke-scenarios/dto/smoke-scenarios.dto.ts
+++ b/app/backend/src/contracts/smoke-scenarios/dto/smoke-scenarios.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsObject } from 'class-validator';
+
+import { SmokeScenariosArtifact } from '../smoke-scenarios.types';
+
+export class ConsumeSmokeScenariosDto {
+  @ApiProperty({
+    type: Object,
+    description: 'Raw smoke-scenarios artifact JSON (quickex-smoke-scenarios-v1)',
+  })
+  @IsObject()
+  artifact!: Record<string, unknown>;
+}
+
+export class SmokeScenariosValidationResultDto {
+  @ApiProperty({ description: 'Whether the artifact is valid' })
+  valid!: boolean;
+
+  @ApiProperty({ type: [String], description: 'Field-level validation errors' })
+  errors!: string[];
+
+  @ApiPropertyOptional({
+    type: Object,
+    description: 'Normalized artifact returned when valid',
+  })
+  artifact?: SmokeScenariosArtifact;
+}

--- a/app/backend/src/contracts/smoke-scenarios/smoke-scenarios.controller.ts
+++ b/app/backend/src/contracts/smoke-scenarios/smoke-scenarios.controller.ts
@@ -1,0 +1,40 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { RequireScopes } from '../../auth/decorators/require-scopes.decorator';
+import { ApiKeyGuard } from '../../auth/guards/api-key.guard';
+import {
+  ConsumeSmokeScenariosDto,
+  SmokeScenariosValidationResultDto,
+} from './dto/smoke-scenarios.dto';
+import { SmokeScenariosService } from './smoke-scenarios.service';
+
+@ApiTags('contracts')
+@ApiHeader({
+  name: 'X-API-Key',
+  description: 'Admin-scoped API key required to validate smoke-scenarios artifacts.',
+  required: true,
+})
+@UseGuards(ApiKeyGuard)
+@Controller('contracts/smoke-scenarios')
+export class SmokeScenariosController {
+  constructor(private readonly smokeScenarios: SmokeScenariosService) {}
+
+  @Post('validate')
+  @HttpCode(HttpStatus.OK)
+  @RequireScopes('admin')
+  @ApiOperation({
+    summary: 'Validate a contract smoke-scenarios artifact',
+    description:
+      'Consumes the canonical quickex-smoke-scenarios-v1 artifact and verifies it ' +
+      'conforms to the schema. Returns field-level errors when invalid and the ' +
+      'normalized artifact when valid.',
+  })
+  @ApiResponse({ status: 200, type: SmokeScenariosValidationResultDto })
+  @ApiResponse({ status: 400, description: 'Artifact does not conform to the schema' })
+  validate(
+    @Body() dto: ConsumeSmokeScenariosDto,
+  ): SmokeScenariosValidationResultDto {
+    return this.smokeScenarios.validate(dto.artifact);
+  }
+}

--- a/app/backend/src/contracts/smoke-scenarios/smoke-scenarios.service.ts
+++ b/app/backend/src/contracts/smoke-scenarios/smoke-scenarios.service.ts
@@ -1,0 +1,154 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+import {
+  SMOKE_SCENARIO_CATEGORIES,
+  SMOKE_SCENARIO_OUTCOMES,
+  SMOKE_SCENARIOS_CONTRACT,
+  SMOKE_SCENARIOS_KIND,
+  SmokeScenario,
+  SmokeScenariosArtifact,
+  SmokeScenariosValidationResult,
+} from './smoke-scenarios.types';
+
+const SCENARIO_ID_PATTERN = /^SMOKE-\d{3}$/;
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
+/**
+ * Consumes the canonical contract smoke-scenarios artifact
+ * (`app/contract/contracts/quickex/smoke-scenarios.json`) so backend deploy
+ * tooling can validate contract behavior against the same expected outcomes
+ * that the contract test suite enforces, without custom translation.
+ */
+@Injectable()
+export class SmokeScenariosService {
+  /**
+   * Parse and strictly validate a raw smoke-scenarios artifact payload.
+   * Throws `BadRequestException` with field-level errors when the payload does
+   * not conform to the canonical schema.
+   */
+  consumeArtifact(raw: unknown): SmokeScenariosArtifact {
+    const validation = this.validate(raw);
+    if (!validation.valid || !validation.artifact) {
+      throw new BadRequestException({
+        code: 'INVALID_SMOKE_SCENARIOS_ARTIFACT',
+        message: validation.errors.join('; '),
+        fields: validation.errors,
+      });
+    }
+    return validation.artifact;
+  }
+
+  /**
+   * Validate a raw smoke-scenarios artifact payload without throwing.
+   * Returns the normalized artifact when valid.
+   */
+  validate(raw: unknown): SmokeScenariosValidationResult {
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+      return { valid: false, errors: ['artifact must be a JSON object'] };
+    }
+
+    const obj = raw as Record<string, unknown>;
+    const errors: string[] = [];
+
+    if (obj.kind !== SMOKE_SCENARIOS_KIND) {
+      errors.push(`kind must be "${SMOKE_SCENARIOS_KIND}"`);
+    }
+    if (typeof obj.version !== 'string' || !SEMVER_PATTERN.test(obj.version)) {
+      errors.push('version must be a semver string (e.g. "1.0.0")');
+    }
+    if (obj.contract !== SMOKE_SCENARIOS_CONTRACT) {
+      errors.push(`contract must be "${SMOKE_SCENARIOS_CONTRACT}"`);
+    }
+    if (!Array.isArray(obj.scenarios) || obj.scenarios.length === 0) {
+      errors.push('scenarios must be a non-empty array');
+    } else {
+      const seenIds = new Set<string>();
+      obj.scenarios.forEach((entry, index) => {
+        if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+          errors.push(`scenarios[${index}] must be an object`);
+          return;
+        }
+        this.validateScenario(entry as Record<string, unknown>, index, seenIds, errors);
+      });
+    }
+
+    const valid = errors.length === 0;
+    return valid
+      ? { valid, errors, artifact: this.toArtifact(obj) }
+      : { valid, errors };
+  }
+
+  private validateScenario(
+    s: Record<string, unknown>,
+    index: number,
+    seenIds: Set<string>,
+    errors: string[],
+  ): void {
+    const where = `scenarios[${index}]`;
+
+    if (typeof s.id !== 'string' || !SCENARIO_ID_PATTERN.test(s.id)) {
+      errors.push(`${where}.id must match SMOKE-NNN`);
+    } else if (seenIds.has(s.id)) {
+      errors.push(`${where}.id duplicates scenario id ${s.id}`);
+    } else {
+      seenIds.add(s.id);
+    }
+
+    if (typeof s.name !== 'string' || s.name.length === 0) {
+      errors.push(`${where}.name is required`);
+    }
+    if (typeof s.entry_point !== 'string' || s.entry_point.length === 0) {
+      errors.push(`${where}.entry_point is required`);
+    }
+    if (
+      typeof s.category !== 'string' ||
+      !(SMOKE_SCENARIO_CATEGORIES as readonly string[]).includes(s.category)
+    ) {
+      errors.push(`${where}.category must be one of ${SMOKE_SCENARIO_CATEGORIES.join(', ')}`);
+    }
+    if (
+      typeof s.expected_outcome !== 'string' ||
+      !(SMOKE_SCENARIO_OUTCOMES as readonly string[]).includes(s.expected_outcome)
+    ) {
+      errors.push(`${where}.expected_outcome must be one of ${SMOKE_SCENARIO_OUTCOMES.join(', ')}`);
+    }
+    if (typeof s.inputs !== 'object' || s.inputs === null || Array.isArray(s.inputs)) {
+      errors.push(`${where}.inputs must be an object`);
+    }
+
+    if (s.expected_outcome === 'rejection') {
+      const err = s.expected_error;
+      if (err === null || typeof err !== 'object' || Array.isArray(err)) {
+        errors.push(`${where}.expected_error is required for rejection scenarios`);
+        return;
+      }
+      const e = err as Record<string, unknown>;
+      if (typeof e.name !== 'string' || e.name.length === 0) {
+        errors.push(`${where}.expected_error.name is required`);
+      }
+      if (typeof e.code !== 'number' || !Number.isInteger(e.code) || e.code < 100) {
+        errors.push(`${where}.expected_error.code must be an integer >= 100`);
+      }
+    }
+  }
+
+  private toArtifact(obj: Record<string, unknown>): SmokeScenariosArtifact {
+    return {
+      kind: String(obj.kind),
+      version: String(obj.version),
+      contract: String(obj.contract),
+      ...(obj.description !== undefined ? { description: String(obj.description) } : {}),
+      scenarios: (obj.scenarios as Record<string, unknown>[]).map((s) => ({
+        id: String(s.id),
+        name: String(s.name),
+        ...(s.description !== undefined ? { description: String(s.description) } : {}),
+        category: s.category as SmokeScenario['category'],
+        entry_point: String(s.entry_point),
+        inputs: s.inputs as Record<string, unknown>,
+        ...(s.expected_result !== undefined ? { expected_result: s.expected_result } : {}),
+        expected_outcome: s.expected_outcome as SmokeScenario['expected_outcome'],
+        expected_error: (s.expected_error as SmokeScenario['expected_error']),
+      })),
+    };
+  }
+}

--- a/app/backend/src/contracts/smoke-scenarios/smoke-scenarios.service.unit.spec.ts
+++ b/app/backend/src/contracts/smoke-scenarios/smoke-scenarios.service.unit.spec.ts
@@ -1,0 +1,129 @@
+import { BadRequestException } from '@nestjs/common';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { SmokeScenariosService } from './smoke-scenarios.service';
+import { SmokeScenariosArtifact } from './smoke-scenarios.types';
+
+/**
+ * Canonical artifact path relative to the backend source root:
+ * app/contract/contracts/quickex/smoke-scenarios.json
+ */
+const ARTIFACT_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  'app',
+  'contract',
+  'contracts',
+  'quickex',
+  'smoke-scenarios.json',
+);
+
+describe('SmokeScenariosService (SC-W7-10)', () => {
+  let service: SmokeScenariosService;
+  let realArtifact: SmokeScenariosArtifact;
+
+  beforeAll(() => {
+    service = new SmokeScenariosService();
+    realArtifact = JSON.parse(
+      readFileSync(ARTIFACT_PATH, 'utf-8'),
+    ) as SmokeScenariosArtifact;
+  });
+
+  describe('consumeArtifact', () => {
+    it('consumes the exported contract artifact without custom translation', () => {
+      const result = service.consumeArtifact(realArtifact);
+      expect(result.kind).toBe('quickex-smoke-scenarios-v1');
+      expect(result.contract).toBe('quickex');
+      expect(result.scenarios.length).toBeGreaterThan(0);
+      for (const scenario of result.scenarios) {
+        expect(scenario.id).toMatch(/^SMOKE-\d{3}$/);
+        expect(['success', 'rejection']).toContain(scenario.expected_outcome);
+      }
+    });
+
+    it('throws BadRequestException for an invalid artifact', () => {
+      const broken = { ...realArtifact, kind: 'something-else' };
+      expect(() => service.consumeArtifact(broken)).toThrow(BadRequestException);
+    });
+  });
+
+  describe('validate', () => {
+    it('accepts the canonical artifact', () => {
+      const result = service.validate(realArtifact);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+      expect(result.artifact).toBeDefined();
+      expect(result.artifact?.scenarios).toHaveLength(realArtifact.scenarios.length);
+    });
+
+    it('rejects a non-object payload', () => {
+      for (const payload of [null, 'nope', 42, []]) {
+        const result = service.validate(payload);
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain('artifact must be a JSON object');
+      }
+    });
+
+    it('rejects an unknown kind', () => {
+      const result = service.validate({ ...realArtifact, kind: 'quickex-contract-spec-v1' });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('kind must be "quickex-smoke-scenarios-v1"');
+    });
+
+    it('rejects a mismatched contract name', () => {
+      const result = service.validate({ ...realArtifact, contract: 'not-quickex' });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('contract must be "quickex"');
+    });
+
+    it('rejects a malformed version', () => {
+      const result = service.validate({ ...realArtifact, version: '1.0' });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('version must be a semver'))).toBe(true);
+    });
+
+    it('rejects an empty scenarios list', () => {
+      const result = service.validate({ ...realArtifact, scenarios: [] });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('scenarios must be a non-empty array');
+    });
+
+    it('rejects duplicate scenario ids', () => {
+      const scenarios = [...realArtifact.scenarios];
+      scenarios.push({ ...scenarios[0] });
+      const result = service.validate({ ...realArtifact, scenarios });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('duplicates scenario id'))).toBe(true);
+    });
+
+    it('rejects an invalid expected_outcome', () => {
+      const scenarios = realArtifact.scenarios.map((s) => ({
+        ...s,
+        expected_outcome: 'maybe',
+      }));
+      const result = service.validate({ ...realArtifact, scenarios });
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.includes('expected_outcome must be one of')),
+      ).toBe(true);
+    });
+
+    it('rejects a rejection scenario without an expected_error', () => {
+      const scenarios = realArtifact.scenarios.map((s) => ({
+        ...s,
+        expected_outcome: 'rejection',
+        expected_error: null,
+      }));
+      const result = service.validate({ ...realArtifact, scenarios });
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.includes('expected_error is required')),
+      ).toBe(true);
+    });
+  });
+});

--- a/app/backend/src/contracts/smoke-scenarios/smoke-scenarios.types.ts
+++ b/app/backend/src/contracts/smoke-scenarios/smoke-scenarios.types.ts
@@ -1,0 +1,47 @@
+export const SMOKE_SCENARIOS_KIND = 'quickex-smoke-scenarios-v1';
+export const SMOKE_SCENARIOS_CONTRACT = 'quickex';
+
+export const SMOKE_SCENARIO_OUTCOMES = ['success', 'rejection'] as const;
+export type SmokeScenarioOutcome = (typeof SMOKE_SCENARIO_OUTCOMES)[number];
+
+export const SMOKE_SCENARIO_CATEGORIES = [
+  'readiness',
+  'metadata',
+  'admin',
+  'commitment',
+  'escrow',
+  'dispute',
+  'privacy',
+] as const;
+export type SmokeScenarioCategory = (typeof SMOKE_SCENARIO_CATEGORIES)[number];
+
+export interface SmokeScenarioError {
+  name: string;
+  code: number;
+}
+
+export interface SmokeScenario {
+  id: string;
+  name: string;
+  description?: string;
+  category: SmokeScenarioCategory;
+  entry_point: string;
+  inputs: Record<string, unknown>;
+  expected_outcome: SmokeScenarioOutcome;
+  expected_result?: unknown;
+  expected_error: SmokeScenarioError | null;
+}
+
+export interface SmokeScenariosArtifact {
+  kind: string;
+  version: string;
+  contract: string;
+  description?: string;
+  scenarios: SmokeScenario[];
+}
+
+export interface SmokeScenariosValidationResult {
+  valid: boolean;
+  errors: string[];
+  artifact?: SmokeScenariosArtifact;
+}

--- a/app/contract/Cargo.lock
+++ b/app/contract/Cargo.lock
@@ -988,6 +988,8 @@ name = "quickex"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "serde",
+ "serde_json",
  "soroban-sdk",
 ]
 

--- a/app/contract/contracts/quickex/Cargo.toml
+++ b/app/contract/contracts/quickex/Cargo.toml
@@ -17,6 +17,8 @@ soroban-sdk = "23"
 [dev-dependencies]
 soroban-sdk = { version = "23", features = ["testutils"] }
 proptest = { version = "1.5.0", default-features = false, features = ["std"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [profile.release]
 opt-level = "z"

--- a/app/contract/contracts/quickex/smoke-scenarios.json
+++ b/app/contract/contracts/quickex/smoke-scenarios.json
@@ -1,0 +1,292 @@
+{
+  "kind": "quickex-smoke-scenarios-v1",
+  "version": "1.0.0",
+  "contract": "quickex",
+  "description": "Canonical post-deploy smoke scenarios covering core QuickEx contract entry points and validation rules. Deploy tooling and contributors run these scenarios after testnet deploys to validate contract behavior consistently. The artifact is machine-readable: backend/test tooling can consume it without custom translation.",
+  "scenarios": [
+    {
+      "id": "SMOKE-001",
+      "name": "health_check",
+      "description": "Verify the contract health check view returns true.",
+      "category": "readiness",
+      "entry_point": "health_check",
+      "inputs": {},
+      "expected_outcome": "success",
+      "expected_result": true,
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-002",
+      "name": "get_deployment_metadata",
+      "description": "Verify the deployment metadata view reports the active schema and event schema versions.",
+      "category": "metadata",
+      "entry_point": "get_deployment_metadata",
+      "inputs": {},
+      "expected_outcome": "success",
+      "expected_result": {
+        "contract_version": 1,
+        "event_schema_version": 2
+      },
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-003",
+      "name": "initialize_already_initialized",
+      "description": "Rejection path: initializing an already initialized contract fails with AlreadyInitialized.",
+      "category": "admin",
+      "entry_point": "initialize",
+      "inputs": {
+        "admin": "CONTRACT_ADMIN_ADDRESS"
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "AlreadyInitialized",
+        "code": 201
+      }
+    },
+    {
+      "id": "SMOKE-004",
+      "name": "create_amount_commitment_success",
+      "description": "Compute the deterministic KECCAK256 commitment hash for a valid owner, amount, and salt.",
+      "category": "commitment",
+      "entry_point": "create_amount_commitment",
+      "inputs": {
+        "owner": "ALICE_ADDRESS",
+        "amount": 1000,
+        "salt": "smoke_salt_001"
+      },
+      "expected_outcome": "success",
+      "expected_result": "32_BYTE_HASH",
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-005",
+      "name": "create_amount_commitment_negative_amount",
+      "description": "Rejection path: creating a commitment with a negative amount fails with InvalidAmount.",
+      "category": "commitment",
+      "entry_point": "create_amount_commitment",
+      "inputs": {
+        "owner": "ALICE_ADDRESS",
+        "amount": -500,
+        "salt": "smoke_salt_001"
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "InvalidAmount",
+        "code": 100
+      }
+    },
+    {
+      "id": "SMOKE-006",
+      "name": "deposit_success",
+      "description": "Deposit funds into escrow and create a pending commitment entry.",
+      "category": "escrow",
+      "entry_point": "deposit",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 1000,
+        "owner": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_1",
+        "timeout_secs": 0,
+        "arbiter": null,
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "success",
+      "expected_result": "32_BYTE_COMMITMENT_HASH",
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-007",
+      "name": "deposit_zero_amount",
+      "description": "Rejection path: depositing a zero amount fails with InvalidAmount.",
+      "category": "escrow",
+      "entry_point": "deposit",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 0,
+        "owner": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_zero",
+        "timeout_secs": 0,
+        "arbiter": null,
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "InvalidAmount",
+        "code": 100
+      }
+    },
+    {
+      "id": "SMOKE-008",
+      "name": "deposit_duplicate_commitment",
+      "description": "Rejection path: depositing with an existing pending commitment fails with CommitmentAlreadyExists.",
+      "category": "escrow",
+      "entry_point": "deposit",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 1000,
+        "owner": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_1",
+        "timeout_secs": 0,
+        "arbiter": null,
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "CommitmentAlreadyExists",
+        "code": 303
+      }
+    },
+    {
+      "id": "SMOKE-009",
+      "name": "withdraw_success",
+      "description": "Withdraw a pending escrow by providing the matching owner, amount, and salt.",
+      "category": "escrow",
+      "entry_point": "withdraw",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 1000,
+        "commitment": "PENDING_COMMITMENT_HASH",
+        "to": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_1",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "success",
+      "expected_result": true,
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-010",
+      "name": "withdraw_already_spent",
+      "description": "Rejection path: withdrawing from an already spent escrow fails with AlreadySpent.",
+      "category": "escrow",
+      "entry_point": "withdraw",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 1000,
+        "commitment": "SPENT_COMMITMENT_HASH",
+        "to": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_1",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "AlreadySpent",
+        "code": 304
+      }
+    },
+    {
+      "id": "SMOKE-011",
+      "name": "refund_before_expiry",
+      "description": "Rejection path: refunding a pending escrow before its timeout expires fails with EscrowNotExpired.",
+      "category": "escrow",
+      "entry_point": "refund",
+      "inputs": {
+        "commitment": "UNEXPIRED_COMMITMENT_HASH",
+        "caller": "ALICE_ADDRESS",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "EscrowNotExpired",
+        "code": 308
+      }
+    },
+    {
+      "id": "SMOKE-012",
+      "name": "refund_after_expiry",
+      "description": "Refund an expired escrow back to the original depositor once the timeout has elapsed.",
+      "category": "escrow",
+      "entry_point": "refund",
+      "inputs": {
+        "commitment": "EXPIRED_COMMITMENT_HASH",
+        "caller": "ALICE_ADDRESS",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "success",
+      "expected_result": null,
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-013",
+      "name": "dispute_without_arbiter",
+      "description": "Rejection path: disputing an escrow without an assigned arbiter fails with NoArbiter.",
+      "category": "dispute",
+      "entry_point": "dispute",
+      "inputs": {
+        "commitment": "NO_ARBITER_COMMITMENT_HASH"
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "NoArbiter",
+        "code": 310
+      }
+    },
+    {
+      "id": "SMOKE-014",
+      "name": "resolve_dispute_by_non_arbiter",
+      "description": "Rejection path: a non-arbiter attempting to resolve a dispute fails with NotArbiter.",
+      "category": "dispute",
+      "entry_point": "resolve_dispute",
+      "inputs": {
+        "caller": "NON_ARBITER_ADDRESS",
+        "commitment": "DISPUTED_COMMITMENT_HASH",
+        "resolve_for_owner": true,
+        "recipient": "BOB_ADDRESS",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "NotArbiter",
+        "code": 312
+      }
+    },
+    {
+      "id": "SMOKE-015",
+      "name": "set_privacy_success",
+      "description": "Enable privacy for an account successfully.",
+      "category": "privacy",
+      "entry_point": "set_privacy",
+      "inputs": {
+        "owner": "ALICE_ADDRESS",
+        "enabled": true
+      },
+      "expected_outcome": "success",
+      "expected_result": null,
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-016",
+      "name": "set_privacy_already_set",
+      "description": "Rejection path: setting privacy when already at the target value fails with PrivacyAlreadySet.",
+      "category": "privacy",
+      "entry_point": "set_privacy",
+      "inputs": {
+        "owner": "ALICE_ADDRESS",
+        "enabled": true
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "PrivacyAlreadySet",
+        "code": 301
+      }
+    }
+  ]
+}

--- a/app/contract/contracts/quickex/smoke-scenarios.schema.json
+++ b/app/contract/contracts/quickex/smoke-scenarios.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://quickex.to/schemas/smoke-scenarios-v1.json",
+  "title": "QuickEx Contract Smoke Scenarios",
+  "description": "Canonical smoke scenarios for the QuickEx Soroban contract. Every contract release ships this artifact so that backend deploy tooling, CI, and contributors all validate contract behavior against the same expected outcomes.",
+  "type": "object",
+  "required": ["kind", "version", "contract", "description", "scenarios"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "description": "Artifact type discriminator. Bump the suffix when the shape changes.",
+      "pattern": "^quickex-smoke-scenarios-v[0-9]+$",
+      "examples": ["quickex-smoke-scenarios-v1"]
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version of this artifact.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "examples": ["1.0.0"]
+    },
+    "contract": {
+      "type": "string",
+      "description": "Canonical contract name matching the Cargo package name.",
+      "pattern": "^[a-z0-9_-]+$",
+      "examples": ["quickex"]
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable summary of the artifact's purpose."
+    },
+    "scenarios": {
+      "type": "array",
+      "description": "Ordered list of canonical smoke scenarios. IDs are stable and unique.",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "category",
+          "entry_point",
+          "inputs",
+          "expected_outcome",
+          "expected_error"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable, unique scenario identifier.",
+            "pattern": "^SMOKE-[0-9]{3}$",
+            "examples": ["SMOKE-001"]
+          },
+          "name": {
+            "type": "string",
+            "description": "Short snake_case scenario name.",
+            "pattern": "^[a-z0-9_]+$",
+            "examples": ["deposit_success"]
+          },
+          "description": {
+            "type": "string",
+            "description": "What the scenario verifies and what outcome is expected."
+          },
+          "category": {
+            "type": "string",
+            "description": "Functional area the scenario exercises.",
+            "enum": [
+              "readiness",
+              "metadata",
+              "admin",
+              "commitment",
+              "escrow",
+              "dispute",
+              "privacy"
+            ],
+            "examples": ["escrow"]
+          },
+          "entry_point": {
+            "type": "string",
+            "description": "Contract method the scenario invokes.",
+            "examples": ["deposit"]
+          },
+          "inputs": {
+            "type": "object",
+            "description": "Sample inputs for the scenario. Symbolic placeholders (e.g. ALICE_ADDRESS, TOKEN_ADDRESS) are resolved by the runner.",
+            "additionalProperties": true
+          },
+          "expected_outcome": {
+            "type": "string",
+            "description": "Whether the invocation is expected to succeed or be rejected.",
+            "enum": ["success", "rejection"],
+            "examples": ["success"]
+          },
+          "expected_result": {
+            "description": "Expected return value when expected_outcome is 'success'. Null when the call returns nothing or the scenario is a rejection.",
+            "type": ["object", "string", "boolean", "integer", "null"]
+          },
+          "expected_error": {
+            "type": ["object", "null"],
+            "description": "Expected contract error when expected_outcome is 'rejection'. Null otherwise.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "QuickexError variant name.",
+                "examples": ["InvalidAmount"]
+              },
+              "code": {
+                "type": "integer",
+                "description": "Canonical error code (see errors.rs).",
+                "minimum": 100
+              }
+            },
+            "required": ["name", "code"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/contract/contracts/quickex/src/lib.rs
+++ b/app/contract/contracts/quickex/src/lib.rs
@@ -41,6 +41,8 @@ mod pause_policy_test;
 mod privacy;
 #[cfg(test)]
 mod role_test;
+#[cfg(test)]
+mod smoke_test;
 mod stealth;
 #[cfg(test)]
 mod stealth_test;

--- a/app/contract/contracts/quickex/src/smoke_test.rs
+++ b/app/contract/contracts/quickex/src/smoke_test.rs
@@ -1,0 +1,468 @@
+//! Canonical smoke-scenario test suite for the QuickEx contract.
+//!
+//! Every scenario declared in `smoke-scenarios.json` is validated twice:
+//!
+//! 1. **Artifact validity** — the exported JSON is structurally sound:
+//!    unique `SMOKE-NNN` ids, known contract entry points, and error codes
+//!    that actually exist on-chain. If the artifact drifts from the contract
+//!    (e.g. a scenario references an unknown method or an error code that was
+//!    renumbered), these tests fail.
+//! 2. **Behavior alignment** — each scenario's declared `expected_outcome` /
+//!    `expected_error` is exercised against the deployed contract so contract
+//!    behavior provably matches the exported artifact.
+//!
+//! Consumers (backend deploy tooling, CI, contributors) can therefore trust
+//! that `smoke-scenarios.json` describes exactly what the contract does.
+
+extern crate std;
+
+use std::{collections::HashSet, string::String, vec::Vec};
+
+use serde::Deserialize;
+
+use crate::{
+    assert_helpers::{
+        assert_escrow_pending, assert_escrow_refunded, assert_escrow_spent, assert_qx_err,
+    },
+    errors::QuickexError,
+    events::EVENT_SCHEMA_VERSION,
+    storage::CURRENT_CONTRACT_VERSION,
+    test_context::TestContext,
+};
+
+/// Raw exported JSON artifact included at compile time.
+const SMOKE_SCENARIOS_JSON: &str = include_str!("../smoke-scenarios.json");
+
+// ---------------------------------------------------------------------------
+// Artifact model (subset of fields the tests consume)
+// ---------------------------------------------------------------------------
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct ScenarioError {
+    name: String,
+    code: u32,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct Scenario {
+    id: String,
+    name: String,
+    #[serde(default)]
+    description: String,
+    category: String,
+    entry_point: String,
+    expected_outcome: String,
+    expected_error: Option<ScenarioError>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct ScenariosArtifact {
+    kind: String,
+    version: String,
+    contract: String,
+    scenarios: Vec<Scenario>,
+}
+
+fn artifact() -> ScenariosArtifact {
+    serde_json::from_str(SMOKE_SCENARIOS_JSON)
+        .expect("smoke-scenarios.json must parse as valid JSON matching the schema")
+}
+
+fn scenario<'a>(artifact: &'a ScenariosArtifact, id: &str) -> &'a Scenario {
+    artifact
+        .scenarios
+        .iter()
+        .find(|s| s.id == id)
+        .unwrap_or_else(|| panic!("smoke-scenarios.json is missing scenario {id}"))
+}
+
+/// Assert that a scenario is declared as a rejection with the given error.
+fn assert_rejection(scenario: &Scenario, error_name: &str, code: u32) {
+    assert_eq!(
+        scenario.expected_outcome, "rejection",
+        "scenario {} must be declared as a rejection",
+        scenario.id
+    );
+    let err = scenario
+        .expected_error
+        .as_ref()
+        .unwrap_or_else(|| panic!("scenario {} must declare expected_error", scenario.id));
+    assert_eq!(
+        err.name, error_name,
+        "scenario {} declares wrong error name",
+        scenario.id
+    );
+    assert_eq!(
+        err.code, code,
+        "scenario {} declares wrong error code",
+        scenario.id
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Artifact validity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn artifact_is_well_formed() {
+    let artifact = artifact();
+    assert_eq!(artifact.kind, "quickex-smoke-scenarios-v1");
+    assert_eq!(artifact.version, "1.0.0");
+    assert_eq!(artifact.contract, "quickex");
+    assert!(
+        !artifact.scenarios.is_empty(),
+        "artifact must declare at least one scenario"
+    );
+}
+
+#[test]
+fn artifact_scenario_ids_are_unique_and_well_formed() {
+    let artifact = artifact();
+    let mut seen = HashSet::new();
+    for s in &artifact.scenarios {
+        assert!(
+            s.id.len() == 9
+                && s.id.starts_with("SMOKE-")
+                && s.id[6..].chars().all(|c| c.is_ascii_digit()),
+            "scenario id {} must match SMOKE-NNN",
+            s.id
+        );
+        assert!(seen.insert(s.id.clone()), "duplicate scenario id {}", s.id);
+        assert!(!s.name.is_empty(), "scenario {} missing name", s.id);
+        assert!(
+            !s.entry_point.is_empty(),
+            "scenario {} missing entry_point",
+            s.id
+        );
+        assert!(
+            s.expected_outcome == "success" || s.expected_outcome == "rejection",
+            "scenario {} has invalid expected_outcome '{}'",
+            s.id,
+            s.expected_outcome
+        );
+        if s.expected_outcome == "rejection" {
+            assert!(
+                s.expected_error.is_some(),
+                "rejection scenario {} must declare expected_error",
+                s.id
+            );
+        }
+    }
+}
+
+#[test]
+fn artifact_entry_points_are_known_contract_methods() {
+    const KNOWN_ENTRY_POINTS: &[&str] = &[
+        "health_check",
+        "get_deployment_metadata",
+        "initialize",
+        "create_amount_commitment",
+        "verify_amount_commitment",
+        "deposit",
+        "withdraw",
+        "refund",
+        "dispute",
+        "resolve_dispute",
+        "set_privacy",
+        "get_privacy",
+    ];
+    let artifact = artifact();
+    for s in &artifact.scenarios {
+        assert!(
+            KNOWN_ENTRY_POINTS.contains(&s.entry_point.as_str()),
+            "scenario {} references unknown entry point '{}'",
+            s.id,
+            s.entry_point
+        );
+    }
+}
+
+#[test]
+fn artifact_error_codes_match_contract_errors() {
+    const KNOWN_ERRORS: &[(QuickexError, &str)] = &[
+        (QuickexError::InvalidAmount, "InvalidAmount"),
+        (QuickexError::AlreadyInitialized, "AlreadyInitialized"),
+        (QuickexError::PrivacyAlreadySet, "PrivacyAlreadySet"),
+        (
+            QuickexError::CommitmentAlreadyExists,
+            "CommitmentAlreadyExists",
+        ),
+        (QuickexError::AlreadySpent, "AlreadySpent"),
+        (QuickexError::EscrowNotExpired, "EscrowNotExpired"),
+        (QuickexError::NoArbiter, "NoArbiter"),
+        (QuickexError::NotArbiter, "NotArbiter"),
+    ];
+    let artifact = artifact();
+    for s in &artifact.scenarios {
+        if let Some(err) = &s.expected_error {
+            let matched = KNOWN_ERRORS
+                .iter()
+                .any(|(variant, name)| *name == err.name && *variant as u32 == err.code);
+            assert!(
+                matched,
+                "scenario {} references unknown error ({}: {})",
+                s.id, err.name, err.code
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Behavior alignment (SMOKE-001 .. SMOKE-016)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn smoke_001_health_check() {
+    let artifact = artifact();
+    let s = scenario(&artifact, "SMOKE-001");
+    assert_eq!(s.expected_outcome, "success");
+    let ctx = TestContext::new();
+    assert!(
+        ctx.client.health_check(),
+        "SMOKE-001: health_check must return true"
+    );
+}
+
+#[test]
+fn smoke_002_get_deployment_metadata() {
+    let artifact = artifact();
+    let s = scenario(&artifact, "SMOKE-002");
+    assert_eq!(s.expected_outcome, "success");
+    let ctx = TestContext::with_admin();
+    let meta = ctx.client.get_deployment_metadata();
+    assert_eq!(meta.contract_version, CURRENT_CONTRACT_VERSION);
+    assert_eq!(meta.event_schema_version, EVENT_SCHEMA_VERSION);
+}
+
+#[test]
+fn smoke_003_initialize_already_initialized() {
+    let artifact = artifact();
+    let s = scenario(&artifact, "SMOKE-003");
+    assert_rejection(s, "AlreadyInitialized", 201);
+    let ctx = TestContext::with_admin();
+    assert_qx_err(
+        ctx.client.try_initialize(&ctx.admin),
+        QuickexError::AlreadyInitialized,
+    );
+}
+
+#[test]
+fn smoke_004_create_amount_commitment_success() {
+    let artifact = artifact();
+    let s = scenario(&artifact, "SMOKE-004");
+    assert_eq!(s.expected_outcome, "success");
+    let ctx = TestContext::new();
+    let salt = ctx.salt(b"smoke_salt_001");
+    let commitment = ctx
+        .client
+        .create_amount_commitment(&ctx.alice, &1000, &salt);
+    assert!(
+        ctx.client
+            .verify_amount_commitment(&commitment, &ctx.alice, &1000, &salt),
+        "SMOKE-004: created commitment must verify"
+    );
+}
+
+#[test]
+fn smoke_005_create_amount_commitment_negative_amount() {
+    let artifact = artifact();
+    let s = scenario(&artifact, "SMOKE-005");
+    assert_rejection(s, "InvalidAmount", 100);
+    let ctx = TestContext::new();
+    let salt = ctx.salt(b"smoke_salt_001");
+    assert_qx_err(
+        ctx.client
+            .try_create_amount_commitment(&ctx.alice, &-500, &salt),
+        QuickexError::InvalidAmount,
+    );
+}
+
+#[test]
+fn smoke_006_008_deposit_lifecycle() {
+    let artifact = artifact();
+    let s006 = scenario(&artifact, "SMOKE-006");
+    let s007 = scenario(&artifact, "SMOKE-007");
+    let s008 = scenario(&artifact, "SMOKE-008");
+    assert_eq!(s006.expected_outcome, "success");
+    assert_rejection(s007, "InvalidAmount", 100);
+    assert_rejection(s008, "CommitmentAlreadyExists", 303);
+
+    let ctx = TestContext::with_fees(0);
+
+    // SMOKE-007: a zero-amount deposit must be rejected.
+    assert_qx_err(
+        ctx.client.try_deposit(
+            &ctx.token,
+            &0,
+            &ctx.alice,
+            &ctx.salt(b"smoke_salt_deposit_zero"),
+            &0,
+            &None,
+            &TestContext::TEST_DEPOSIT_NONCE,
+            &TestContext::TEST_DEPOSIT_VALID_UNTIL,
+        ),
+        QuickexError::InvalidAmount,
+    );
+
+    // SMOKE-006: a valid deposit creates a pending escrow.
+    let commitment = ctx.simple_deposit(&ctx.alice, 1000, b"smoke_salt_deposit_1");
+    assert_escrow_pending(&ctx.client, &commitment);
+
+    // SMOKE-008: re-depositing the same commitment (different escrow id and
+    // nonce so the replay-protection registry is bypassed) is rejected.
+    assert_qx_err(
+        ctx.client.try_deposit(
+            &ctx.token,
+            &1000,
+            &ctx.alice,
+            &ctx.salt(b"smoke_salt_deposit_1"),
+            &3600,
+            &None,
+            &1u64,
+            &TestContext::TEST_DEPOSIT_VALID_UNTIL,
+        ),
+        QuickexError::CommitmentAlreadyExists,
+    );
+}
+
+#[test]
+fn smoke_009_010_withdraw_lifecycle() {
+    let artifact = artifact();
+    let s009 = scenario(&artifact, "SMOKE-009");
+    let s010 = scenario(&artifact, "SMOKE-010");
+    assert_eq!(s009.expected_outcome, "success");
+    assert_rejection(s010, "AlreadySpent", 304);
+
+    let ctx = TestContext::with_fees(0);
+    let salt = b"smoke_salt_deposit_1";
+    let commitment = ctx.simple_deposit(&ctx.alice, 1000, salt);
+
+    // SMOKE-009: the depositor withdraws the escrow successfully.
+    let ok = ctx.client.withdraw(
+        &ctx.token,
+        &1000,
+        &commitment,
+        &ctx.alice,
+        &ctx.salt(salt),
+        &TestContext::TEST_DEPOSIT_NONCE,
+        &TestContext::TEST_DEPOSIT_VALID_UNTIL,
+    );
+    assert!(ok, "SMOKE-009: withdraw must return true");
+    assert_escrow_spent(&ctx.client, &commitment);
+
+    // SMOKE-010: withdrawing a spent escrow is rejected (with a fresh nonce
+    // so the replay-protection registry is bypassed).
+    assert_qx_err(
+        ctx.client.try_withdraw(
+            &ctx.token,
+            &1000,
+            &commitment,
+            &ctx.alice,
+            &ctx.salt(salt),
+            &1u64,
+            &TestContext::TEST_DEPOSIT_VALID_UNTIL,
+        ),
+        QuickexError::AlreadySpent,
+    );
+}
+
+#[test]
+fn smoke_011_012_refund_lifecycle() {
+    let artifact = artifact();
+    let s011 = scenario(&artifact, "SMOKE-011");
+    let s012 = scenario(&artifact, "SMOKE-012");
+    assert_rejection(s011, "EscrowNotExpired", 308);
+    assert_eq!(s012.expected_outcome, "success");
+
+    let ctx = TestContext::with_fees(0);
+    let commitment = ctx.deposit_with_arbiter(&ctx.alice, 1000, b"smoke_salt_refund_1", 3600);
+
+    // SMOKE-011: refund before the timeout elapses is rejected.
+    assert_qx_err(
+        ctx.client.try_refund(
+            &commitment,
+            &ctx.alice,
+            &TestContext::TEST_DEPOSIT_NONCE,
+            &TestContext::TEST_DEPOSIT_VALID_UNTIL,
+        ),
+        QuickexError::EscrowNotExpired,
+    );
+
+    // SMOKE-012: after the timeout the owner can refund.
+    ctx.advance_time(3601);
+    ctx.client.refund(
+        &commitment,
+        &ctx.alice,
+        &TestContext::TEST_DEPOSIT_NONCE,
+        &TestContext::TEST_DEPOSIT_VALID_UNTIL,
+    );
+    assert_escrow_refunded(&ctx.client, &commitment);
+}
+
+#[test]
+fn smoke_013_014_dispute_lifecycle() {
+    let artifact = artifact();
+    let s013 = scenario(&artifact, "SMOKE-013");
+    let s014 = scenario(&artifact, "SMOKE-014");
+    assert_rejection(s013, "NoArbiter", 310);
+    assert_rejection(s014, "NotArbiter", 312);
+
+    let ctx = TestContext::with_fees(0);
+
+    // SMOKE-013: an escrow without an arbiter cannot be disputed.
+    let no_arbiter = ctx.simple_deposit(&ctx.alice, 1000, b"smoke_salt_no_arbiter");
+    assert_qx_err(ctx.client.try_dispute(&no_arbiter), QuickexError::NoArbiter);
+
+    // SMOKE-014: a non-arbiter cannot resolve a disputed escrow. Mint and
+    // deposit manually with a fresh nonce (nonce 0 was consumed above).
+    ctx.mint(&ctx.alice, 1000);
+    let disputed = ctx.client.deposit(
+        &ctx.token,
+        &1000,
+        &ctx.alice,
+        &ctx.salt(b"smoke_salt_with_arbiter"),
+        &3600,
+        &Some(ctx.arbiter.clone()),
+        &1u64,
+        &TestContext::TEST_DEPOSIT_VALID_UNTIL,
+    );
+    ctx.client.dispute(&disputed);
+    assert_qx_err(
+        ctx.client.try_resolve_dispute(
+            &ctx.alice,
+            &disputed,
+            &true,
+            &ctx.bob,
+            &TestContext::TEST_DEPOSIT_NONCE,
+            &TestContext::TEST_DEPOSIT_VALID_UNTIL,
+        ),
+        QuickexError::NotArbiter,
+    );
+}
+
+#[test]
+fn smoke_015_016_privacy_lifecycle() {
+    let artifact = artifact();
+    let s015 = scenario(&artifact, "SMOKE-015");
+    let s016 = scenario(&artifact, "SMOKE-016");
+    assert_eq!(s015.expected_outcome, "success");
+    assert_rejection(s016, "PrivacyAlreadySet", 301);
+
+    let ctx = TestContext::with_admin();
+
+    // SMOKE-015: enabling privacy succeeds and is observable.
+    ctx.client.set_privacy(&ctx.alice, &true);
+    assert!(
+        ctx.client.get_privacy(&ctx.alice),
+        "SMOKE-015: privacy must be enabled"
+    );
+
+    // SMOKE-016: setting privacy to the same value is rejected.
+    assert_qx_err(
+        ctx.client.try_set_privacy(&ctx.alice, &true),
+        QuickexError::PrivacyAlreadySet,
+    );
+}

--- a/app/contract/docs/smoke-scenarios/smoke-scenarios.json
+++ b/app/contract/docs/smoke-scenarios/smoke-scenarios.json
@@ -1,0 +1,292 @@
+{
+  "kind": "quickex-smoke-scenarios-v1",
+  "version": "1.0.0",
+  "contract": "quickex",
+  "description": "Canonical post-deploy smoke scenarios covering core QuickEx contract entry points and validation rules. Deploy tooling and contributors run these scenarios after testnet deploys to validate contract behavior consistently. The artifact is machine-readable: backend/test tooling can consume it without custom translation.",
+  "scenarios": [
+    {
+      "id": "SMOKE-001",
+      "name": "health_check",
+      "description": "Verify the contract health check view returns true.",
+      "category": "readiness",
+      "entry_point": "health_check",
+      "inputs": {},
+      "expected_outcome": "success",
+      "expected_result": true,
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-002",
+      "name": "get_deployment_metadata",
+      "description": "Verify the deployment metadata view reports the active schema and event schema versions.",
+      "category": "metadata",
+      "entry_point": "get_deployment_metadata",
+      "inputs": {},
+      "expected_outcome": "success",
+      "expected_result": {
+        "contract_version": 1,
+        "event_schema_version": 2
+      },
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-003",
+      "name": "initialize_already_initialized",
+      "description": "Rejection path: initializing an already initialized contract fails with AlreadyInitialized.",
+      "category": "admin",
+      "entry_point": "initialize",
+      "inputs": {
+        "admin": "CONTRACT_ADMIN_ADDRESS"
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "AlreadyInitialized",
+        "code": 201
+      }
+    },
+    {
+      "id": "SMOKE-004",
+      "name": "create_amount_commitment_success",
+      "description": "Compute the deterministic KECCAK256 commitment hash for a valid owner, amount, and salt.",
+      "category": "commitment",
+      "entry_point": "create_amount_commitment",
+      "inputs": {
+        "owner": "ALICE_ADDRESS",
+        "amount": 1000,
+        "salt": "smoke_salt_001"
+      },
+      "expected_outcome": "success",
+      "expected_result": "32_BYTE_HASH",
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-005",
+      "name": "create_amount_commitment_negative_amount",
+      "description": "Rejection path: creating a commitment with a negative amount fails with InvalidAmount.",
+      "category": "commitment",
+      "entry_point": "create_amount_commitment",
+      "inputs": {
+        "owner": "ALICE_ADDRESS",
+        "amount": -500,
+        "salt": "smoke_salt_001"
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "InvalidAmount",
+        "code": 100
+      }
+    },
+    {
+      "id": "SMOKE-006",
+      "name": "deposit_success",
+      "description": "Deposit funds into escrow and create a pending commitment entry.",
+      "category": "escrow",
+      "entry_point": "deposit",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 1000,
+        "owner": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_1",
+        "timeout_secs": 0,
+        "arbiter": null,
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "success",
+      "expected_result": "32_BYTE_COMMITMENT_HASH",
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-007",
+      "name": "deposit_zero_amount",
+      "description": "Rejection path: depositing a zero amount fails with InvalidAmount.",
+      "category": "escrow",
+      "entry_point": "deposit",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 0,
+        "owner": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_zero",
+        "timeout_secs": 0,
+        "arbiter": null,
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "InvalidAmount",
+        "code": 100
+      }
+    },
+    {
+      "id": "SMOKE-008",
+      "name": "deposit_duplicate_commitment",
+      "description": "Rejection path: depositing with an existing pending commitment fails with CommitmentAlreadyExists.",
+      "category": "escrow",
+      "entry_point": "deposit",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 1000,
+        "owner": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_1",
+        "timeout_secs": 0,
+        "arbiter": null,
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "CommitmentAlreadyExists",
+        "code": 303
+      }
+    },
+    {
+      "id": "SMOKE-009",
+      "name": "withdraw_success",
+      "description": "Withdraw a pending escrow by providing the matching owner, amount, and salt.",
+      "category": "escrow",
+      "entry_point": "withdraw",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 1000,
+        "commitment": "PENDING_COMMITMENT_HASH",
+        "to": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_1",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "success",
+      "expected_result": true,
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-010",
+      "name": "withdraw_already_spent",
+      "description": "Rejection path: withdrawing from an already spent escrow fails with AlreadySpent.",
+      "category": "escrow",
+      "entry_point": "withdraw",
+      "inputs": {
+        "token": "TOKEN_ADDRESS",
+        "amount": 1000,
+        "commitment": "SPENT_COMMITMENT_HASH",
+        "to": "ALICE_ADDRESS",
+        "salt": "smoke_salt_deposit_1",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "AlreadySpent",
+        "code": 304
+      }
+    },
+    {
+      "id": "SMOKE-011",
+      "name": "refund_before_expiry",
+      "description": "Rejection path: refunding a pending escrow before its timeout expires fails with EscrowNotExpired.",
+      "category": "escrow",
+      "entry_point": "refund",
+      "inputs": {
+        "commitment": "UNEXPIRED_COMMITMENT_HASH",
+        "caller": "ALICE_ADDRESS",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "EscrowNotExpired",
+        "code": 308
+      }
+    },
+    {
+      "id": "SMOKE-012",
+      "name": "refund_after_expiry",
+      "description": "Refund an expired escrow back to the original depositor once the timeout has elapsed.",
+      "category": "escrow",
+      "entry_point": "refund",
+      "inputs": {
+        "commitment": "EXPIRED_COMMITMENT_HASH",
+        "caller": "ALICE_ADDRESS",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "success",
+      "expected_result": null,
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-013",
+      "name": "dispute_without_arbiter",
+      "description": "Rejection path: disputing an escrow without an assigned arbiter fails with NoArbiter.",
+      "category": "dispute",
+      "entry_point": "dispute",
+      "inputs": {
+        "commitment": "NO_ARBITER_COMMITMENT_HASH"
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "NoArbiter",
+        "code": 310
+      }
+    },
+    {
+      "id": "SMOKE-014",
+      "name": "resolve_dispute_by_non_arbiter",
+      "description": "Rejection path: a non-arbiter attempting to resolve a dispute fails with NotArbiter.",
+      "category": "dispute",
+      "entry_point": "resolve_dispute",
+      "inputs": {
+        "caller": "NON_ARBITER_ADDRESS",
+        "commitment": "DISPUTED_COMMITMENT_HASH",
+        "resolve_for_owner": true,
+        "recipient": "BOB_ADDRESS",
+        "nonce": 0,
+        "valid_until": 18446744073709551615
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "NotArbiter",
+        "code": 312
+      }
+    },
+    {
+      "id": "SMOKE-015",
+      "name": "set_privacy_success",
+      "description": "Enable privacy for an account successfully.",
+      "category": "privacy",
+      "entry_point": "set_privacy",
+      "inputs": {
+        "owner": "ALICE_ADDRESS",
+        "enabled": true
+      },
+      "expected_outcome": "success",
+      "expected_result": null,
+      "expected_error": null
+    },
+    {
+      "id": "SMOKE-016",
+      "name": "set_privacy_already_set",
+      "description": "Rejection path: setting privacy when already at the target value fails with PrivacyAlreadySet.",
+      "category": "privacy",
+      "entry_point": "set_privacy",
+      "inputs": {
+        "owner": "ALICE_ADDRESS",
+        "enabled": true
+      },
+      "expected_outcome": "rejection",
+      "expected_result": null,
+      "expected_error": {
+        "name": "PrivacyAlreadySet",
+        "code": 301
+      }
+    }
+  ]
+}

--- a/app/contract/scripts/export-smoke-scenarios.sh
+++ b/app/contract/scripts/export-smoke-scenarios.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Exports the QuickEx contract's canonical smoke scenarios as a machine-readable
+# JSON artifact, so backend deploy tooling, CI, and contributors all validate
+# contract behavior against the same expected outcomes.
+#
+# The canonical source of truth is `contracts/quickex/smoke-scenarios.json`.
+# This script validates that file and publishes a copy to docs/smoke-scenarios/.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_PATH="$ROOT_DIR/contracts/quickex/smoke-scenarios.json"
+SCHEMA_PATH="$ROOT_DIR/contracts/quickex/smoke-scenarios.schema.json"
+OUT_PATH="${OUT_PATH:-$ROOT_DIR/docs/smoke-scenarios/smoke-scenarios.json}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing required command: $1" >&2; exit 1; }; }
+need python3
+
+if [[ ! -f "$SOURCE_PATH" ]]; then
+  echo "smoke scenarios artifact not found at $SOURCE_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SCHEMA_PATH" ]]; then
+  echo "smoke scenarios schema not found at $SCHEMA_PATH" >&2
+  exit 1
+fi
+
+echo "==> Validating $SOURCE_PATH"
+python3 - "$SOURCE_PATH" <<'PY'
+import json, sys
+
+path = sys.argv[1]
+with open(path) as f:
+    artifact = json.load(f)
+
+assert artifact["kind"] == "quickex-smoke-scenarios-v1", "artifact kind mismatch"
+assert artifact["contract"] == "quickex", "artifact must target the quickex contract"
+assert isinstance(artifact["version"], str) and artifact["version"].count(".") == 2, "invalid version"
+
+scenarios = artifact["scenarios"]
+assert isinstance(scenarios, list) and scenarios, "artifact must declare at least one scenario"
+
+seen_ids = set()
+for s in scenarios:
+    sid = s["id"]
+    assert len(sid) == 9 and sid.startswith("SMOKE-") and sid[6:].isdigit(), f"invalid id {sid}"
+    assert sid not in seen_ids, f"duplicate scenario id {sid}"
+    seen_ids.add(sid)
+    assert s["name"], f"{sid} missing name"
+    assert s["entry_point"], f"{sid} missing entry_point"
+    assert s["expected_outcome"] in ("success", "rejection"), f"{sid} invalid expected_outcome"
+    if s["expected_outcome"] == "rejection":
+        assert s["expected_error"] and s["expected_error"]["name"], f"{sid} missing expected_error"
+
+print(f"validated {len(scenarios)} scenarios")
+PY
+
+echo "==> Publishing to $OUT_PATH"
+mkdir -p "$(dirname "$OUT_PATH")"
+cp "$SOURCE_PATH" "$OUT_PATH"
+
+echo "Smoke scenarios exported to $OUT_PATH"


### PR DESCRIPTION
## Overview

This PR implements the **Contract Smoke Scenario Export** (SC-W7-10). It defines a canonical smoke scenario list with expected outcomes for the QuickEx Soroban contract, exports the scenario metadata as a machine-readable `smoke-scenarios.json` artifact, adds tests that keep scenario outputs aligned with contract behavior, and provides backend tooling that can consume and validate the exported artifact.

## Related Issue

Closes #674

## Changes

### 🧪 Canonical Smoke Scenarios

* **[ADD]** `app/contract/contracts/quickex/smoke-scenarios.json`
  * 16 canonical post-deploy smoke scenarios with expected outcomes (`success` / `rejection`), entry points, inputs, and expected error codes.
* **[ADD]** `app/contract/contracts/quickex/smoke-scenarios.schema.json`
  * JSON Schema that makes the artifact structurally validatable by any tooling.

### 🔒 Contract Alignment Tests

* **[ADD]** `app/contract/contracts/quickex/src/smoke_test.rs`
  * Validates the artifact is well-formed, scenario IDs are unique, entry points map to real contract methods, and error codes match `QuickexError`.
  * Executes each scenario against the contract to prevent drift between the artifact and actual contract behavior.

### 📤 Export Automation

* **[ADD]** `app/contract/scripts/export-smoke-scenarios.sh`
  * Validates and publishes the artifact to `app/contract/docs/smoke-scenarios/`.

### 🛠 Backend Tooling

* **[ADD]** `app/backend/src/contracts/smoke-scenarios/`
  * `SmokeScenariosService` + `SmokeScenariosController` exposing `POST /contracts/smoke-scenarios/validate` (admin-only) to consume and validate the exported artifact.
* **[MODIFY]** `app/backend/src/contracts/contracts.module.ts` — registers the new controller/service.

## Verification Results

```
cd app/contract/contracts/quickex && cargo test smoke_
✅ 14/14 passed

cargo test
✅ 398 passed

cargo clippy --all-targets --all-features -- -D warnings
✅ clean

cargo fmt --all -- --check
✅ clean

Backend: jest unit suite, eslint, tsc --noEmit, nest build
✅ all green
```

| Acceptance Criteria | Status |
| --- | --- |
| Canonical smoke scenario list with expected outcomes | ✅ 16 scenarios with success/rejection outcomes and expected error codes |
| Scenario metadata exported as a machine-readable artifact | ✅ `smoke-scenarios.json` + JSON Schema |
| Tests keep scenario outputs aligned with contract behavior | ✅ `smoke_test.rs` validates the artifact and executes each scenario |
| Backend tooling can consume the exported artifact | ✅ `SmokeScenariosService` + `POST /contracts/smoke-scenarios/validate` |
