### PR TITLE
feat: batch operation size limits and resource guards (SC-W8-11)

### DIFF
--- a/app/contract/contracts/quickex/src/batch.rs
+++ b/app/contract/contracts/quickex/src/batch.rs
@@ -9,11 +9,35 @@
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
 use crate::errors::QuickexError;
-use crate::storage::{get_escrow, store_escrow};
+use crate::storage::{get_escrow, put_escrow};
 use crate::types::{EscrowEntry, EscrowStatus};
 
 /// Maximum number of items allowed in a single batch call.
-const MAX_BATCH_SIZE: u32 = 20;
+///
+/// ## Resource Cost Justification
+///
+/// Soroban mainnet transaction budget: 400,000,000 CPU instructions (`tx_max_instructions`).
+///
+/// Per-operation costs (from `bench_core_lifecycle_costs` in bench_test.rs):
+/// - `deposit` / `batch_create` item: ~600,000 CPU instructions (native Rust estimate)
+/// - `withdraw` / `batch_release` item: ~500,000 CPU instructions
+/// - `refund` / `batch_refund` item: ~500,000 CPU instructions
+///
+/// WASM execution overhead is typically 2-3× native Rust, so worst-case per-op:
+/// - `deposit`: ~1,800,000 CPU instructions
+/// - `withdraw`/`refund`: ~1,500,000 CPU instructions
+///
+/// With a 50% safety margin (leaving headroom for auth, storage reads, events):
+/// - Available budget: 400,000,000 × 0.50 = 200,000,000 CPU instructions
+/// - Max `deposit` batch: 200,000,000 / 1,800,000 ≈ 111 items
+/// - Max `withdraw`/`refund` batch: 200,000,000 / 1,500,000 ≈ 133 items
+///
+/// We choose **20** as a conservative limit that:
+/// 1. Stays well within budget even with storage contention or auth overhead
+/// 2. Avoids hitting ledger read/write entry limits (max 200 entries per tx)
+/// 3. Keeps transaction size small enough for reliable propagation
+/// 4. Matches common batch patterns in DeFi protocols (10-25 items)
+pub const MAX_BATCH_SIZE: u32 = 20;
 
 /// Per-item outcome returned by every batch function.
 #[contracttype]
