### PR TITLE
feat(backend): sync GitHub branch/PR deployment metadata (BE-60) #544

### DIFF
--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -61,6 +61,7 @@ import { RuntimeConfigModule } from "./runtime-config/runtime-config.module";
 import { TransactionTimelineModule } from "./transaction-timeline/transaction-timeline.module";
 import { DashboardFeedModule } from "./dashboard-feed/dashboard-feed.module";
 import { OutboxModule } from "./events/outbox/outbox.module";
+import { DeploymentSyncModule } from "./deployment-sync/deployment-sync.module";
 
 type AppImport =
 | Type<unknown>
@@ -114,6 +115,7 @@ OperationsModule,
     TransactionTimelineModule,
     DashboardFeedModule,
     OutboxModule,
+    DeploymentSyncModule,
     ];
 
     try {

--- a/app/backend/src/config/app-config.service.ts
+++ b/app/backend/src/config/app-config.service.ts
@@ -200,6 +200,14 @@ export class AppConfigService {
   }
 
   /**
+   * GitHub webhook secret (optional). When unset, the deployment webhook
+   * endpoint is unavailable and returns 503.
+   */
+  get githubWebhookSecret(): string | undefined {
+    return this.configService.get("GITHUB_WEBHOOK_SECRET", { infer: true });
+  }
+
+  /**
    * Max usernames per wallet (optional). When not set, returns undefined (no limit).
    */
   get maxUsernamesPerWallet(): number | undefined {

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -180,6 +180,14 @@ export const envSchema = Joi.object({
     .default("https://app.quickex.io")
     .description("Fallback frontend URL for unknown branches"),
 
+  // GitHub branch/PR deployment metadata sync (BE-60)
+  GITHUB_WEBHOOK_SECRET: Joi.string()
+    .empty("")
+    .optional()
+    .description(
+      "Secret used to verify GitHub webhook signatures (X-Hub-Signature-256). When unset, the deployment webhook endpoint returns 503.",
+    ),
+
   FEATURE_FLAGS_BOOTSTRAP_JSON: Joi.string()
     .empty("")
     .optional()
@@ -490,6 +498,7 @@ export interface EnvConfig {
   CORS_ALLOWED_ORIGINS?: string;
   CORS_VERCEL_PROJECT?: string;
   MAX_USERNAMES_PER_WALLET?: number;
+  GITHUB_WEBHOOK_SECRET?: string;
   CACHE_MAX_ITEMS: number;
   CACHE_TTL_MS: number;
   FEATURE_FLAGS_CACHE_TTL_MS: number;

--- a/app/backend/src/deployment-sync/__tests__/deployment-sync.controller.unit.spec.ts
+++ b/app/backend/src/deployment-sync/__tests__/deployment-sync.controller.unit.spec.ts
@@ -1,0 +1,218 @@
+import { createHmac } from 'crypto';
+import {
+  BadRequestException,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { RawBodyRequest, Request } from 'express';
+
+import { AppConfigService } from '../../config/app-config.service';
+import { BranchDeploymentService } from '../deployment-sync.service';
+import { BranchDeploymentController } from '../deployment-sync.controller';
+import { BranchDeployment } from '../deployment-sync.model';
+import { SyncBranchDeploymentDto } from '../dto/sync-branch-deployment.dto';
+
+const SECRET = 'test-webhook-secret';
+const COMMIT_SHA = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+function sign(payload: unknown): { rawBody: Buffer; signature: string } {
+  const rawBody = Buffer.from(JSON.stringify(payload));
+  const signature = `sha256=${createHmac('sha256', SECRET).update(rawBody).digest('hex')}`;
+  return { rawBody, signature };
+}
+
+function makeRequest(rawBody: Buffer, parsedBody: unknown): RawBodyRequest<Request> {
+  return {
+    rawBody,
+    body: parsedBody,
+    headers: {},
+  } as unknown as RawBodyRequest<Request>;
+}
+
+function makeDeployment(overrides: Partial<BranchDeployment> = {}): BranchDeployment {
+  return {
+    id: 'deploy-1',
+    branchName: 'feat/be-branch-metadata-sync',
+    prNumber: 544,
+    commitSha: COMMIT_SHA,
+    previewUrl: 'https://preview-544.quickex.to',
+    status: 'deployed',
+    environment: 'preview',
+    deliveredAt: new Date('2026-08-25T10:00:00.000Z'),
+    createdAt: new Date('2026-08-25T10:00:00.000Z'),
+    updatedAt: new Date('2026-08-25T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('BranchDeploymentController (BE-60)', () => {
+  let controller: BranchDeploymentController;
+  let service: {
+    syncDeployment: jest.Mock;
+    getDeploymentByBranch: jest.Mock;
+    getDeploymentsByPr: jest.Mock;
+  };
+  let config: { githubWebhookSecret: string | undefined };
+
+  beforeEach(() => {
+    service = {
+      syncDeployment: jest.fn().mockResolvedValue(makeDeployment()),
+      getDeploymentByBranch: jest.fn().mockResolvedValue(makeDeployment()),
+      getDeploymentsByPr: jest.fn().mockResolvedValue([makeDeployment()]),
+    };
+    config = { githubWebhookSecret: SECRET };
+
+    controller = new BranchDeploymentController(
+      service as unknown as BranchDeploymentService,
+      config as unknown as AppConfigService,
+    );
+  });
+
+  describe('webhook (POST /deployments/webhook)', () => {
+    const normalizedPayload = {
+      branchName: 'feat/be-branch-metadata-sync',
+      prNumber: 544,
+      commitSha: COMMIT_SHA,
+      previewUrl: 'https://preview-544.quickex.to',
+      status: 'deployed',
+      environment: 'preview',
+      deliveredAt: '2026-08-25T10:00:00.000Z',
+    };
+
+    it('ingests a normalized payload with a valid signature', async () => {
+      const { rawBody, signature } = sign(normalizedPayload);
+      const req = makeRequest(rawBody, normalizedPayload);
+
+      const result = await controller.webhook(req, signature);
+
+      expect(service.syncDeployment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          branchName: 'feat/be-branch-metadata-sync',
+          prNumber: 544,
+          commitSha: COMMIT_SHA,
+        }),
+        'github-webhook',
+      );
+      expect(result).toMatchObject({ branchName: 'feat/be-branch-metadata-sync', status: 'deployed' });
+    });
+
+    it('rejects requests when the webhook secret is not configured', async () => {
+      config.githubWebhookSecret = undefined;
+      const { rawBody, signature } = sign(normalizedPayload);
+
+      await expect(controller.webhook(makeRequest(rawBody, normalizedPayload), signature)).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('rejects requests with an invalid signature', async () => {
+      const { rawBody } = sign(normalizedPayload);
+      const bogusSignature = `sha256=${'0'.repeat(64)}`;
+
+      await expect(
+        controller.webhook(makeRequest(rawBody, normalizedPayload), bogusSignature),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('rejects requests with a missing signature', async () => {
+      const { rawBody } = sign(normalizedPayload);
+
+      await expect(
+        controller.webhook(makeRequest(rawBody, normalizedPayload), undefined),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('accepts a native GitHub deployment_status event', async () => {
+      const githubEvent = {
+        deployment: {
+          id: 42,
+          sha: COMMIT_SHA,
+          ref: 'feat/be-branch-metadata-sync',
+          environment: 'preview',
+          created_at: '2026-08-25T10:00:00Z',
+        },
+        deployment_status: {
+          id: 99,
+          state: 'success',
+          environment: 'preview',
+          environment_url: 'https://preview-544.quickex.to',
+          created_at: '2026-08-25T10:05:00Z',
+        },
+        pull_request: { number: 544 },
+        repository: { full_name: 'Pulsefy/QiuckEx' },
+      };
+      const { rawBody, signature } = sign(githubEvent);
+
+      await controller.webhook(makeRequest(rawBody, githubEvent), signature);
+
+      expect(service.syncDeployment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          branchName: 'feat/be-branch-metadata-sync',
+          prNumber: 544,
+          commitSha: COMMIT_SHA,
+          previewUrl: 'https://preview-544.quickex.to',
+          status: 'deployed',
+        }),
+        'github-webhook',
+      );
+    });
+
+    it('rejects a payload that is neither normalized nor a valid GitHub event', async () => {
+      const bogus = { hello: 'world' };
+      const { rawBody, signature } = sign(bogus);
+
+      await expect(
+        controller.webhook(makeRequest(rawBody, bogus), signature),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('sync (POST /admin/deployments/sync)', () => {
+    it('forwards the admin payload and uses the API key as the audit actor', async () => {
+      const dto = new SyncBranchDeploymentDto();
+      dto.branchName = 'feat/be-branch-metadata-sync';
+      dto.commitSha = COMMIT_SHA;
+      dto.previewUrl = 'https://preview-544.quickex.to';
+      dto.status = 'deployed';
+
+      const req = { apiKey: { id: 'key-abc' } } as unknown as Request;
+
+      await controller.sync(dto, req);
+
+      expect(service.syncDeployment).toHaveBeenCalledWith(
+        expect.objectContaining({ branchName: 'feat/be-branch-metadata-sync' }),
+        'key-abc',
+      );
+    });
+  });
+
+  describe('getByBranch (GET /admin/deployments/branch/:branchName)', () => {
+    it('returns the latest deployment for a branch', async () => {
+      const result = await controller.getByBranch('feat/be-branch-metadata-sync', undefined);
+
+      expect(service.getDeploymentByBranch).toHaveBeenCalledWith(
+        'feat/be-branch-metadata-sync',
+        undefined,
+      );
+      expect(result.commitSha).toBe(COMMIT_SHA);
+    });
+
+    it('parses an optional ?pr= query parameter', async () => {
+      await controller.getByBranch('feat/be-branch-metadata-sync', '544');
+      expect(service.getDeploymentByBranch).toHaveBeenCalledWith(
+        'feat/be-branch-metadata-sync',
+        544,
+      );
+    });
+  });
+
+  describe('getByPr (GET /admin/deployments/pr/:prNumber)', () => {
+    it('returns deployment history for a PR', async () => {
+      const result = await controller.getByPr(544, undefined);
+
+      expect(service.getDeploymentsByPr).toHaveBeenCalledWith(544, 20);
+      expect(result).toHaveLength(1);
+      expect(result[0].prNumber).toBe(544);
+    });
+  });
+});

--- a/app/backend/src/deployment-sync/__tests__/deployment-sync.service.unit.spec.ts
+++ b/app/backend/src/deployment-sync/__tests__/deployment-sync.service.unit.spec.ts
@@ -1,0 +1,196 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+
+import { AuditService } from '../../audit/audit.service';
+import { BranchDeploymentRepository } from '../deployment-sync.repository';
+import {
+  BranchDeployment,
+  SyncBranchDeploymentInput,
+} from '../deployment-sync.model';
+import { BranchDeploymentService } from '../deployment-sync.service';
+import { SyncBranchDeploymentDto } from '../dto/sync-branch-deployment.dto';
+
+const COMMIT_SHA = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+function makeDeployment(overrides: Partial<BranchDeployment> = {}): BranchDeployment {
+  return {
+    id: 'deploy-1',
+    branchName: 'feat/be-branch-metadata-sync',
+    prNumber: 544,
+    commitSha: COMMIT_SHA,
+    previewUrl: 'https://preview-544.quickex.to',
+    status: 'deployed',
+    environment: 'preview',
+    deliveredAt: new Date('2026-08-25T10:00:00.000Z'),
+    createdAt: new Date('2026-08-25T10:00:00.000Z'),
+    updatedAt: new Date('2026-08-25T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function makeDto(overrides: Partial<SyncBranchDeploymentDto> = {}): SyncBranchDeploymentDto {
+  const dto = new SyncBranchDeploymentDto();
+  dto.branchName = 'feat/be-branch-metadata-sync';
+  dto.prNumber = 544;
+  dto.commitSha = COMMIT_SHA;
+  dto.previewUrl = 'https://preview-544.quickex.to';
+  dto.status = 'deployed';
+  dto.environment = 'preview';
+  dto.deliveredAt = '2026-08-25T10:00:00.000Z';
+  return Object.assign(dto, overrides) as SyncBranchDeploymentDto;
+}
+
+describe('BranchDeploymentService (BE-60)', () => {
+  let service: BranchDeploymentService;
+  let repository: {
+    findLatestForBranch: jest.Mock;
+    findByBranchAndCommit: jest.Mock;
+    upsert: jest.Mock;
+    findByPrNumber: jest.Mock;
+  };
+  let auditService: { log: jest.Mock };
+
+  beforeEach(() => {
+    repository = {
+      findLatestForBranch: jest.fn().mockResolvedValue(null),
+      findByBranchAndCommit: jest.fn().mockResolvedValue(null),
+      upsert: jest.fn().mockImplementation((input: SyncBranchDeploymentInput) =>
+        Promise.resolve(makeDeployment({ deliveredAt: input.deliveredAt })),
+      ),
+      findByPrNumber: jest.fn().mockResolvedValue([]),
+    };
+    auditService = { log: jest.fn().mockResolvedValue(undefined) };
+
+    service = new BranchDeploymentService(
+      repository as unknown as BranchDeploymentRepository,
+      auditService as unknown as AuditService,
+    );
+  });
+
+  describe('syncDeployment', () => {
+    it('ingests a new deployment and writes an audit event', async () => {
+      const result = await service.syncDeployment(makeDto(), 'api-key-1');
+
+      expect(repository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          branchName: 'feat/be-branch-metadata-sync',
+          prNumber: 544,
+          commitSha: COMMIT_SHA,
+          status: 'deployed',
+          environment: 'preview',
+        }),
+      );
+      expect(result.id).toBe('deploy-1');
+      expect(auditService.log).toHaveBeenCalledWith(
+        'api-key-1',
+        'branch_deployment.synced',
+        'deploy-1',
+        expect.objectContaining({ commitSha: COMMIT_SHA, branchName: 'feat/be-branch-metadata-sync' }),
+      );
+    });
+
+    it('is idempotent for duplicate deliveries of the same (branch, commit)', async () => {
+      const existing = makeDeployment();
+      repository.findByBranchAndCommit.mockResolvedValue(existing);
+
+      const result = await service.syncDeployment(
+        makeDto({ deliveredAt: '2026-08-25T09:00:00.000Z' }),
+        'github-webhook',
+      );
+
+      expect(result).toBe(existing);
+      expect(repository.upsert).not.toHaveBeenCalled();
+      expect(auditService.log).not.toHaveBeenCalled();
+    });
+
+    it('rejects stale out-of-order deliveries with a ConflictException', async () => {
+      repository.findLatestForBranch.mockResolvedValue(
+        makeDeployment({ deliveredAt: new Date('2026-08-25T11:00:00.000Z') }),
+      );
+
+      await expect(
+        service.syncDeployment(makeDto({ deliveredAt: '2026-08-25T10:00:00.000Z' }), 'github-webhook'),
+      ).rejects.toBeInstanceOf(ConflictException);
+
+      expect(repository.upsert).not.toHaveBeenCalled();
+    });
+
+    it('normalizes branch names to lowercase', async () => {
+      await service.syncDeployment(
+        makeDto({ branchName: 'Feature/BE-Branch-Sync' }),
+        'api-key-1',
+      );
+
+      expect(repository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ branchName: 'feature/be-branch-sync' }),
+      );
+    });
+
+    it('defaults deliveredAt to now when omitted', async () => {
+      const before = new Date().getTime();
+      await service.syncDeployment(makeDto({ deliveredAt: undefined }), 'api-key-1');
+      const after = new Date().getTime();
+
+      const input = repository.upsert.mock.calls[0][0] as SyncBranchDeploymentInput;
+      expect(input.deliveredAt.getTime()).toBeGreaterThanOrEqual(before);
+      expect(input.deliveredAt.getTime()).toBeLessThanOrEqual(after);
+    });
+
+    it('updates a record when a newer delivery arrives for the same commit', async () => {
+      const existing = makeDeployment({ deliveredAt: new Date('2026-08-25T09:00:00.000Z') });
+      repository.findByBranchAndCommit.mockResolvedValue(existing);
+
+      await service.syncDeployment(
+        makeDto({ deliveredAt: '2026-08-25T10:00:00.000Z' }),
+        'github-webhook',
+      );
+
+      expect(repository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deliveredAt: new Date('2026-08-25T10:00:00.000Z'),
+          status: 'deployed',
+        }),
+      );
+    });
+  });
+
+  describe('getDeploymentByBranch', () => {
+    it('returns the latest deployment for a branch', async () => {
+      const deployment = makeDeployment();
+      repository.findLatestForBranch.mockResolvedValue(deployment);
+
+      const result = await service.getDeploymentByBranch('feat/be-branch-metadata-sync');
+
+      expect(result).toBe(deployment);
+      expect(repository.findLatestForBranch).toHaveBeenCalledWith(
+        'feat/be-branch-metadata-sync',
+        undefined,
+      );
+    });
+
+    it('scopes the lookup by PR number when provided', async () => {
+      repository.findLatestForBranch.mockResolvedValue(makeDeployment());
+      await service.getDeploymentByBranch('feat/be-branch-metadata-sync', 544);
+      expect(repository.findLatestForBranch).toHaveBeenCalledWith(
+        'feat/be-branch-metadata-sync',
+        544,
+      );
+    });
+
+    it('throws NotFoundException when nothing is recorded', async () => {
+      await expect(
+        service.getDeploymentByBranch('unknown-branch'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('getDeploymentsByPr', () => {
+    it('delegates to the repository with a default limit', async () => {
+      repository.findByPrNumber.mockResolvedValue([makeDeployment()]);
+
+      const result = await service.getDeploymentsByPr(544);
+
+      expect(repository.findByPrNumber).toHaveBeenCalledWith(544, 20);
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/app/backend/src/deployment-sync/__tests__/github-deployment-status.mapper.unit.spec.ts
+++ b/app/backend/src/deployment-sync/__tests__/github-deployment-status.mapper.unit.spec.ts
@@ -1,0 +1,106 @@
+import { mapGithubDeploymentStatusEvent } from '../github-deployment-status.mapper';
+
+const COMMIT_SHA = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+function githubEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    deployment: {
+      id: 42,
+      sha: COMMIT_SHA,
+      ref: 'feat/be-branch-metadata-sync',
+      environment: 'preview',
+      created_at: '2026-08-25T10:00:00Z',
+    },
+    deployment_status: {
+      id: 99,
+      state: 'success',
+      environment: 'preview',
+      environment_url: 'https://preview-544.quickex.to',
+      created_at: '2026-08-25T10:05:00Z',
+    },
+    pull_request: { number: 544 },
+    repository: { full_name: 'Pulsefy/QiuckEx' },
+    ...overrides,
+  };
+}
+
+describe('mapGithubDeploymentStatusEvent (BE-60)', () => {
+  it('maps a native GitHub deployment_status event', () => {
+    const mapped = mapGithubDeploymentStatusEvent(githubEvent());
+
+    expect(mapped).toEqual({
+      branchName: 'feat/be-branch-metadata-sync',
+      prNumber: 544,
+      commitSha: COMMIT_SHA,
+      previewUrl: 'https://preview-544.quickex.to',
+      status: 'deployed',
+      environment: 'preview',
+      deliveredAt: '2026-08-25T10:05:00Z',
+    });
+  });
+
+  it.each([
+    ['pending', 'in_progress'],
+    ['queued', 'in_progress'],
+    ['in_progress', 'in_progress'],
+    ['success', 'deployed'],
+    ['failure', 'failed'],
+    ['error', 'failed'],
+    ['inactive', 'cancelled'],
+    ['destroyed', 'cancelled'],
+  ])('maps GitHub state %s to %s', (state, expected) => {
+    const mapped = mapGithubDeploymentStatusEvent(
+      githubEvent({ deployment_status: { ...githubEvent().deployment_status, state } }),
+    );
+    expect(mapped?.status).toBe(expected);
+  });
+
+  it('strips refs/heads/ prefix from the deployment ref', () => {
+    const mapped = mapGithubDeploymentStatusEvent(
+      githubEvent({ deployment: { ...githubEvent().deployment, ref: 'refs/heads/main' } }),
+    );
+    expect(mapped?.branchName).toBe('main');
+  });
+
+  it('falls back to pull_request.head.ref when deployment.ref is absent', () => {
+    const event = githubEvent({
+      deployment: { ...githubEvent().deployment, ref: null },
+      pull_request: { number: 544, head: { ref: 'feat/head-branch' } },
+    });
+    const mapped = mapGithubDeploymentStatusEvent(event);
+    expect(mapped?.branchName).toBe('feat/head-branch');
+    expect(mapped?.prNumber).toBe(544);
+  });
+
+  it('returns null for non-object payloads', () => {
+    expect(mapGithubDeploymentStatusEvent(null)).toBeNull();
+    expect(mapGithubDeploymentStatusEvent('nope')).toBeNull();
+    expect(mapGithubDeploymentStatusEvent(42)).toBeNull();
+  });
+
+  it('returns null when deployment or deployment_status is missing', () => {
+    expect(mapGithubDeploymentStatusEvent({ deployment: {} })).toBeNull();
+    expect(mapGithubDeploymentStatusEvent({ deployment_status: {} })).toBeNull();
+    expect(mapGithubDeploymentStatusEvent({})).toBeNull();
+  });
+
+  it('returns null for unsupported deployment states', () => {
+    const event = githubEvent({ deployment_status: { ...githubEvent().deployment_status, state: 'mystery' } });
+    expect(mapGithubDeploymentStatusEvent(event)).toBeNull();
+  });
+
+  it('returns null when no branch can be derived', () => {
+    const event = githubEvent({
+      deployment: { ...githubEvent().deployment, ref: null },
+      pull_request: null,
+    });
+    expect(mapGithubDeploymentStatusEvent(event)).toBeNull();
+  });
+
+  it('returns null when environment_url is missing', () => {
+    const event = githubEvent({
+      deployment_status: { ...githubEvent().deployment_status, environment_url: null },
+    });
+    expect(mapGithubDeploymentStatusEvent(event)).toBeNull();
+  });
+});

--- a/app/backend/src/deployment-sync/__tests__/github-webhook-signature.unit.spec.ts
+++ b/app/backend/src/deployment-sync/__tests__/github-webhook-signature.unit.spec.ts
@@ -1,0 +1,38 @@
+import { createHmac } from 'crypto';
+
+import { verifyGithubSignature } from '../github-webhook-signature';
+
+describe('verifyGithubSignature (BE-60)', () => {
+  const secret = 'test-secret';
+  const body = Buffer.from('{"branch":"main","ok":true}');
+
+  function sign(): string {
+    return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+  }
+
+  it('verifies a valid sha256 HMAC signature', () => {
+    expect(verifyGithubSignature(body, sign(), secret)).toBe(true);
+  });
+
+  it('accepts a signature without the sha256= prefix', () => {
+    const bare = sign().replace('sha256=', '');
+    expect(verifyGithubSignature(body, bare, secret)).toBe(true);
+  });
+
+  it('rejects a signature produced with a different secret', () => {
+    const other = `sha256=${createHmac('sha256', 'wrong-secret').update(body).digest('hex')}`;
+    expect(verifyGithubSignature(body, other, secret)).toBe(false);
+  });
+
+  it('rejects a malformed signature', () => {
+    expect(verifyGithubSignature(body, 'sha256=not-hex', secret)).toBe(false);
+    expect(verifyGithubSignature(body, 'sha256=abcd', secret)).toBe(false);
+  });
+
+  it('rejects when raw body, signature, or secret is missing', () => {
+    expect(verifyGithubSignature(undefined, sign(), secret)).toBe(false);
+    expect(verifyGithubSignature(body, undefined, secret)).toBe(false);
+    expect(verifyGithubSignature(body, sign(), undefined)).toBe(false);
+    expect(verifyGithubSignature(Buffer.alloc(0), sign(), secret)).toBe(false);
+  });
+});

--- a/app/backend/src/deployment-sync/deployment-sync.controller.ts
+++ b/app/backend/src/deployment-sync/deployment-sync.controller.ts
@@ -1,0 +1,199 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  Req,
+  ServiceUnavailableException,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { RawBodyRequest, Request } from 'express';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { AppConfigService } from '../config/app-config.service';
+import { RequireScopes } from '../auth/decorators/require-scopes.decorator';
+import { ApiKeyGuard } from '../auth/guards/api-key.guard';
+import { RateLimitGroupTag } from '../auth/decorators/rate-limit-group.decorator';
+import { mapValidationErrors } from '../common/utils/validation-error.mapper';
+import { BranchDeploymentService } from './deployment-sync.service';
+import { SyncBranchDeploymentDto } from './dto/sync-branch-deployment.dto';
+import { BranchDeploymentResponseDto } from './dto/deployment-response.dto';
+import { BranchDeployment } from './deployment-sync.model';
+import { mapGithubDeploymentStatusEvent } from './github-deployment-status.mapper';
+import { verifyGithubSignature } from './github-webhook-signature';
+
+@ApiTags('deployments')
+@Controller()
+export class BranchDeploymentController {
+  constructor(
+    private readonly service: BranchDeploymentService,
+    private readonly configService: AppConfigService,
+  ) {}
+
+  /**
+   * Webhook ingestion for branch/PR deployment metadata (BE-60).
+   *
+   * Accepts either the normalized payload or a native GitHub
+   * `deployment_status` event. Requests are authenticated with GitHub's
+   * HMAC-SHA256 webhook signature (`X-Hub-Signature-256`).
+   */
+  @Post('deployments/webhook')
+  @RateLimitGroupTag('webhooks')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Ingest branch/PR deployment metadata (GitHub webhook)',
+    description:
+      'Verified by X-Hub-Signature-256. Accepts both the normalized deployment payload and native GitHub deployment_status events.',
+  })
+  @ApiResponse({ status: 200, type: BranchDeploymentResponseDto })
+  @ApiResponse({ status: 401, description: 'Invalid webhook signature' })
+  @ApiResponse({ status: 503, description: 'GITHUB_WEBHOOK_SECRET not configured' })
+  async webhook(
+    @Req() req: RawBodyRequest<Request>,
+    @Headers('x-hub-signature-256') signature?: string,
+  ): Promise<BranchDeploymentResponseDto> {
+    const secret = this.configService.githubWebhookSecret;
+    if (!secret) {
+      throw new ServiceUnavailableException({
+        error: 'WEBHOOK_NOT_CONFIGURED',
+        message: 'GITHUB_WEBHOOK_SECRET is not configured on this instance',
+      });
+    }
+
+    if (!verifyGithubSignature(req.rawBody, signature, secret)) {
+      throw new UnauthorizedException({
+        error: 'INVALID_WEBHOOK_SIGNATURE',
+        message: 'Invalid X-Hub-Signature-256',
+      });
+    }
+
+    const body = req.body as unknown;
+    const mapped = mapGithubDeploymentStatusEvent(body);
+    const dto = mapped
+      ? plainToInstance(SyncBranchDeploymentDto, {
+          branchName: mapped.branchName,
+          prNumber: mapped.prNumber,
+          commitSha: mapped.commitSha,
+          previewUrl: mapped.previewUrl,
+          status: mapped.status,
+          environment: mapped.environment,
+          deliveredAt: mapped.deliveredAt,
+        })
+      : await this.toValidatedDto(body);
+
+    const deployment = await this.service.syncDeployment(dto, 'github-webhook');
+    return this.toResponse(deployment);
+  }
+
+  /**
+   * Admin ingestion endpoint (BE-60). Enables polling-based ingestion:
+   * a scheduler can fetch GitHub deployment state and push it here with an
+   * admin-scoped API key.
+   */
+  @Post('admin/deployments/sync')
+  @UseGuards(ApiKeyGuard)
+  @RequireScopes('admin')
+  @RateLimitGroupTag('authenticated')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Sync branch/PR deployment metadata (admin)',
+    description:
+      'Push deployment metadata for a branch/PR. Idempotent for duplicate deliveries; stale events are rejected with 409.',
+  })
+  @ApiResponse({ status: 200, type: BranchDeploymentResponseDto })
+  @ApiResponse({ status: 409, description: 'Stale deployment event' })
+  async sync(
+    @Body() dto: SyncBranchDeploymentDto,
+    @Req() req: Request,
+  ): Promise<BranchDeploymentResponseDto> {
+    const actor = req.apiKey?.id ?? 'admin';
+    const deployment = await this.service.syncDeployment(dto, actor);
+    return this.toResponse(deployment);
+  }
+
+  @Get('admin/deployments/branch/:branchName')
+  @UseGuards(ApiKeyGuard)
+  @RequireScopes('admin')
+  @RateLimitGroupTag('authenticated')
+  @ApiOperation({
+    summary: 'Get latest deployment metadata for a branch (admin)',
+    description:
+      'Optionally scope the lookup to a pull request with ?pr=<number>.',
+  })
+  @ApiResponse({ status: 200, type: BranchDeploymentResponseDto })
+  @ApiResponse({ status: 404, description: 'No deployment metadata found' })
+  async getByBranch(
+    @Param('branchName') branchName: string,
+    @Query('pr') pr?: string,
+  ): Promise<BranchDeploymentResponseDto> {
+    const prNumber = pr !== undefined ? Number(pr) : undefined;
+    const deployment = await this.service.getDeploymentByBranch(
+      branchName,
+      Number.isFinite(prNumber) ? prNumber : undefined,
+    );
+    return this.toResponse(deployment);
+  }
+
+  @Get('admin/deployments/pr/:prNumber')
+  @UseGuards(ApiKeyGuard)
+  @RequireScopes('admin')
+  @RateLimitGroupTag('authenticated')
+  @ApiOperation({
+    summary: 'List deployment metadata for a pull request (admin)',
+    description: 'Returns deployment history for the PR, newest first.',
+  })
+  @ApiResponse({ status: 200, type: [BranchDeploymentResponseDto] })
+  async getByPr(
+    @Param('prNumber', ParseIntPipe) prNumber: number,
+    @Query('limit') limit?: string,
+  ): Promise<BranchDeploymentResponseDto[]> {
+    const parsedLimit = limit !== undefined ? Number(limit) : 20;
+    const deployments = await this.service.getDeploymentsByPr(
+      prNumber,
+      Number.isFinite(parsedLimit) ? parsedLimit : 20,
+    );
+    return deployments.map((d) => this.toResponse(d));
+  }
+
+  private async toValidatedDto(body: unknown): Promise<SyncBranchDeploymentDto> {
+    const dto = plainToInstance(SyncBranchDeploymentDto, body ?? {});
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    if (errors.length > 0) {
+      const mapped = mapValidationErrors(errors);
+      throw new BadRequestException({
+        code: 'VALIDATION_ERROR',
+        message: mapped.message,
+        fields: mapped.fields,
+      });
+    }
+    return dto;
+  }
+
+  private toResponse(d: BranchDeployment): BranchDeploymentResponseDto {
+    return {
+      id: d.id,
+      branchName: d.branchName,
+      prNumber: d.prNumber,
+      commitSha: d.commitSha,
+      previewUrl: d.previewUrl,
+      status: d.status,
+      environment: d.environment,
+      deliveredAt: d.deliveredAt.toISOString(),
+      createdAt: d.createdAt.toISOString(),
+      updatedAt: d.updatedAt.toISOString(),
+    };
+  }
+}

--- a/app/backend/src/deployment-sync/deployment-sync.model.ts
+++ b/app/backend/src/deployment-sync/deployment-sync.model.ts
@@ -1,0 +1,23 @@
+export const BRANCH_DEPLOYMENT_STATUSES = [
+  'in_progress',
+  'deployed',
+  'failed',
+  'cancelled',
+] as const;
+export type BranchDeploymentStatus = (typeof BRANCH_DEPLOYMENT_STATUSES)[number];
+
+export interface SyncBranchDeploymentInput {
+  branchName: string;
+  prNumber?: number;
+  commitSha: string;
+  previewUrl: string;
+  status: BranchDeploymentStatus;
+  environment: string;
+  deliveredAt: Date;
+}
+
+export interface BranchDeployment extends SyncBranchDeploymentInput {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/app/backend/src/deployment-sync/deployment-sync.module.ts
+++ b/app/backend/src/deployment-sync/deployment-sync.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+
+import { ApiKeysModule } from '../api-keys/api-keys.module';
+import { AuditModule } from '../audit/audit.module';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { BranchDeploymentRepository } from './deployment-sync.repository';
+import { BranchDeploymentService } from './deployment-sync.service';
+import { BranchDeploymentController } from './deployment-sync.controller';
+
+@Module({
+  imports: [ApiKeysModule, AuditModule, SupabaseModule],
+  controllers: [BranchDeploymentController],
+  providers: [BranchDeploymentRepository, BranchDeploymentService],
+  exports: [BranchDeploymentService],
+})
+export class DeploymentSyncModule {}

--- a/app/backend/src/deployment-sync/deployment-sync.repository.ts
+++ b/app/backend/src/deployment-sync/deployment-sync.repository.ts
@@ -1,0 +1,156 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SupabaseService } from '../supabase/supabase.service';
+import {
+  BranchDeployment,
+  SyncBranchDeploymentInput,
+} from './deployment-sync.model';
+
+@Injectable()
+export class BranchDeploymentRepository {
+  private readonly logger = new Logger(BranchDeploymentRepository.name);
+  private readonly TABLE_NAME = 'branch_deployments';
+
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  /**
+   * Insert or update the deployment for (branch, commit). The unique index
+   * on (branch_name, commit_sha) makes re-deliveries of the same commit an
+   * update rather than a duplicate row.
+   */
+  async upsert(input: SyncBranchDeploymentInput): Promise<BranchDeployment> {
+    const client = this.supabaseService.getClient();
+    const now = new Date().toISOString();
+
+    const { data, error } = await client
+      .from(this.TABLE_NAME)
+      .upsert(
+        {
+          branch_name: this.normalizeBranch(input.branchName),
+          pr_number: input.prNumber ?? null,
+          commit_sha: input.commitSha,
+          preview_url: input.previewUrl,
+          status: input.status,
+          environment: input.environment,
+          delivered_at: input.deliveredAt.toISOString(),
+          updated_at: now,
+        },
+        { onConflict: 'branch_name,commit_sha' },
+      )
+      .select()
+      .single();
+
+    if (error) {
+      this.logger.error(
+        `Failed to upsert branch deployment: ${error.message}`,
+        error,
+      );
+      throw new Error(`Database error: ${error.message}`);
+    }
+
+    return this.mapDbToModel(data);
+  }
+
+  /**
+   * Find the stored deployment for a specific (branch, commit) delivery.
+   */
+  async findByBranchAndCommit(
+    branchName: string,
+    commitSha: string,
+  ): Promise<BranchDeployment | null> {
+    const client = this.supabaseService.getClient();
+    const { data, error } = await client
+      .from(this.TABLE_NAME)
+      .select('*')
+      .eq('branch_name', this.normalizeBranch(branchName))
+      .eq('commit_sha', commitSha)
+      .maybeSingle();
+
+    if (error) {
+      this.logger.error(
+        `Error finding branch deployment: ${error.message}`,
+        error,
+      );
+      return null;
+    }
+
+    return data ? this.mapDbToModel(data) : null;
+  }
+
+  /**
+   * Find the most recent deployment for a branch, optionally scoped to a PR.
+   */
+  async findLatestForBranch(
+    branchName: string,
+    prNumber?: number,
+  ): Promise<BranchDeployment | null> {
+    const client = this.supabaseService.getClient();
+    let query = client
+      .from(this.TABLE_NAME)
+      .select('*')
+      .eq('branch_name', this.normalizeBranch(branchName));
+
+    if (prNumber !== undefined) {
+      query = query.eq('pr_number', prNumber);
+    }
+
+    const { data, error } = await query
+      .order('delivered_at', { ascending: false })
+      .limit(1);
+
+    if (error) {
+      this.logger.error(
+        `Error fetching latest branch deployment: ${error.message}`,
+        error,
+      );
+      return null;
+    }
+
+    return data && data.length > 0 ? this.mapDbToModel(data[0]) : null;
+  }
+
+  /**
+   * List deployments for a PR, newest first.
+   */
+  async findByPrNumber(
+    prNumber: number,
+    limit = 20,
+  ): Promise<BranchDeployment[]> {
+    const client = this.supabaseService.getClient();
+    const { data, error } = await client
+      .from(this.TABLE_NAME)
+      .select('*')
+      .eq('pr_number', prNumber)
+      .order('delivered_at', { ascending: false })
+      .limit(Math.min(limit, 100));
+
+    if (error) {
+      this.logger.error(
+        `Error fetching PR deployments: ${error.message}`,
+        error,
+      );
+      return [];
+    }
+
+    return (data ?? []).map((row) => this.mapDbToModel(row));
+  }
+
+  private normalizeBranch(branchName: string): string {
+    return branchName.toLowerCase().trim();
+  }
+
+  private mapDbToModel(dbRecord: Record<string, unknown>): BranchDeployment {
+    return {
+      id: String(dbRecord.id),
+      branchName: String(dbRecord.branch_name),
+      prNumber: dbRecord.pr_number != null ? Number(dbRecord.pr_number) : undefined,
+      commitSha: String(dbRecord.commit_sha),
+      previewUrl: String(dbRecord.preview_url),
+      status: dbRecord.status as BranchDeployment['status'],
+      environment: String(dbRecord.environment),
+      deliveredAt: new Date(String(dbRecord.delivered_at)),
+      createdAt: new Date(String(dbRecord.created_at)),
+      updatedAt: new Date(String(dbRecord.updated_at)),
+    };
+  }
+}

--- a/app/backend/src/deployment-sync/deployment-sync.service.ts
+++ b/app/backend/src/deployment-sync/deployment-sync.service.ts
@@ -1,0 +1,120 @@
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { AuditService } from '../audit/audit.service';
+import { SyncBranchDeploymentDto } from './dto/sync-branch-deployment.dto';
+import { BranchDeploymentRepository } from './deployment-sync.repository';
+import {
+  BranchDeployment,
+  SyncBranchDeploymentInput,
+} from './deployment-sync.model';
+
+@Injectable()
+export class BranchDeploymentService {
+  private readonly logger = new Logger(BranchDeploymentService.name);
+
+  constructor(
+    private readonly repository: BranchDeploymentRepository,
+    private readonly auditService: AuditService,
+  ) {}
+
+  /**
+   * Ingest a branch/PR deployment event (BE-60).
+   *
+   * Duplicate deliveries of the same (branch, commit) at or before the stored
+   * delivery time are idempotent — the existing record is returned unchanged.
+   * Deliveries older than the newest already-recorded event for the branch are
+   * rejected as stale, so out-of-order webhooks can never clobber newer state.
+   */
+  async syncDeployment(
+    dto: SyncBranchDeploymentDto,
+    actor: string,
+  ): Promise<BranchDeployment> {
+    const input = this.toInput(dto);
+
+    const latest = await this.repository.findLatestForBranch(input.branchName);
+    if (latest && latest.deliveredAt.getTime() > input.deliveredAt.getTime()) {
+      this.logger.warn(
+        `Rejected stale deployment delivery for ${input.branchName}@${input.commitSha.slice(0, 7)} ` +
+          `(event ${input.deliveredAt.toISOString()} older than recorded ${latest.deliveredAt.toISOString()})`,
+      );
+      throw new ConflictException({
+        error: 'STALE_DEPLOYMENT_EVENT',
+        message: `A newer deployment (${latest.commitSha.slice(0, 7)}) is already recorded for branch "${input.branchName}"`,
+        branchName: input.branchName,
+        recordedCommitSha: latest.commitSha,
+        recordedDeliveredAt: latest.deliveredAt.toISOString(),
+      });
+    }
+
+    const existing = await this.repository.findByBranchAndCommit(
+      input.branchName,
+      input.commitSha,
+    );
+    if (existing && existing.deliveredAt.getTime() >= input.deliveredAt.getTime()) {
+      this.logger.log(
+        `Duplicate deployment delivery for ${input.branchName}@${input.commitSha.slice(0, 7)} — returning existing record`,
+      );
+      return existing;
+    }
+
+    const saved = await this.repository.upsert(input);
+
+    await this.auditService.log(actor, 'branch_deployment.synced', saved.id, {
+      branchName: saved.branchName,
+      prNumber: saved.prNumber,
+      commitSha: saved.commitSha,
+      previewUrl: saved.previewUrl,
+      status: saved.status,
+      environment: saved.environment,
+      deliveredAt: saved.deliveredAt.toISOString(),
+    });
+
+    return saved;
+  }
+
+  /**
+   * Latest deployment metadata for a branch, optionally scoped to a PR.
+   */
+  async getDeploymentByBranch(
+    branchName: string,
+    prNumber?: number,
+  ): Promise<BranchDeployment> {
+    const found = await this.repository.findLatestForBranch(branchName, prNumber);
+    if (!found) {
+      throw new NotFoundException({
+        error: 'DEPLOYMENT_NOT_FOUND',
+        message: `No deployment metadata found for branch "${branchName}"${
+          prNumber !== undefined ? ` and PR #${prNumber}` : ''
+        }`,
+      });
+    }
+    return found;
+  }
+
+  /**
+   * Deployment history for a PR, newest first.
+   */
+  async getDeploymentsByPr(
+    prNumber: number,
+    limit = 20,
+  ): Promise<BranchDeployment[]> {
+    return this.repository.findByPrNumber(prNumber, limit);
+  }
+
+  private toInput(dto: SyncBranchDeploymentDto): SyncBranchDeploymentInput {
+    return {
+      branchName: dto.branchName.toLowerCase().trim(),
+      prNumber: dto.prNumber,
+      commitSha: dto.commitSha.toLowerCase(),
+      previewUrl: dto.previewUrl,
+      status: dto.status,
+      environment: dto.environment ?? 'preview',
+      deliveredAt: dto.deliveredAt ? new Date(dto.deliveredAt) : new Date(),
+    };
+  }
+}

--- a/app/backend/src/deployment-sync/dto/deployment-response.dto.ts
+++ b/app/backend/src/deployment-sync/dto/deployment-response.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { BranchDeployment } from '../deployment-sync.model';
+
+export class BranchDeploymentResponseDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() branchName!: string;
+  @ApiPropertyOptional() prNumber?: number;
+  @ApiProperty() commitSha!: string;
+  @ApiProperty() previewUrl!: string;
+  @ApiProperty({ enum: ['in_progress', 'deployed', 'failed', 'cancelled'] })
+  status!: BranchDeployment['status'];
+  @ApiProperty() environment!: string;
+  @ApiProperty() deliveredAt!: string;
+  @ApiProperty() createdAt!: string;
+  @ApiProperty() updatedAt!: string;
+}

--- a/app/backend/src/deployment-sync/dto/sync-branch-deployment.dto.ts
+++ b/app/backend/src/deployment-sync/dto/sync-branch-deployment.dto.ts
@@ -1,0 +1,78 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Matches,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+import { BRANCH_DEPLOYMENT_STATUSES, BranchDeploymentStatus } from '../deployment-sync.model';
+
+export class SyncBranchDeploymentDto {
+  @ApiProperty({
+    description: 'Git branch name the deployment was created for',
+    example: 'feat/be-branch-metadata-sync',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(256)
+  branchName!: string;
+
+  @ApiPropertyOptional({
+    description: 'Pull request number when the deployment belongs to a PR branch',
+    example: 544,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  prNumber?: number;
+
+  @ApiProperty({
+    description: 'Git commit SHA that was deployed',
+    example: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+  })
+  @IsString()
+  @Matches(/^[a-fA-F0-9]{7,64}$/)
+  commitSha!: string;
+
+  @ApiProperty({
+    description: 'Public preview URL for the deployment',
+    example: 'https://preview-544.quickex.to',
+  })
+  @IsUrl({ require_tld: false })
+  previewUrl!: string;
+
+  @ApiProperty({
+    description: 'Deployment status',
+    enum: BRANCH_DEPLOYMENT_STATUSES,
+    example: 'deployed',
+  })
+  @IsEnum(BRANCH_DEPLOYMENT_STATUSES)
+  status!: BranchDeploymentStatus;
+
+  @ApiPropertyOptional({
+    description: 'Deployment environment name',
+    default: 'preview',
+    example: 'preview',
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(64)
+  environment?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'ISO 8601 timestamp of the deployment event. Used to reject stale out-of-order deliveries.',
+    example: '2026-08-25T00:00:00.000Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  deliveredAt?: string;
+}

--- a/app/backend/src/deployment-sync/github-deployment-status.mapper.ts
+++ b/app/backend/src/deployment-sync/github-deployment-status.mapper.ts
@@ -1,0 +1,109 @@
+import { BranchDeploymentStatus } from './deployment-sync.model';
+
+/**
+ * Maps native GitHub `deployment_status` webhook events (BE-60) into the
+ * normalized sync DTO so the ingestion webhook accepts both our normalized
+ * payloads and GitHub's own delivery format.
+ *
+ * Returns null when the event is not a mappable `deployment_status` payload.
+ */
+
+const GITHUB_DEPLOYMENT_STATE_TO_STATUS: Record<string, BranchDeploymentStatus> = {
+  pending: 'in_progress',
+  in_progress: 'in_progress',
+  queued: 'in_progress',
+  success: 'deployed',
+  failure: 'failed',
+  error: 'failed',
+  inactive: 'cancelled',
+  destroyed: 'cancelled',
+};
+
+export interface MappedGithubDeploymentEvent {
+  branchName: string;
+  prNumber?: number;
+  commitSha: string;
+  previewUrl: string;
+  status: BranchDeploymentStatus;
+  environment: string;
+  deliveredAt?: string;
+}
+
+export function mapGithubDeploymentStatusEvent(
+  payload: unknown,
+): MappedGithubDeploymentEvent | null {
+  if (payload === null || typeof payload !== 'object') return null;
+
+  const event = payload as Record<string, unknown>;
+  const deployment = event.deployment as Record<string, unknown> | undefined;
+  const deploymentStatus = event.deployment_status as
+    | Record<string, unknown>
+    | undefined;
+
+  if (
+    !deployment ||
+    typeof deployment !== 'object' ||
+    !deploymentStatus ||
+    typeof deploymentStatus !== 'object'
+  ) {
+    return null;
+  }
+
+  const commitSha =
+    typeof deployment.sha === 'string' && deployment.sha
+      ? deployment.sha
+      : undefined;
+  const state =
+    typeof deploymentStatus.state === 'string' ? deploymentStatus.state : undefined;
+  const status = state ? GITHUB_DEPLOYMENT_STATE_TO_STATUS[state] : undefined;
+
+  if (!commitSha || !status) return null;
+
+  // Branch: prefer the deployment ref, fall back to the PR head ref.
+  let branchName =
+    typeof deployment.ref === 'string' && deployment.ref
+      ? deployment.ref.replace(/^refs\/heads\//, '')
+      : undefined;
+
+  let prNumber: number | undefined;
+  const pr = event.pull_request as Record<string, unknown> | null | undefined;
+  if (pr && typeof pr === 'object' && typeof pr.number === 'number') {
+    prNumber = pr.number;
+    if (!branchName) {
+      const head = pr.head as Record<string, unknown> | undefined;
+      if (head && typeof head === 'object' && typeof head.ref === 'string') {
+        branchName = head.ref;
+      }
+    }
+  }
+
+  if (!branchName) return null;
+
+  const previewUrl =
+    typeof deploymentStatus.environment_url === 'string' &&
+    deploymentStatus.environment_url
+      ? deploymentStatus.environment_url
+      : undefined;
+  if (!previewUrl) return null;
+
+  const deliveredAt =
+    typeof deploymentStatus.created_at === 'string'
+      ? deploymentStatus.created_at
+      : typeof deployment.created_at === 'string'
+        ? deployment.created_at
+        : undefined;
+
+  return {
+    branchName,
+    prNumber,
+    commitSha,
+    previewUrl,
+    status,
+    environment:
+      typeof deploymentStatus.environment === 'string' &&
+      deploymentStatus.environment
+        ? deploymentStatus.environment
+        : 'preview',
+    deliveredAt,
+  };
+}

--- a/app/backend/src/deployment-sync/github-webhook-signature.ts
+++ b/app/backend/src/deployment-sync/github-webhook-signature.ts
@@ -1,0 +1,30 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+/**
+ * GitHub webhook signature verification (BE-60).
+ *
+ * GitHub signs the raw request body with HMAC-SHA256 using the shared webhook
+ * secret and sends it in the `X-Hub-Signature-256` header as
+ * `sha256=<hex digest>`. Verification MUST run against the exact raw bytes of
+ * the body — re-serializing the parsed JSON would break the digest.
+ */
+export function verifyGithubSignature(
+  rawBody: Buffer | undefined,
+  signature: string | undefined,
+  secret: string | undefined,
+): boolean {
+  if (!rawBody || rawBody.length === 0 || !signature || !secret) {
+    return false;
+  }
+
+  const expected = signature.startsWith('sha256=') ? signature.slice(7) : signature;
+
+  const actual = createHmac('sha256', secret).update(rawBody).digest('hex');
+
+  try {
+    return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(actual, 'hex'));
+  } catch {
+    // Malformed expected digest (e.g. wrong length) makes timingSafeEqual throw.
+    return false;
+  }
+}

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -76,6 +76,7 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule, {
     logger: WinstonModule.createLogger(winstonConfig),
+    rawBody: true, // Required for GitHub webhook HMAC signature verification
   });
 
   const configService = app.get(AppConfigService);

--- a/app/backend/supabase/migrations/20260825000000_create_branch_deployments_table.sql
+++ b/app/backend/supabase/migrations/20260825000000_create_branch_deployments_table.sql
@@ -1,0 +1,45 @@
+-- BE-60: GitHub Branch/PR Deployment Metadata Sync
+--
+-- Stores deployment metadata (branch, PR number, commit SHA, preview URL,
+-- status) ingested from GitHub branch/PR deployment events so admin tooling
+-- can answer "what is deployed for branch X / PR Y" without scraping GitHub.
+--
+-- Idempotency: a unique index on (branch_name, commit_sha) makes duplicate
+-- webhook deliveries of the same commit a no-op update rather than a new row.
+
+CREATE TABLE IF NOT EXISTS branch_deployments (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  branch_name   TEXT        NOT NULL,
+  pr_number     INTEGER,
+  commit_sha    TEXT        NOT NULL,
+  preview_url   TEXT        NOT NULL,
+  status        TEXT        NOT NULL DEFAULT 'deployed' CHECK (
+                    status IN ('in_progress', 'deployed', 'failed', 'cancelled')
+                  ),
+  environment   TEXT        NOT NULL DEFAULT 'preview',
+
+  -- Timestamp of the deployment event (from the source webhook/poll), used
+  -- to reject stale out-of-order deliveries.
+  delivered_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE branch_deployments IS
+  'Deployment metadata synced from GitHub branch/PR deployment events.';
+COMMENT ON COLUMN branch_deployments.pr_number IS
+  'Pull request number when the deployment belongs to a PR branch; NULL for plain branch deployments.';
+COMMENT ON COLUMN branch_deployments.delivered_at IS
+  'Timestamp of the source deployment event; stale deliveries (older than the newest stored) are rejected.';
+
+-- Idempotent duplicate-delivery key: one row per (branch, commit).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_branch_deployments_branch_commit
+  ON branch_deployments (branch_name, commit_sha);
+
+CREATE INDEX IF NOT EXISTS idx_branch_deployments_branch
+  ON branch_deployments (branch_name, delivered_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_branch_deployments_pr
+  ON branch_deployments (pr_number, delivered_at DESC);


### PR DESCRIPTION
## Overview

This PR implements the **GitHub Branch/PR Deployment Metadata Sync** (BE-60). It adds webhook and polling support for ingesting branch/PR deployment metadata, stores branch name, PR number, commit SHA, preview URL, and status in a new `branch_deployments` table, and exposes admin endpoints to query deployment metadata by branch or PR — with tests covering duplicate delivery and stale metadata updates.

## Related Issue

Closes #544

## Changes

### 🗄 Storage

* **[ADD]** `app/backend/supabase/migrations/20260825000000_create_branch_deployments_table.sql`
  * `branch_deployments` table: branch name, PR number, commit SHA, preview URL, status, environment, delivered_at.
  * Unique index on `(branch_name, commit_sha)` for idempotent duplicate deliveries.

### 📥 Ingestion

* **[ADD]** `app/backend/src/deployment-sync/`
  * `POST /deployments/webhook` — accepts normalized payloads or native GitHub `deployment_status` events, verified via `X-Hub-Signature-256` HMAC against the raw request body.
  * `POST /admin/deployments/sync` — admin (API-key) ingestion for polling-based sync.
  * `github-deployment-status.mapper.ts` — maps GitHub event states (`success`, `failure`, `pending`, …) to normalized statuses.
  * `github-webhook-signature.ts` — timing-safe HMAC signature verification.

### 🔎 Admin Queries

* **[ADD]** `GET /admin/deployments/branch/:branchName` (optional `?pr=`) — latest deployment metadata for a branch/PR.
* **[ADD]** `GET /admin/deployments/pr/:prNumber` — deployment history for a PR, newest first.

### 🧪 Tests

* **[ADD]** Unit tests covering duplicate delivery idempotency, stale out-of-order rejection (409), admin queries, signature verification, and GitHub event mapping.

## Verification Results

```
cd app/backend && pnpm exec jest --config jest.unit.config.ts src/deployment-sync
✅ 41/41 passed

Full backend unit suite
✅ 1372 passed

eslint, tsc --noEmit, nest build
✅ all green

Migration validated against PostgreSQL 16 (upsert-on-conflict + status CHECK constraint)
✅ passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Webhook/polling support for branch/PR metadata ingestion | ✅ GitHub webhook (signature-verified) + admin sync endpoint |
| Store branch, PR number, commit SHA, preview URL, status | ✅ `branch_deployments` table |
| Admin endpoints to query by branch or PR | ✅ GET by branch (optional `?pr`) and by PR |
| Tests for duplicate delivery and stale updates | ✅ 41 unit tests incl. idempotency and stale rejection |
