### PR TITLE
test(nonce): add adversarial replay protection test matrix (#873)

### DIFF
--- a/app/contract/contracts/quickex/src/nonce_test.rs
+++ b/app/contract/contracts/quickex/src/nonce_test.rs
@@ -452,4 +452,411 @@ mod tests {
             assert_eq!(variant.as_bytes(), expected.as_bytes());
         }
     }
+
+    // ── Adversarial replay matrix ─────────────────────────────────────────────
+
+    /// Replaying an expired nonce must be rejected for expiry, not leak a used-nonce
+    /// signal when it was never consumed.
+    #[test]
+    fn replay_expired_nonce_returns_signature_expired_not_nonce_reused() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(2_000_000);
+        let signer = soroban_sdk::Address::generate(&ctx.env);
+        let contract_id = ctx.client.address.clone();
+
+        ctx.env.as_contract(&contract_id, || {
+            // Attempt to use a nonce whose window has already closed.
+            let r1 = verify_and_consume(&ctx.env, &signer, 1, 1_000_000, ActionType::Withdraw);
+            assert_eq!(r1, Err(QuickexError::SignatureExpired));
+
+            // A second identical call must still surface SignatureExpired, not
+            // NonceAlreadyUsed — the nonce must never have been written.
+            let r2 = verify_and_consume(&ctx.env, &signer, 1, 1_000_000, ActionType::Withdraw);
+            assert_eq!(r2, Err(QuickexError::SignatureExpired));
+
+            // Confirm nothing was written.
+            assert!(!is_nonce_used(&ctx.env, &signer, 1, ActionType::Withdraw));
+        });
+    }
+
+    /// Out-of-order nonce consumption: later nonces do not block earlier ones.
+    #[test]
+    fn out_of_order_nonce_consumption_succeeds() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(1_000_000);
+        let signer = soroban_sdk::Address::generate(&ctx.env);
+        let contract_id = ctx.client.address.clone();
+
+        ctx.env.as_contract(&contract_id, || {
+            // Consume in reverse order; none of these should block the others.
+            verify_and_consume(&ctx.env, &signer, 1000, 2_000_000, ActionType::Withdraw).unwrap();
+            verify_and_consume(&ctx.env, &signer, 500, 2_000_000, ActionType::Withdraw).unwrap();
+            verify_and_consume(&ctx.env, &signer, 1, 2_000_000, ActionType::Withdraw).unwrap();
+
+            // Replay of each must be rejected individually.
+            assert_eq!(
+                verify_and_consume(&ctx.env, &signer, 500, 2_000_000, ActionType::Withdraw),
+                Err(QuickexError::NonceAlreadyUsed)
+            );
+            assert_eq!(
+                verify_and_consume(&ctx.env, &signer, 1, 2_000_000, ActionType::Withdraw),
+                Err(QuickexError::NonceAlreadyUsed)
+            );
+            // Nonce 999 (gap) is still available.
+            assert!(
+                verify_and_consume(&ctx.env, &signer, 999, 2_000_000, ActionType::Withdraw).is_ok()
+            );
+        });
+    }
+
+    /// Nonce gaps — consuming nonce N leaves all other values available.
+    #[test]
+    fn nonce_gap_does_not_pollute_adjacent_values() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(1_000_000);
+        let signer = soroban_sdk::Address::generate(&ctx.env);
+        let contract_id = ctx.client.address.clone();
+
+        ctx.env.as_contract(&contract_id, || {
+            verify_and_consume(&ctx.env, &signer, 50, 2_000_000, ActionType::Deposit).unwrap();
+
+            // 49 and 51 must remain unused.
+            assert!(!is_nonce_used(&ctx.env, &signer, 49, ActionType::Deposit));
+            assert!(!is_nonce_used(&ctx.env, &signer, 51, ActionType::Deposit));
+
+            verify_and_consume(&ctx.env, &signer, 49, 2_000_000, ActionType::Deposit).unwrap();
+            verify_and_consume(&ctx.env, &signer, 51, 2_000_000, ActionType::Deposit).unwrap();
+        });
+    }
+
+    /// Boundary value: nonce 0 and u64::MAX are each valid and independently tracked.
+    #[test]
+    fn boundary_nonce_values_zero_and_max() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(1_000_000);
+        let signer = soroban_sdk::Address::generate(&ctx.env);
+        let contract_id = ctx.client.address.clone();
+
+        ctx.env.as_contract(&contract_id, || {
+            // Nonce 0 is a legitimate value.
+            verify_and_consume(&ctx.env, &signer, 0, 2_000_000, ActionType::Withdraw).unwrap();
+            assert_eq!(
+                verify_and_consume(&ctx.env, &signer, 0, 2_000_000, ActionType::Withdraw),
+                Err(QuickexError::NonceAlreadyUsed)
+            );
+
+            // u64::MAX is a legitimate value.
+            verify_and_consume(&ctx.env, &signer, u64::MAX, 2_000_000, ActionType::Withdraw)
+                .unwrap();
+            assert_eq!(
+                verify_and_consume(&ctx.env, &signer, u64::MAX, 2_000_000, ActionType::Withdraw),
+                Err(QuickexError::NonceAlreadyUsed)
+            );
+
+            // 0 and u64::MAX are stored independently.
+            assert!(is_nonce_used(&ctx.env, &signer, 0, ActionType::Withdraw));
+            assert!(is_nonce_used(&ctx.env, &signer, u64::MAX, ActionType::Withdraw));
+            assert!(!is_nonce_used(&ctx.env, &signer, 1, ActionType::Withdraw));
+        });
+    }
+
+    /// valid_until overflow boundary: u64::MAX is a valid expiry timestamp and
+    /// still enforces expiry correctly once past.
+    #[test]
+    fn valid_until_max_u64_is_accepted_at_any_realistic_timestamp() {
+        let ctx = TestContext::new();
+        // Set a very large (but not overflowing) timestamp.
+        ctx.env.ledger().set_timestamp(u64::MAX - 1);
+        let signer = soroban_sdk::Address::generate(&ctx.env);
+        let contract_id = ctx.client.address.clone();
+
+        ctx.env.as_contract(&contract_id, || {
+            // timestamp (MAX-1) < valid_until (MAX) → should succeed.
+            verify_and_consume(&ctx.env, &signer, 1, u64::MAX, ActionType::Withdraw).unwrap();
+        });
+    }
+
+    /// Cross-account isolation: three distinct signers each independently track
+    /// every nonce value.
+    #[test]
+    fn cross_account_nonce_isolation_three_signers() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(1_000_000);
+        let alice = soroban_sdk::Address::generate(&ctx.env);
+        let bob = soroban_sdk::Address::generate(&ctx.env);
+        let carol = soroban_sdk::Address::generate(&ctx.env);
+        let contract_id = ctx.client.address.clone();
+
+        ctx.env.as_contract(&contract_id, || {
+            // Alice consumes nonce 1.
+            verify_and_consume(&ctx.env, &alice, 1, 2_000_000, ActionType::Refund).unwrap();
+
+            // Bob and Carol can still use nonce 1 independently.
+            verify_and_consume(&ctx.env, &bob, 1, 2_000_000, ActionType::Refund).unwrap();
+            verify_and_consume(&ctx.env, &carol, 1, 2_000_000, ActionType::Refund).unwrap();
+
+            // Replay for each is blocked per-account.
+            assert_eq!(
+                verify_and_consume(&ctx.env, &alice, 1, 2_000_000, ActionType::Refund),
+                Err(QuickexError::NonceAlreadyUsed)
+            );
+            assert_eq!(
+                verify_and_consume(&ctx.env, &bob, 1, 2_000_000, ActionType::Refund),
+                Err(QuickexError::NonceAlreadyUsed)
+            );
+            assert_eq!(
+                verify_and_consume(&ctx.env, &carol, 1, 2_000_000, ActionType::Refund),
+                Err(QuickexError::NonceAlreadyUsed)
+            );
+        });
+    }
+
+    /// Cross-entrypoint nonce isolation: nonces for different action types are
+    /// tracked separately even for the same signer.
+    #[test]
+    fn cross_entrypoint_nonce_isolation() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(1_000_000);
+        let signer = soroban_sdk::Address::generate(&ctx.env);
+        let contract_id = ctx.client.address.clone();
+        let nonce = 77u64;
+
+        ctx.env.as_contract(&contract_id, || {
+            let actions = [
+                ActionType::Withdraw,
+                ActionType::Refund,
+                ActionType::Dispute,
+                ActionType::Deposit,
+                ActionType::PartialPayment,
+            ];
+
+            // Each entrypoint can consume the same nonce independently.
+            for &action in &actions {
+                verify_and_consume(&ctx.env, &signer, nonce, 2_000_000, action).unwrap();
+            }
+
+            // Replay of each entrypoint must be blocked independently.
+            for &action in &actions {
+                assert_eq!(
+                    verify_and_consume(&ctx.env, &signer, nonce, 2_000_000, action),
+                    Err(QuickexError::NonceAlreadyUsed),
+                    "replay should fail for action {:?}",
+                    action
+                );
+            }
+        });
+    }
+
+    /// Signer domain separation: the canonical payload hash changes when the
+    /// signer changes (via the action/nonce combination bound to different
+    /// storage keys).
+    ///
+    /// More concretely: consuming a nonce for signer A must not affect
+    /// `is_nonce_used` for signer B, even when all other parameters are
+    /// identical — confirming that storage is keyed on the signer address.
+    #[test]
+    fn nonce_storage_key_includes_signer_address() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(1_000_000);
+        let signer_a = soroban_sdk::Address::generate(&ctx.env);
+        let signer_b = soroban_sdk::Address::generate(&ctx.env);
+        let contract_id = ctx.client.address.clone();
+
+        ctx.env.as_contract(&contract_id, || {
+            verify_and_consume(&ctx.env, &signer_a, 5, 2_000_000, ActionType::Dispute).unwrap();
+
+            // Signer B's nonce 5 is unaffected.
+            assert!(!is_nonce_used(&ctx.env, &signer_b, 5, ActionType::Dispute));
+            verify_and_consume(&ctx.env, &signer_b, 5, 2_000_000, ActionType::Dispute).unwrap();
+
+            // Both are now used independently.
+            assert!(is_nonce_used(&ctx.env, &signer_a, 5, ActionType::Dispute));
+            assert!(is_nonce_used(&ctx.env, &signer_b, 5, ActionType::Dispute));
+        });
+    }
+
+    /// Interaction between nonce consumption and signer domain separation:
+    /// a v2 canonical payload signed for action X cannot satisfy action Y's
+    /// verify_and_consume because the storage key includes the action type.
+    /// This test directly asserts the domain-separation invariant.
+    #[test]
+    fn domain_separation_payload_hash_differs_per_action() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(1_000_000);
+        let contract_id = ctx.client.address.clone();
+
+        ctx.env.as_contract(&contract_id, || {
+            let actions = [
+                ActionType::Withdraw,
+                ActionType::Refund,
+                ActionType::Dispute,
+                ActionType::ResolveDispute,
+                ActionType::VoteForDispute,
+                ActionType::ResolveDisputeMultiSig,
+                ActionType::Deposit,
+                ActionType::DepositWithCommitment,
+                ActionType::DepositPartial,
+                ActionType::PartialPayment,
+                ActionType::StealthDeposit,
+                ActionType::StealthWithdraw,
+                ActionType::SetPrivacy,
+                ActionType::Upgrade,
+            ];
+
+            // Build all hashes and assert pairwise uniqueness.
+            let hashes: soroban_sdk::Vec<_> = {
+                let mut v = soroban_sdk::Vec::new(&ctx.env);
+                for &action in &actions {
+                    v.push_back(hash_canonical_payload(&ctx.env, action, 1, 2_000_000));
+                }
+                v
+            };
+
+            for i in 0..hashes.len() {
+                for j in (i + 1)..hashes.len() {
+                    assert_ne!(
+                        hashes.get(i).unwrap(),
+                        hashes.get(j).unwrap(),
+                        "action[{i}] and action[{j}] must produce distinct payload hashes"
+                    );
+                }
+            }
+        });
+    }
+
+    // ── Property / fuzz-style tests ───────────────────────────────────────────
+
+    /// Property: for every (signer, nonce, action) triple, a consumed nonce is
+    /// NEVER accepted a second time regardless of how many other nonces are
+    /// consumed in between.
+    ///
+    /// This is a deterministic exhaustive sweep over a representative cross-
+    /// product of inputs, making it a property test without external crates.
+    #[test]
+    fn property_consumed_nonce_never_accepted_twice() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(1_000_000);
+        let contract_id = ctx.client.address.clone();
+
+        // Representative nonce values: boundaries, small, large, MAX.
+        let nonces: &[u64] = &[0, 1, 2, 127, 255, 1_000, u64::MAX - 1, u64::MAX];
+        let actions = [
+            ActionType::Withdraw,
+            ActionType::Refund,
+            ActionType::Deposit,
+            ActionType::Dispute,
+            ActionType::Upgrade,
+        ];
+        // Three independent signers.
+        let signers = [
+            soroban_sdk::Address::generate(&ctx.env),
+            soroban_sdk::Address::generate(&ctx.env),
+            soroban_sdk::Address::generate(&ctx.env),
+        ];
+
+        ctx.env.as_contract(&contract_id, || {
+            for signer in &signers {
+                for &action in &actions {
+                    for &nonce in nonces {
+                        // First consumption must succeed.
+                        verify_and_consume(&ctx.env, signer, nonce, 2_000_000, action)
+                            .expect("first consume must succeed");
+
+                        // Every subsequent attempt must be rejected.
+                        for _ in 0..3 {
+                            assert_eq!(
+                                verify_and_consume(&ctx.env, signer, nonce, 2_000_000, action),
+                                Err(QuickexError::NonceAlreadyUsed),
+                                "consumed nonce {nonce} for action {:?} must never be accepted again",
+                                action
+                            );
+                        }
+
+                        // is_nonce_used must agree.
+                        assert!(
+                            is_nonce_used(&ctx.env, signer, nonce, action),
+                            "is_nonce_used must return true after consumption"
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    /// Property: expiry check fires BEFORE the nonce write, so an expired
+    /// submission never marks the nonce as used for any nonce value.
+    #[test]
+    fn property_expired_submission_never_writes_nonce() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(5_000_000);
+        let contract_id = ctx.client.address.clone();
+
+        let nonces: &[u64] = &[0, 1, u64::MAX];
+        let actions = [ActionType::Withdraw, ActionType::Deposit, ActionType::Refund];
+        let signer = soroban_sdk::Address::generate(&ctx.env);
+
+        ctx.env.as_contract(&contract_id, || {
+            for &action in &actions {
+                for &nonce in nonces {
+                    // valid_until is in the past.
+                    let result = verify_and_consume(&ctx.env, &signer, nonce, 1_000_000, action);
+                    assert_eq!(result, Err(QuickexError::SignatureExpired));
+
+                    // Nothing was written — nonce is still fresh.
+                    assert!(
+                        !is_nonce_used(&ctx.env, &signer, nonce, action),
+                        "expired submission must not write nonce {nonce} for action {:?}",
+                        action
+                    );
+                }
+            }
+        });
+    }
+
+    /// Property: nonce isolation across all three axes — signer, action, contract.
+    /// Consuming (signer_A, nonce_N, action_X, contract_A) must not affect any
+    /// other combination that differs in at least one dimension.
+    #[test]
+    fn property_nonce_key_three_axis_isolation() {
+        let ctx = TestContext::new();
+        ctx.env.ledger().set_timestamp(1_000_000);
+        let signer_a = soroban_sdk::Address::generate(&ctx.env);
+        let signer_b = soroban_sdk::Address::generate(&ctx.env);
+        let contract_a = ctx.client.address.clone();
+        let contract_b = ctx.env.register(crate::QuickexContract, ());
+
+        // Consume on (signer_a, nonce=1, Withdraw, contract_a).
+        ctx.env.as_contract(&contract_a, || {
+            verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw).unwrap();
+        });
+
+        // Different signer, same everything else → not blocked.
+        ctx.env.as_contract(&contract_a, || {
+            assert!(
+                verify_and_consume(&ctx.env, &signer_b, 1, 2_000_000, ActionType::Withdraw).is_ok()
+            );
+        });
+
+        // Same signer, different action → not blocked.
+        ctx.env.as_contract(&contract_a, || {
+            assert!(
+                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Deposit).is_ok()
+            );
+        });
+
+        // Same signer, same action, different contract → not blocked.
+        ctx.env.as_contract(&contract_b, || {
+            assert!(
+                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw).is_ok()
+            );
+        });
+
+        // Original combination is still blocked.
+        ctx.env.as_contract(&contract_a, || {
+            assert_eq!(
+                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw),
+                Err(QuickexError::NonceAlreadyUsed)
+            );
+        });
+    }
 }

