### PR TITLE
MOB-58: Move the hardcoded swap asset whitelist to runtime config

### DIFF
--- a/app/mobile/__tests__/swappable-assets.test.ts
+++ b/app/mobile/__tests__/swappable-assets.test.ts
@@ -1,0 +1,101 @@
+import {
+  DEFAULT_SWAPPABLE_ASSETS,
+  resolveSwappableAssets,
+  isAssetSwappable,
+} from '../services/swappable-assets';
+
+describe('resolveSwappableAssets', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('uses the config-supplied list when provided', () => {
+    const configList = ['XLM', 'USDC', 'AQUA', 'yXLM'];
+
+    const result = resolveSwappableAssets(configList);
+
+    expect(result).toEqual(configList);
+    // A valid runtime list must not trigger the fallback log.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('reflects assets added backend-side without any code change', () => {
+    // Simulate the backend adding a brand new asset to the runtime config.
+    const result = resolveSwappableAssets(['XLM', 'USDC', 'EURC']);
+
+    expect(result).toContain('EURC');
+  });
+
+  it('falls back to the conservative default and logs when config is missing', () => {
+    const result = resolveSwappableAssets(undefined);
+
+    expect(result).toEqual([...DEFAULT_SWAPPABLE_ASSETS]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back and logs when config is null', () => {
+    const result = resolveSwappableAssets(null);
+
+    expect(result).toEqual([...DEFAULT_SWAPPABLE_ASSETS]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back and logs when config is an empty array', () => {
+    const result = resolveSwappableAssets([]);
+
+    expect(result).toEqual([...DEFAULT_SWAPPABLE_ASSETS]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops malformed entries and keeps valid ones', () => {
+    // Malformed entries (blank / non-string) are filtered out.
+    const result = resolveSwappableAssets([
+      'XLM',
+      '',
+      '  ',
+      // @ts-expect-error exercising a malformed runtime payload
+      42,
+      'USDC',
+    ]);
+
+    expect(result).toEqual(['XLM', 'USDC']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns a copy of the default so callers cannot mutate it', () => {
+    const result = resolveSwappableAssets(undefined);
+
+    result.push('MUTATED');
+
+    expect(DEFAULT_SWAPPABLE_ASSETS).not.toContain('MUTATED');
+  });
+});
+
+describe('isAssetSwappable', () => {
+  it('returns true for an asset in the whitelist', () => {
+    const whitelist = resolveSwappableAssets(['XLM', 'USDC', 'AQUA']);
+
+    expect(isAssetSwappable('AQUA', whitelist)).toBe(true);
+  });
+
+  it('returns false when an unsupported asset is selected', () => {
+    const whitelist = resolveSwappableAssets(['XLM', 'USDC']);
+
+    // "DOGE" is not part of the runtime whitelist and must be rejected.
+    expect(isAssetSwappable('DOGE', whitelist)).toBe(false);
+  });
+
+  it('rejects an asset that is absent from the conservative default', () => {
+    const whitelist = resolveSwappableAssets(undefined);
+
+    // yXLM is in the old hardcoded list but not the conservative default,
+    // so without runtime config it must not be considered swappable.
+    expect(isAssetSwappable('yXLM', whitelist)).toBe(false);
+  });
+});

--- a/app/mobile/app/payment-confirmation.tsx
+++ b/app/mobile/app/payment-confirmation.tsx
@@ -17,9 +17,8 @@ import { v4 as uuidv4 } from "uuid";
 import { ActivityIndicator } from "react-native";
 import { useContractRegistry } from "../hooks/useContractRegistry";
 import { ErrorState } from "@/components/resilience/error-state";
-
-// List of assets to attempt swaps from (hardcoded whitelist matching backend)
-const SWAPPABLE_ASSETS = ["XLM", "USDC", "AQUA", "yXLM"];
+import { useSession } from "../contexts/SessionContext";
+import { resolveSwappableAssets } from "../services/swappable-assets";
 
 export default function PaymentConfirmationScreen() {
   const router = useRouter();
@@ -57,6 +56,16 @@ export default function PaymentConfirmationScreen() {
   const [selectedSwapPath, setSelectedSwapPath] = React.useState<PathPreviewRow | null>(null);
   const [slippageTolerance, setSlippageTolerance] = React.useState(1.0); // 1.0% default
 
+  // Swap asset whitelist sourced from the runtime config bootstrap, with a
+  // conservative built-in default when config is unavailable (see
+  // services/swappable-assets). This keeps the app in sync with the backend
+  // without requiring an app store release.
+  const { data: sessionData } = useSession();
+  const swappableAssets = React.useMemo(
+    () => resolveSwappableAssets(sessionData?.swappableAssets),
+    [sessionData?.swappableAssets],
+  );
+
   // Fetch swap options from backend (only if we have a valid destination asset)
   const {
     swapOptions,
@@ -65,7 +74,7 @@ export default function PaymentConfirmationScreen() {
     timeRemaining,
     isExpired,
     refetch,
-  } = useSwapOptions(username || "", numAmount, asset || "", SWAPPABLE_ASSETS);
+  } = useSwapOptions(username || "", numAmount, asset || "", swappableAssets);
 
   // Filter swap options to exclude the destination asset itself
   const availableSwapOptions = (swapOptions || []).filter(

--- a/app/mobile/services/session-bootstrap.ts
+++ b/app/mobile/services/session-bootstrap.ts
@@ -10,6 +10,13 @@ export interface BootstrapResponse {
   unreadCount: number;
   featureFlags: Record<string, boolean>;
   accountContext: AccountContext | null;
+  /**
+   * Runtime-configured whitelist of assets the backend can swap FROM.
+   * Sourced from the backend so it stays in sync without an app release.
+   * May be absent on older backends, in which case the client falls back
+   * to a conservative built-in default (see services/swappable-assets).
+   */
+  swappableAssets?: string[];
 }
 
 /**

--- a/app/mobile/services/swappable-assets.ts
+++ b/app/mobile/services/swappable-assets.ts
@@ -1,0 +1,51 @@
+/**
+ * Swap asset whitelist resolution.
+ *
+ * The authoritative list of assets that may be swapped FROM lives on the
+ * backend and is delivered to the app through the session bootstrap runtime
+ * config (see `BootstrapResponse.swappableAssets`). Sourcing it at runtime
+ * means the backend can add an asset without shipping a new app release.
+ *
+ * This module resolves that runtime value, falling back to a conservative
+ * built-in default when the config is unavailable or malformed.
+ */
+
+/**
+ * Conservative built-in default whitelist.
+ *
+ * Used only when the runtime config does not supply a list. Kept intentionally
+ * minimal to the most established, liquid assets so that, absent fresh config,
+ * the app degrades safely rather than offering swaps the backend may reject.
+ */
+export const DEFAULT_SWAPPABLE_ASSETS: readonly string[] = ["XLM", "USDC"];
+
+/**
+ * Resolves the swap asset whitelist from the runtime config bootstrap.
+ *
+ * Returns the config-supplied list when it is a non-empty array of valid asset
+ * codes. Otherwise logs a warning and returns a copy of the conservative
+ * built-in default.
+ */
+export function resolveSwappableAssets(configAssets?: string[] | null): string[] {
+  if (Array.isArray(configAssets)) {
+    const cleaned = configAssets.filter(
+      (asset): asset is string => typeof asset === "string" && asset.trim().length > 0,
+    );
+    if (cleaned.length > 0) {
+      return cleaned;
+    }
+  }
+
+  console.warn(
+    "[swappable-assets] Runtime config did not supply a swap asset whitelist; " +
+      `falling back to built-in default: ${DEFAULT_SWAPPABLE_ASSETS.join(", ")}`,
+  );
+  return [...DEFAULT_SWAPPABLE_ASSETS];
+}
+
+/**
+ * Returns true when the given asset code is present in the resolved whitelist.
+ */
+export function isAssetSwappable(asset: string, whitelist: string[]): boolean {
+  return whitelist.includes(asset);
+}


### PR DESCRIPTION
## Summary

Closes #848.

The swap asset whitelist in `app/mobile/app/payment-confirmation.tsx` was a hardcoded local constant (`["XLM", "USDC", "AQUA", "yXLM"]`) with a comment noting it "matches backend". The two copies drifted the moment the backend added an asset, and correcting it required an app store release. This sources the list from the session bootstrap runtime config that already exists.

## Changes

- **`services/session-bootstrap.ts`** — add an optional `swappableAssets?: string[]` field to `BootstrapResponse` so the backend can deliver the authoritative whitelist at runtime. Optional + forward-compatible, so older backends keep working.
- **`services/swappable-assets.ts`** (new) — `resolveSwappableAssets()` returns the config-supplied list when it is a valid non-empty array, and otherwise logs a warning and falls back to a conservative built-in default (`XLM`, `USDC`). Also adds `isAssetSwappable()`.
- **`app/payment-confirmation.tsx`** — read the whitelist from `useSession()` and resolve it via the helper; remove the hardcoded `SWAPPABLE_ASSETS` array and its comment.
- **`__tests__/swappable-assets.test.ts`** (new) — cover the config-supplied list, the logged fallback (undefined / null / empty / malformed), and selection of an unsupported asset.

## Acceptance criteria

- [x] Whitelist read from runtime config rather than a local constant.
- [x] Conservative built-in default applies when config is unavailable, and the fallback is logged.
- [x] Adding an asset backend-side changes mobile behaviour without an app release.
- [x] The hardcoded array and its comment are removed.
- [x] Tests cover config-supplied list, fallback, and an unsupported asset selection.

## Notes

The resolver logic was verified standalone. Dependencies were not installed locally, so the Jest suite was not executed here; the mobile test job runs in CI.