@@ -53,7 +77,7 @@ pub fn batch_create(
     caller.require_auth();
 
     if items.len() > MAX_BATCH_SIZE {
-        return Err(QuickexError::InvalidAmount);
+        return Err(QuickexError::BatchSizeExceeded);
     }
 
     let mut results: Vec<BatchItemResult> = Vec::new(env);
@@ -62,12 +86,20 @@ pub fn batch_create(
         let idx = i as u32;
 
         if item.amount <= 0 {
-            results.push_back(BatchItemResult { index: idx, success: false, error_code: QuickexError::InvalidAmount as u32 });
+            results.push_back(BatchItemResult {
+                index: idx,
+                success: false,
+                error_code: QuickexError::InvalidAmount as u32,
+            });
             continue;
         }
 
         if get_escrow(env, &item.escrow_id).is_some() {
-            results.push_back(BatchItemResult { index: idx, success: false, error_code: QuickexError::EscrowExists as u32 });
+            results.push_back(BatchItemResult {
+                index: idx,
+                success: false,
+                error_code: QuickexError::CommitmentAlreadyExists as u32,
+            });
             continue;
         }
 
@@ -80,10 +112,16 @@ pub fn batch_create(
             created_at: env.ledger().timestamp(),
             expires_at: item.expires_at,
             arbiter: None,
+            arbiters: Vec::new(env),
+            arbiter_threshold: 0,
         };
 
-        store_escrow(env, &item.escrow_id, &entry);
-        results.push_back(BatchItemResult { index: idx, success: true, error_code: 0 });
+        put_escrow(env, &item.escrow_id, &entry);
+        results.push_back(BatchItemResult {
+            index: idx,
+            success: true,
+            error_code: 0,
+        });
     }
 
     Ok(results)
@@ -103,7 +141,7 @@ pub fn batch_release(
     caller.require_auth();
 
     if escrow_ids.len() > MAX_BATCH_SIZE {
-        return Err(QuickexError::InvalidAmount);
+        return Err(QuickexError::BatchSizeExceeded);
     }
 
     let now = env.ledger().timestamp();
@@ -115,24 +153,40 @@ pub fn batch_release(
         let mut entry = match get_escrow(env, &id) {
             Some(e) => e,
             None => {
-                results.push_back(BatchItemResult { index: idx, success: false, error_code: QuickexError::EscrowNotFound as u32 });
+                results.push_back(BatchItemResult {
+                    index: idx,
+                    success: false,
+                    error_code: QuickexError::CommitmentNotFound as u32,
+                });
                 continue;
             }
         };
 
         if entry.status != EscrowStatus::Pending {
-            results.push_back(BatchItemResult { index: idx, success: false, error_code: QuickexError::AlreadySpent as u32 });
+            results.push_back(BatchItemResult {
+                index: idx,
+                success: false,
+                error_code: QuickexError::AlreadySpent as u32,
+            });
             continue;
         }
 
         if entry.expires_at > 0 && now >= entry.expires_at {
-            results.push_back(BatchItemResult { index: idx, success: false, error_code: QuickexError::EscrowExpired as u32 });
+            results.push_back(BatchItemResult {
+                index: idx,
+                success: false,
+                error_code: QuickexError::EscrowExpired as u32,
+            });
             continue;
         }
 
         entry.status = EscrowStatus::Spent;
-        store_escrow(env, &id, &entry);
-        results.push_back(BatchItemResult { index: idx, success: true, error_code: 0 });
+        put_escrow(env, &id, &entry);
+        results.push_back(BatchItemResult {
+            index: idx,
+            success: true,
+            error_code: 0,
+        });
     }
 
     Ok(results)
@@ -152,7 +206,7 @@ pub fn batch_refund(
     caller.require_auth();
 
     if escrow_ids.len() > MAX_BATCH_SIZE {
-        return Err(QuickexError::InvalidAmount);
+        return Err(QuickexError::BatchSizeExceeded);
     }
 
     let now = env.ledger().timestamp();
@@ -164,24 +218,40 @@ pub fn batch_refund(
         let mut entry = match get_escrow(env, &id) {
             Some(e) => e,
             None => {
-                results.push_back(BatchItemResult { index: idx, success: false, error_code: QuickexError::EscrowNotFound as u32 });
+                results.push_back(BatchItemResult {
+                    index: idx,
+                    success: false,
+                    error_code: QuickexError::CommitmentNotFound as u32,
+                });
                 continue;
             }
         };
 
         if entry.status != EscrowStatus::Pending {
-            results.push_back(BatchItemResult { index: idx, success: false, error_code: QuickexError::AlreadySpent as u32 });
+            results.push_back(BatchItemResult {
+                index: idx,
+                success: false,
+                error_code: QuickexError::AlreadySpent as u32,
+            });
             continue;
         }
 
         if entry.expires_at == 0 || now < entry.expires_at {
-            results.push_back(BatchItemResult { index: idx, success: false, error_code: QuickexError::EscrowNotExpired as u32 });
+            results.push_back(BatchItemResult {
+                index: idx,
+                success: false,
+                error_code: QuickexError::EscrowNotExpired as u32,
+            });
             continue;
         }
 
         entry.status = EscrowStatus::Refunded;
-        store_escrow(env, &id, &entry);
-        results.push_back(BatchItemResult { index: idx, success: true, error_code: 0 });
+        put_escrow(env, &id, &entry);
+        results.push_back(BatchItemResult {
+            index: idx,
+            success: true,
+            error_code: 0,
+        });
     }
 
     Ok(results)

--- a/app/contract/contracts/quickex/src/batch_test.rs
+++ b/app/contract/contracts/quickex/src/batch_test.rs
@@ -1,0 +1,209 @@
+use crate::{
+    batch::{batch_create, BatchCreateItem, MAX_BATCH_SIZE},
+    errors::QuickexError,
+    storage::get_escrow,
+    QuickexContract, QuickexContractClient,
+};
+
+use soroban_sdk::{testutils::Address as _, token, Address, Bytes, Env, Vec};
+
+fn setup<'a>() -> (Env, QuickexContractClient<'a>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+fn create_test_token(env: &Env) -> Address {
+    env.register_stellar_asset_contract_v2(Address::generate(env))
+        .address()
+}
+
+/// Test: batch exactly at MAX_BATCH_SIZE succeeds normally.
+#[test]
+fn test_batch_create_at_limit_succeeds() {
+    let (env, _client) = setup();
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &(MAX_BATCH_SIZE as i128 * 1_000));
+
+    let mut items: Vec<BatchCreateItem> = Vec::new(&env);
+    for i in 0..MAX_BATCH_SIZE {
+        let mut escrow_id = Bytes::new(&env);
+        escrow_id.push_back(i as u8);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+
+        items.push_back(BatchCreateItem {
+            escrow_id,
+            owner: owner.clone(),
+            token: token.clone(),
+            amount: 1_000,
+            expires_at: 0,
+        });
+    }
+
+    let results = batch_create(&env, &owner, items).unwrap();
+    assert_eq!(results.len(), MAX_BATCH_SIZE);
+    for i in 0..MAX_BATCH_SIZE {
+        let result = results.get(i).unwrap();
+        assert!(result.success, "Item {} should succeed", i);
+        assert_eq!(result.error_code, 0);
+    }
+}
+
+/// Test: batch of MAX_BATCH_SIZE + 1 is rejected immediately with BatchSizeExceeded error.
+/// Confirms zero operations from that batch were executed.
+#[test]
+fn test_batch_create_over_limit_rejects_immediately() {
+    let (env, client) = setup();
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &((MAX_BATCH_SIZE + 1) as i128 * 1_000));
+
+    let mut items: Vec<BatchCreateItem> = Vec::new(&env);
+    for i in 0..=MAX_BATCH_SIZE {
+        let mut escrow_id = Bytes::new(&env);
+        escrow_id.push_back(i as u8);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+
+        items.push_back(BatchCreateItem {
+            escrow_id,
+            owner: owner.clone(),
+            token: token.clone(),
+            amount: 1_000,
+            expires_at: 0,
+        });
+    }
+
+    let result = batch_create(&env, &owner, items);
+    assert_eq!(result, Err(QuickexError::BatchSizeExceeded));
+
+    // Verify zero operations were executed
+    env.as_contract(&client.address, || {
+        for i in 0..=MAX_BATCH_SIZE {
+            let mut escrow_id = Bytes::new(&env);
+            escrow_id.push_back(i as u8);
+            escrow_id.push_back(0);
+            escrow_id.push_back(0);
+            escrow_id.push_back(0);
+
+            let entry = get_escrow(&env, &escrow_id);
+            assert!(entry.is_none(), "No escrow should exist for item {}", i);
+        }
+    });
+}
+
+/// Test: within an at-or-under-limit batch, one operation partway through fails.
+/// Confirms partial-success semantics: operations before the failing one are committed,
+/// the failing one is not committed, and operations after are still executed.
+#[test]
+fn test_batch_create_mid_batch_failure_partial_success() {
+    let (env, client) = setup();
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &10_000);
+
+    // Create 5 items: items 0-2 will succeed, item 3 has zero amount (fails),
+    // item 4 should still be executed (partial-success semantics)
+    let mut items: Vec<BatchCreateItem> = Vec::new(&env);
+
+    // Items 0-2: valid
+    for i in 0..3 {
+        let mut escrow_id = Bytes::new(&env);
+        escrow_id.push_back(i as u8);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+
+        items.push_back(BatchCreateItem {
+            escrow_id,
+            owner: owner.clone(),
+            token: token.clone(),
+            amount: 1_000,
+            expires_at: 0,
+        });
+    }
+
+    // Item 3: zero amount (will fail with InvalidAmount)
+    {
+        let mut escrow_id = Bytes::new(&env);
+        escrow_id.push_back(3);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+
+        items.push_back(BatchCreateItem {
+            escrow_id,
+            owner: owner.clone(),
+            token: token.clone(),
+            amount: 0, // Invalid amount
+            expires_at: 0,
+        });
+    }
+
+    // Item 4: valid and should be executed (partial-success semantics)
+    {
+        let mut escrow_id = Bytes::new(&env);
+        escrow_id.push_back(4);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+        escrow_id.push_back(0);
+
+        items.push_back(BatchCreateItem {
+            escrow_id,
+            owner: owner.clone(),
+            token: token.clone(),
+            amount: 1_000,
+            expires_at: 0,
+        });
+    }
+
+    let results = batch_create(&env, &owner, items).unwrap();
+    assert_eq!(results.len(), 5);
+
+    // Items 0-2: success
+    for i in 0..3 {
+        let result = results.get(i).unwrap();
+        assert!(result.success, "Item {} should succeed", i);
+        assert_eq!(result.error_code, 0);
+    }
+
+    // Item 3: failure (zero amount)
+    let result_3 = results.get(3).unwrap();
+    assert!(!result_3.success);
+    assert_eq!(result_3.error_code, QuickexError::InvalidAmount as u32);
+
+    // Item 4: success (partial-success semantics: loop continues after failure)
+    let result_4 = results.get(4).unwrap();
+    assert!(result_4.success, "Item 4 should succeed");
+    assert_eq!(result_4.error_code, 0);
+
+    // Verify state: items 0-2 and 4 are committed, item 3 is not
+    env.as_contract(&client.address, || {
+        for i in 0..5u8 {
+            let mut escrow_id = Bytes::new(&env);
+            escrow_id.push_back(i);
+            escrow_id.push_back(0);
+            escrow_id.push_back(0);
+            escrow_id.push_back(0);
+
+            let entry = get_escrow(&env, &escrow_id);
+            if i == 3 {
+                assert!(entry.is_none(), "Item 3 should not be committed");
+            } else {
+                assert!(entry.is_some(), "Item {} should be committed", i);
+            }
+        }
+    });
+}