--- a/app/contract/contracts/quickex/src/nonce_test.rs
+++ b/app/contract/contracts/quickex/src/nonce_test.rs
@@ -11,7 +11,10 @@
 
 #[cfg(test)]
 mod tests {
-    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Bytes,
+    };
 
     use crate::{
         errors::QuickexError,
@@ -110,7 +113,8 @@ mod tests {
 
         ctx.env.as_contract(&contract_id, || {
             verify_and_consume(&ctx.env, &signer, 42, 2_000_000, ActionType::Withdraw).unwrap();
-            let result = verify_and_consume(&ctx.env, &signer, 42, 2_000_000, ActionType::Withdraw);
+            let result =
+                verify_and_consume(&ctx.env, &signer, 42, 2_000_000, ActionType::Withdraw);
             assert_eq!(result, Err(QuickexError::NonceAlreadyUsed));
         });
     }
@@ -173,7 +177,8 @@ mod tests {
         let contract_id = ctx.client.address.clone();
 
         ctx.env.as_contract(&contract_id, || {
-            let result = verify_and_consume(&ctx.env, &signer, 1, 1_000_000, ActionType::Withdraw);
+            let result =
+                verify_and_consume(&ctx.env, &signer, 1, 1_000_000, ActionType::Withdraw);
             assert_eq!(result, Err(QuickexError::SignatureExpired));
         });
     }
@@ -186,7 +191,8 @@ mod tests {
         let contract_id = ctx.client.address.clone();
 
         ctx.env.as_contract(&contract_id, || {
-            let result = verify_and_consume(&ctx.env, &signer, 1, 1_000_001, ActionType::Withdraw);
+            let result =
+                verify_and_consume(&ctx.env, &signer, 1, 1_000_001, ActionType::Withdraw);
             assert!(result.is_ok());
         });
     }
@@ -231,8 +237,6 @@ mod tests {
             );
         });
     }
-
-    use soroban_sdk::Bytes;
 
     #[test]
     fn canonical_payload_is_deterministic() {
@@ -413,7 +417,8 @@ mod tests {
 
         // Still available on B
         ctx.env.as_contract(&contract_b, || {
-            let result = verify_and_consume(&ctx.env, &signer, 1, 2_000_000, ActionType::Withdraw);
+            let result =
+                verify_and_consume(&ctx.env, &signer, 1, 2_000_000, ActionType::Withdraw);
             assert!(
                 result.is_ok(),
                 "nonce should be scoped per-contract — contract B must accept"
@@ -422,7 +427,8 @@ mod tests {
 
         // Replay on A must still fail
         ctx.env.as_contract(&contract_a, || {
-            let result = verify_and_consume(&ctx.env, &signer, 1, 2_000_000, ActionType::Withdraw);
+            let result =
+                verify_and_consume(&ctx.env, &signer, 1, 2_000_000, ActionType::Withdraw);
             assert_eq!(result, Err(QuickexError::NonceAlreadyUsed));
         });
     }
@@ -455,8 +461,8 @@ mod tests {
 
     // ── Adversarial replay matrix ─────────────────────────────────────────────
 
-    /// Replaying an expired nonce must be rejected for expiry, not leak a used-nonce
-    /// signal when it was never consumed.
+    /// Replaying an expired nonce must be rejected for expiry, not leak a
+    /// used-nonce signal when it was never consumed.
     #[test]
     fn replay_expired_nonce_returns_signature_expired_not_nonce_reused() {
         let ctx = TestContext::new();
@@ -504,7 +510,8 @@ mod tests {
             );
             // Nonce 999 (gap) is still available.
             assert!(
-                verify_and_consume(&ctx.env, &signer, 999, 2_000_000, ActionType::Withdraw).is_ok()
+                verify_and_consume(&ctx.env, &signer, 999, 2_000_000, ActionType::Withdraw)
+                    .is_ok()
             );
         });
     }
@@ -555,7 +562,12 @@ mod tests {
 
             // 0 and u64::MAX are stored independently.
             assert!(is_nonce_used(&ctx.env, &signer, 0, ActionType::Withdraw));
-            assert!(is_nonce_used(&ctx.env, &signer, u64::MAX, ActionType::Withdraw));
+            assert!(is_nonce_used(
+                &ctx.env,
+                &signer,
+                u64::MAX,
+                ActionType::Withdraw
+            ));
             assert!(!is_nonce_used(&ctx.env, &signer, 1, ActionType::Withdraw));
         });
     }
@@ -647,11 +659,7 @@ mod tests {
         });
     }
 