--- a/app/contract/contracts/quickex/src/batch_test.rs
+++ b/app/contract/contracts/quickex/src/batch_test.rs
@@ -23,7 +23,7 @@ fn create_test_token(env: &Env) -> Address {
 /// Test: batch exactly at MAX_BATCH_SIZE succeeds normally.
 #[test]
 fn test_batch_create_at_limit_succeeds() {
-    let (env, _client) = setup();
+    let (env, client) = setup();
     let token = create_test_token(&env);
     let owner = Address::generate(&env);
 
@@ -47,7 +47,9 @@ fn test_batch_create_at_limit_succeeds() {
         });
     }
 
-    let results = batch_create(&env, &owner, items).unwrap();
+    let results = env
+        .as_contract(&client.address, || batch_create(&env, &owner, items))
+        .unwrap();
     assert_eq!(results.len(), MAX_BATCH_SIZE);
     for i in 0..MAX_BATCH_SIZE {
         let result = results.get(i).unwrap();
@@ -84,7 +86,7 @@ fn test_batch_create_over_limit_rejects_immediately() {
         });
     }
 
-    let result = batch_create(&env, &owner, items);
+    let result = env.as_contract(&client.address, || batch_create(&env, &owner, items));
     assert_eq!(result, Err(QuickexError::BatchSizeExceeded));
 
     // Verify zero operations were executed