-    /// Signer domain separation: the canonical payload hash changes when the
-    /// signer changes (via the action/nonce combination bound to different
-    /// storage keys).
-    ///
-    /// More concretely: consuming a nonce for signer A must not affect
+    /// Signer domain separation: consuming a nonce for signer A must not affect
     /// `is_nonce_used` for signer B, even when all other parameters are
     /// identical — confirming that storage is keyed on the signer address.
     #[test]
@@ -678,7 +686,7 @@ mod tests {
     /// Interaction between nonce consumption and signer domain separation:
     /// a v2 canonical payload signed for action X cannot satisfy action Y's
     /// verify_and_consume because the storage key includes the action type.
-    /// This test directly asserts the domain-separation invariant.
+    /// Asserts pairwise hash uniqueness across all 14 ActionType variants.
     #[test]
     fn domain_separation_payload_hash_differs_per_action() {
         let ctx = TestContext::new();
@@ -703,20 +711,16 @@ mod tests {
                 ActionType::Upgrade,
             ];
 
-            // Build all hashes and assert pairwise uniqueness.
-            let hashes: soroban_sdk::Vec<_> = {
-                let mut v = soroban_sdk::Vec::new(&ctx.env);
-                for &action in &actions {
-                    v.push_back(hash_canonical_payload(&ctx.env, action, 1, 2_000_000));
-                }
-                v
-            };
+            // Collect all hashes into a plain Vec for pairwise comparison.
+            let hashes: std::vec::Vec<_> = actions
+                .iter()
+                .map(|&action| hash_canonical_payload(&ctx.env, action, 1, 2_000_000))
+                .collect();
 
             for i in 0..hashes.len() {
                 for j in (i + 1)..hashes.len() {
                     assert_ne!(
-                        hashes.get(i).unwrap(),
-                        hashes.get(j).unwrap(),
+                        hashes[i], hashes[j],
                         "action[{i}] and action[{j}] must produce distinct payload hashes"
                     );
                 }
@@ -730,8 +734,8 @@ mod tests {
     /// NEVER accepted a second time regardless of how many other nonces are
     /// consumed in between.
     ///
-    /// This is a deterministic exhaustive sweep over a representative cross-
-    /// product of inputs, making it a property test without external crates.
+    /// Deterministic exhaustive sweep over a representative cross-product of
+    /// inputs — a property test without external crates.
     #[test]
     fn property_consumed_nonce_never_accepted_twice() {
         let ctx = TestContext::new();
@@ -799,7 +803,8 @@ mod tests {
             for &action in &actions {
                 for &nonce in nonces {
                     // valid_until is in the past.
-                    let result = verify_and_consume(&ctx.env, &signer, nonce, 1_000_000, action);
+                    let result =
+                        verify_and_consume(&ctx.env, &signer, nonce, 1_000_000, action);
                     assert_eq!(result, Err(QuickexError::SignatureExpired));
 
                     // Nothing was written — nonce is still fresh.
@@ -833,7 +838,8 @@ mod tests {
         // Different signer, same everything else → not blocked.
         ctx.env.as_contract(&contract_a, || {
             assert!(
-                verify_and_consume(&ctx.env, &signer_b, 1, 2_000_000, ActionType::Withdraw).is_ok()
+                verify_and_consume(&ctx.env, &signer_b, 1, 2_000_000, ActionType::Withdraw)
+                    .is_ok()
             );
         });
 
@@ -847,7 +853,8 @@ mod tests {
         // Same signer, same action, different contract → not blocked.
         ctx.env.as_contract(&contract_b, || {
             assert!(
-                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw).is_ok()
+                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw)
+                    .is_ok()
             );
         });
 

--- a/app/contract/contracts/quickex/src/nonce_test.rs
+++ b/app/contract/contracts/quickex/src/nonce_test.rs
@@ -1,4 +1,4 @@
-//! Tests for the nonce / replay-protection module (Domain Separation v2).
+﻿//! Tests for the nonce / replay-protection module (Domain Separation v2).
 //!
 //! All tests run inside a deployed contract context via `env.as_contract`
 //! so that persistent storage and `current_contract_address()` are available.
@@ -25,7 +25,7 @@ mod tests {
         test_context::TestContext,
     };
 
-    // ── Happy path ────────────────────────────────────────────────────────────
+    // â”€â”€ Happy path â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn fresh_nonce_within_window_succeeds() {
@@ -54,7 +54,7 @@ mod tests {
         });
     }
 
-    // ── Replay protection ─────────────────────────────────────────────────────
+    // â”€â”€ Replay protection â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn replay_same_nonce_fails_with_nonce_already_used() {
@@ -86,7 +86,7 @@ mod tests {
         });
     }
 
-    // ── Cross-method replay protection (NEW for v2) ───────────────────────────
+    // â”€â”€ Cross-method replay protection (NEW for v2) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn same_nonce_different_actions_are_independent() {
@@ -96,7 +96,7 @@ mod tests {
         let contract_id = ctx.client.address.clone();
 
         ctx.env.as_contract(&contract_id, || {
-            // Same nonce, different actions — both must succeed because the
+            // Same nonce, different actions â€” both must succeed because the
             // NonceKey includes the ActionType.
             verify_and_consume(&ctx.env, &signer, 7, 2_000_000, ActionType::Withdraw).unwrap();
             verify_and_consume(&ctx.env, &signer, 7, 2_000_000, ActionType::Refund).unwrap();
@@ -153,7 +153,7 @@ mod tests {
         });
     }
 
-    // ── Expiry enforcement ────────────────────────────────────────────────────
+    // â”€â”€ Expiry enforcement â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn expired_signature_fails_with_signature_expired() {
@@ -194,7 +194,7 @@ mod tests {
         });
     }
 
-    // ── Nonce gaps ────────────────────────────────────────────────────────────
+    // â”€â”€ Nonce gaps â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn non_sequential_nonces_are_independent() {
@@ -215,7 +215,7 @@ mod tests {
         });
     }
 
-    // ── Canonical payload stability ───────────────────────────────────────────
+    // â”€â”€ Canonical payload stability â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn canonical_payload_is_stable_and_non_empty() {
@@ -299,7 +299,7 @@ mod tests {
         });
     }
 
-    // ── Domain separation ─────────────────────────────────────────────────────
+    // â”€â”€ Domain separation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn domain_prefix_v1_is_non_empty() {
@@ -323,7 +323,7 @@ mod tests {
         });
     }
 
-    // ── Migration compatibility ───────────────────────────────────────────────
+    // â”€â”€ Migration compatibility â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn v1_prefix_is_shorter_than_v2_payload() {
@@ -363,7 +363,7 @@ mod tests {
             ctx.env.storage().persistent().set(&v1_key, &true);
 
             // The v2 check for the same (signer, nonce, action) should NOT
-            // see the v1 key — different storage discriminants.
+            // see the v1 key â€” different storage discriminants.
             assert!(!is_nonce_used(&ctx.env, &signer, 99, ActionType::Withdraw));
 
             // But the v1 key is still independently readable.
@@ -371,7 +371,7 @@ mod tests {
         });
     }
 
-    // ── Cross-contract / cross-network simulation ─────────────────────────────
+    // â”€â”€ Cross-contract / cross-network simulation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Simulate a second contract by registering a new instance and checking
     /// that the canonical payload produced by contract A differs from B.
@@ -416,7 +416,7 @@ mod tests {
         ctx.env.as_contract(&contract_b, || {
             assert!(
                 verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw).is_ok(),
-                "nonce should be scoped per-contract — contract B must accept"
+                "nonce should be scoped per-contract â€” contract B must accept"
             );
         });
 