@@ -169,7 +171,9 @@ fn test_batch_create_mid_batch_failure_partial_success() {
         });
     }
 
-    let results = batch_create(&env, &owner, items).unwrap();
+    let results = env
+        .as_contract(&client.address, || batch_create(&env, &owner, items))
+        .unwrap();
     assert_eq!(results.len(), 5);
 
     // Items 0-2: success

--- a/app/contract/contracts/quickex/src/errors.rs
+++ b/app/contract/contracts/quickex/src/errors.rs
@@ -15,6 +15,8 @@ pub enum QuickexError {
     InvalidAmount = 100,
     InvalidSalt = 101,
     InvalidPrivacyLevel = 102,
+    /// Batch size exceeds the maximum allowed limit.
+    BatchSizeExceeded = 103,
     // Auth/admin failures (200-299)
     Unauthorized = 200,
     AlreadyInitialized = 201,

--- a/app/contract/contracts/quickex/src/lib.rs
+++ b/app/contract/contracts/quickex/src/lib.rs
@@ -5,6 +5,9 @@ use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, Symbol, V
 mod admin;
 #[cfg(test)]
 mod assert_helpers;
+pub mod batch;
+#[cfg(test)]
+mod batch_test;
 #[cfg(test)]
 mod bench_test;
 mod commitment;


### PR DESCRIPTION
## Closes #872

## Summary

Implements SC-W8-11: Batch Operation Size Limits and Resource Guards for the QuickEx contract.

## Changes

### 1. Distinct Error Variant
- Added BatchSizeExceeded = 103 to QuickexError enum (validation failures band 100-199)
- Replaced ambiguous InvalidAmount error with distinct BatchSizeExceeded for oversized batch rejection

### 2. MAX_BATCH_SIZE Constant with Resource Cost Justification

**Chosen value: 20**

**Resource cost calculation:**
- Soroban mainnet transaction budget: 400,000,000 CPU instructions (	x_max_instructions)
- Per-operation costs (from \ench_core_lifecycle_costs\ in bench_test.rs):
  - \deposit\ / \atch_create\ item: ~600,000 CPU instructions (native Rust estimate)
  - \withdraw\ / \atch_release\ item: ~500,000 CPU instructions
  - \efund\ / \atch_refund\ item: ~500,000 CPU instructions
- WASM execution overhead is typically 2-3× native Rust, so worst-case per-op:
  - \deposit\: ~1,800,000 CPU instructions
  - \withdraw\/\efund\: ~1,500,000 CPU instructions
- With a 50% safety margin (leaving headroom for auth, storage reads, events):
  - Available budget: 400,000,000 × 0.50 = 200,000,000 CPU instructions
  - Max \deposit\ batch: 200,000,000 / 1,800,000 ≈ 111 items
  - Max \withdraw\/\efund\ batch: 200,000,000 / 1,500,000 ≈ 133 items

**Why 20:**
1. Stays well within budget even with storage contention or auth overhead
2. Avoids hitting ledger read/write entry limits (max 200 entries per tx)
3. Keeps transaction size small enough for reliable propagation
4. Matches common batch patterns in DeFi protocols (10-25 items)

### 3. Semantics: Partial-Success (Documented)

Chose **partial-success semantics** because:
- Already the existing pattern in batch.rs (documented in module doc comment)
- Operations are non-atomic: a failure on item N does not roll back items that already succeeded
- This is consistent with how the contract handles multi-step operations elsewhere
- Explicitly documented in batch function doc comments

### 4. Batch Size Enforcement

- Enforced at the very start of batch processing (before any operation executes)
- Oversized batch is rejected immediately with zero partial work done

## Acceptance Criteria Verification

| Criterion | Status | Test |
|-----------|--------|------|
| MAX_BATCH_SIZE constant declared and enforced | ✅ | \	est_batch_create_at_limit_succeeds\ |
| Distinct error variant for batch size exceeded | ✅ | \	est_batch_create_over_limit_rejects_immediately\ |
| Zero operations executed for oversized batch | ✅ | \	est_batch_create_over_limit_rejects_immediately\ |
| Partial-success semantics documented and tested | ✅ | \	est_batch_create_mid_batch_failure_partial_success\ |

## CI Verification

All CI-equivalent checks passed locally:
- \cargo fmt --all -- --check\ ✅
- \cargo clippy --all-targets --all-features -- -D warnings\ ✅
- \cargo check --tests\ ✅ (tests compile successfully)

Note: \cargo test\ could not run locally due to Windows dlltool environment issue, but code compiles and passes all static analysis checks.

## Files Changed

- \pp/contract/contracts/quickex/src/errors.rs\: Added \BatchSizeExceeded\ variant
- \pp/contract/contracts/quickex/src/batch.rs\: Updated error handling, added resource justification
- \pp/contract/contracts/quickex/src/lib.rs\: Added batch module declaration
- \pp/contract/contracts/quickex/src/batch_test.rs\: Added three required tests