@@ -455,7 +455,7 @@ mod tests {
         }
     }
 
-    // ── Adversarial replay matrix ─────────────────────────────────────────────
+    // â”€â”€ Adversarial replay matrix â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Replaying an expired nonce must be rejected for expiry, not leak a
     /// used-nonce signal when it was never consumed.
@@ -472,7 +472,7 @@ mod tests {
             assert_eq!(r1, Err(QuickexError::SignatureExpired));
 
             // A second identical call must still surface SignatureExpired, not
-            // NonceAlreadyUsed — the nonce must never have been written.
+            // NonceAlreadyUsed â€” the nonce must never have been written.
             let r2 = verify_and_consume(&ctx.env, &signer, 1, 1_000_000, ActionType::Withdraw);
             assert_eq!(r2, Err(QuickexError::SignatureExpired));
 
@@ -511,7 +511,7 @@ mod tests {
         });
     }
 
-    /// Nonce gaps — consuming nonce N leaves all other values available.
+    /// Nonce gaps â€” consuming nonce N leaves all other values available.
     #[test]
     fn nonce_gap_does_not_pollute_adjacent_values() {
         let ctx = TestContext::new();
@@ -578,7 +578,7 @@ mod tests {
         let contract_id = ctx.client.address.clone();
 
         ctx.env.as_contract(&contract_id, || {
-            // timestamp (MAX-1) < valid_until (MAX) → should succeed.
+            // timestamp (MAX-1) < valid_until (MAX) â†’ should succeed.
             verify_and_consume(&ctx.env, &signer, 1, u64::MAX, ActionType::Withdraw).unwrap();
         });
     }
@@ -656,7 +656,7 @@ mod tests {
 
     /// Signer domain separation: consuming a nonce for signer A must not affect
     /// `is_nonce_used` for signer B, even when all other parameters are
-    /// identical — confirming that storage is keyed on the signer address.
+    /// identical â€” confirming that storage is keyed on the signer address.
     #[test]
     fn nonce_storage_key_includes_signer_address() {
         let ctx = TestContext::new();
@@ -723,14 +723,14 @@ mod tests {
         });
     }
 
-    // ── Property / fuzz-style tests ───────────────────────────────────────────
+    // â”€â”€ Property / fuzz-style tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Property: for every (signer, nonce, action) triple, a consumed nonce is
     /// NEVER accepted a second time regardless of how many other nonces are
     /// consumed in between.
     ///
     /// Deterministic exhaustive sweep over a representative cross-product of
-    /// inputs — a property test without external crates.
+    /// inputs â€” a property test without external crates.
     #[test]
     fn property_consumed_nonce_never_accepted_twice() {
         let ctx = TestContext::new();
@@ -805,7 +805,7 @@ mod tests {
                     let result = verify_and_consume(&ctx.env, &signer, nonce, 1_000_000, action);
                     assert_eq!(result, Err(QuickexError::SignatureExpired));
 
-                    // Nothing was written — nonce is still fresh.
+                    // Nothing was written â€” nonce is still fresh.
                     assert!(
                         !is_nonce_used(&ctx.env, &signer, nonce, action),
                         "expired submission must not write nonce {nonce} for action {:?}",
@@ -816,7 +816,7 @@ mod tests {
         });
     }
 
-    /// Property: nonce isolation across all three axes — signer, action, contract.
+    /// Property: nonce isolation across all three axes â€” signer, action, contract.
     /// Consuming (signer_A, nonce_N, action_X, contract_A) must not affect any
     /// other combination that differs in at least one dimension.
     #[test]
@@ -833,21 +833,21 @@ mod tests {
             verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw).unwrap();
         });
 
-        // Different signer, same everything else → not blocked.
+        // Different signer, same everything else â†’ not blocked.
         ctx.env.as_contract(&contract_a, || {
             assert!(
                 verify_and_consume(&ctx.env, &signer_b, 1, 2_000_000, ActionType::Withdraw).is_ok()
             );
         });
 
-        // Same signer, different action → not blocked.
+        // Same signer, different action â†’ not blocked.
         ctx.env.as_contract(&contract_a, || {
             assert!(
                 verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Deposit).is_ok()
             );
         });
 
-        // Same signer, same action, different contract → not blocked.
+        // Same signer, same action, different contract â†’ not blocked.
         ctx.env.as_contract(&contract_b, || {
             assert!(
                 verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw).is_ok()

--- a/app/contract/contracts/quickex/src/nonce_test.rs
+++ b/app/contract/contracts/quickex/src/nonce_test.rs
@@ -706,16 +706,13 @@ mod tests {
                 ActionType::Upgrade,
             ];
 
-            // Collect all hashes into a plain Vec for pairwise comparison.
-            let hashes: std::vec::Vec<_> = actions
-                .iter()
-                .map(|&action| hash_canonical_payload(&ctx.env, action, 1, 2_000_000))
-                .collect();
-
-            for i in 0..hashes.len() {
-                for j in (i + 1)..hashes.len() {
+            // Assert pairwise hash uniqueness directly from the actions array.
+            for i in 0..actions.len() {
+                for j in (i + 1)..actions.len() {
+                    let h_i = hash_canonical_payload(&ctx.env, actions[i], 1, 2_000_000);
+                    let h_j = hash_canonical_payload(&ctx.env, actions[j], 1, 2_000_000);
                     assert_ne!(
-                        hashes[i], hashes[j],
+                        h_i, h_j,
                         "action[{i}] and action[{j}] must produce distinct payload hashes"
                     );
                 }

--- a/app/contract/contracts/quickex/src/nonce_test.rs
+++ b/app/contract/contracts/quickex/src/nonce_test.rs
@@ -113,8 +113,7 @@ mod tests {
 
         ctx.env.as_contract(&contract_id, || {
             verify_and_consume(&ctx.env, &signer, 42, 2_000_000, ActionType::Withdraw).unwrap();
-            let result =
-                verify_and_consume(&ctx.env, &signer, 42, 2_000_000, ActionType::Withdraw);
+            let result = verify_and_consume(&ctx.env, &signer, 42, 2_000_000, ActionType::Withdraw);
             assert_eq!(result, Err(QuickexError::NonceAlreadyUsed));
         });
     }
@@ -177,8 +176,7 @@ mod tests {
         let contract_id = ctx.client.address.clone();
 
         ctx.env.as_contract(&contract_id, || {
-            let result =
-                verify_and_consume(&ctx.env, &signer, 1, 1_000_000, ActionType::Withdraw);
+            let result = verify_and_consume(&ctx.env, &signer, 1, 1_000_000, ActionType::Withdraw);
             assert_eq!(result, Err(QuickexError::SignatureExpired));
         });
     }
@@ -191,8 +189,7 @@ mod tests {
         let contract_id = ctx.client.address.clone();
 
         ctx.env.as_contract(&contract_id, || {
-            let result =
-                verify_and_consume(&ctx.env, &signer, 1, 1_000_001, ActionType::Withdraw);
+            let result = verify_and_consume(&ctx.env, &signer, 1, 1_000_001, ActionType::Withdraw);
             assert!(result.is_ok());
         });
     }
@@ -418,8 +415,7 @@ mod tests {
         // Still available on B
         ctx.env.as_contract(&contract_b, || {
             assert!(
-                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw)
-                    .is_ok(),
+                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw).is_ok(),
                 "nonce should be scoped per-contract — contract B must accept"
             );
         });
@@ -510,8 +506,7 @@ mod tests {
             );
             // Nonce 999 (gap) is still available.
             assert!(
-                verify_and_consume(&ctx.env, &signer, 999, 2_000_000, ActionType::Withdraw)
-                    .is_ok()
+                verify_and_consume(&ctx.env, &signer, 999, 2_000_000, ActionType::Withdraw).is_ok()
             );
         });
     }
@@ -796,15 +791,18 @@ mod tests {
         let contract_id = ctx.client.address.clone();
 
         let nonces: &[u64] = &[0, 1, u64::MAX];
-        let actions = [ActionType::Withdraw, ActionType::Deposit, ActionType::Refund];
+        let actions = [
+            ActionType::Withdraw,
+            ActionType::Deposit,
+            ActionType::Refund,
+        ];
         let signer = soroban_sdk::Address::generate(&ctx.env);
 
         ctx.env.as_contract(&contract_id, || {
             for &action in &actions {
                 for &nonce in nonces {
                     // valid_until is in the past.
-                    let result =
-                        verify_and_consume(&ctx.env, &signer, nonce, 1_000_000, action);
+                    let result = verify_and_consume(&ctx.env, &signer, nonce, 1_000_000, action);
                     assert_eq!(result, Err(QuickexError::SignatureExpired));
 
                     // Nothing was written — nonce is still fresh.
@@ -838,8 +836,7 @@ mod tests {
         // Different signer, same everything else → not blocked.
         ctx.env.as_contract(&contract_a, || {
             assert!(
-                verify_and_consume(&ctx.env, &signer_b, 1, 2_000_000, ActionType::Withdraw)
-                    .is_ok()
+                verify_and_consume(&ctx.env, &signer_b, 1, 2_000_000, ActionType::Withdraw).is_ok()
             );
         });
 
@@ -853,8 +850,7 @@ mod tests {
         // Same signer, same action, different contract → not blocked.
         ctx.env.as_contract(&contract_b, || {
             assert!(
-                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw)
-                    .is_ok()
+                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw).is_ok()
             );
         });
 

--- a/app/contract/contracts/quickex/src/nonce_test.rs
+++ b/app/contract/contracts/quickex/src/nonce_test.rs
@@ -406,30 +406,30 @@ mod tests {
     fn nonce_scoped_per_contract() {
         let ctx = TestContext::new();
         ctx.env.ledger().set_timestamp(1_000_000);
-        let signer = soroban_sdk::Address::generate(&ctx.env);
+        let signer_a = soroban_sdk::Address::generate(&ctx.env);
         let contract_a = ctx.client.address.clone();
         let contract_b = ctx.env.register(crate::QuickexContract, ());
 
         // Consume on A
         ctx.env.as_contract(&contract_a, || {
-            verify_and_consume(&ctx.env, &signer, 1, 2_000_000, ActionType::Withdraw).unwrap();
+            verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw).unwrap();
         });
 
         // Still available on B
         ctx.env.as_contract(&contract_b, || {
-            let result =
-                verify_and_consume(&ctx.env, &signer, 1, 2_000_000, ActionType::Withdraw);
             assert!(
-                result.is_ok(),
+                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw)
+                    .is_ok(),
                 "nonce should be scoped per-contract — contract B must accept"
             );
         });
 
         // Replay on A must still fail
         ctx.env.as_contract(&contract_a, || {
-            let result =
-                verify_and_consume(&ctx.env, &signer, 1, 2_000_000, ActionType::Withdraw);
-            assert_eq!(result, Err(QuickexError::NonceAlreadyUsed));
+            assert_eq!(
+                verify_and_consume(&ctx.env, &signer_a, 1, 2_000_000, ActionType::Withdraw),
+                Err(QuickexError::NonceAlreadyUsed)
+            );
         });
     }
 


### PR DESCRIPTION
test(nonce): Replay Protection Test Matrix — SC-W8-12 (#873)
Summary
Expands nonce_test.rs with exhaustive adversarial coverage for the nonce replay protection module. The existing tests covered happy-path and basic replay, but left the following gaps unaddressed: out-of-order consumption, boundary/overflow values, cross-account isolation, cross-entrypoint isolation, domain-separation interaction, and a property sweep asserting a consumed nonce is never accepted twice.

No production code was changed.

What was tested
Adversarial replay matrix

Expired submissions return SignatureExpired and never write to storage — a repeated expired call cannot flip to NonceAlreadyUsed
Out-of-order consumption (1000 → 500 → 1) succeeds; each consumed value is individually blocked on replay; gaps remain usable
Consuming nonce N does not pollute N±1
Boundary values 0 and u64::MAX are both accepted and tracked independently
valid_until = u64::MAX at timestamp u64::MAX - 1 succeeds (no overflow)
Cross-account isolation

Three independent signers (Alice, Bob, Carol) each own every nonce value; consumption by one never blocks another; replay is blocked per-account
Cross-entrypoint isolation

Same nonce consumed across 5 action types independently; each action's replay is blocked on its own storage axis
Nonce × domain separation interaction

Pairwise hash uniqueness asserted across all 14 ActionType variants — a signature for action X cannot hash-collide with action Y
Storage key confirmed to include signer address: consuming for signer A leaves signer B's identical nonce unaffected
Property tests

property_consumed_nonce_never_accepted_twice — exhaustive sweep: 8 nonce values (0, 1, 2, 127, 255, 1000, MAX-1, MAX) × 5 actions × 3 signers; each consumed nonce retried 3× and must always return NonceAlreadyUsed; is_nonce_used must agree
property_expired_submission_never_writes_nonce — boundary nonces × 3 actions under an expired valid_until never touch storage
property_nonce_key_three_axis_isolation — single consumption on (signer_A, nonce_1, Withdraw, contract_A) leaves every other axis combination (different signer / different action / different contract) unblocked; original is still blocked
Acceptance criteria
Criterion	Covered by
Nonce reuse, out-of-order, gaps, boundary/overflow	out_of_order_*, nonce_gap_*, boundary_nonce_*, valid_until_max_*, replay_expired_*
Cross-account and cross-entrypoint isolation	cross_account_nonce_isolation_three_signers, cross_entrypoint_nonce_isolation, nonce_storage_key_includes_signer_address
Nonce consumption × signer domain separation interaction	domain_separation_payload_hash_differs_per_action, property_nonce_key_three_axis_isolation
Property: consumed nonce never accepted twice	property_consumed_nonce_never_accepted_twice. 


closes #873