### PR TITLE
refactor(backend): decouple links/timeline/receipts/usernames from Supabase via repository pattern

### DIFF
--- a/app/backend/docs/REPOSITORY-PATTERN.md
+++ b/app/backend/docs/REPOSITORY-PATTERN.md
@@ -1,0 +1,103 @@
+# Repository Pattern
+
+Services must not talk to Supabase directly. All persistence goes through a
+**repository** owned by the domain, exposed as an **interface** and backed by a
+**Supabase adapter** registered in the module's dependency-injection container.
+
+This decouples the domain services from the storage engine so that unit tests
+run entirely without Supabase (no network, no credentials, no mock query
+builder chains).
+
+## Problem
+
+Services were coupled to Supabase in two ways:
+
+1. Injecting the concrete `SupabaseService` and calling its data-access methods
+   directly (e.g. `usernames.service.ts`).
+2. Reaching through `supabaseService.getClient().from('table')...` from inside a
+   service (e.g. `payment-link.service.ts`, `payment-link-expiry.service.ts`,
+   `transaction-timeline.service.ts`).
+
+Both make the service hard to test (chainable builder mocks) and impossible to
+port to a different persistence layer.
+
+## Pattern
+
+Each domain owns a port/adapter pair:
+
+```
+<domain>.repository.ts
+├── domain types          (persistence shape, e.g. UsernameRow, ListingPage)
+├── interface              (the contract services depend on)
+├── DI token               (Symbol, e.g. USERNAMES_REPOSITORY)
+└── Supabase adapter       (implements the interface via SupabaseService)
+```
+
+- **Services** depend on the interface, injected with `@Inject(TOKEN)`.
+- **Modules** bind the token to the adapter with
+  `{ provide: TOKEN, useClass: Supabase<Domain>Repository }`.
+- **Unit tests** provide an in-memory fake:
+  `{ provide: TOKEN, useValue: { ...jest.fn() } }`.
+
+### Conventions
+
+- File name: `<domain>.repository.ts` (e.g. `usernames.repository.ts`).
+- Token name: uppercase `<DOMAIN>_REPOSITORY` constant.
+- Adapter name: `Supabase<Domain>Repository`.
+- Adapter throws domain errors, not storage errors — e.g.
+  `SupabaseUsernamesRepository` translates `SupabaseUniqueConstraintError` into
+  `UsernameConflictError` so services never import `supabase.errors`.
+- Types returned by the interface are domain types, not `supabase-js` row types.
+
+## Repositories in this codebase
+
+| Domain                | File                                                      | Token                         |
+| --------------------- | --------------------------------------------------------- | ----------------------------- |
+| Usernames             | `src/usernames/usernames.repository.ts`                  | `USERNAMES_REPOSITORY`        |
+| Payment links         | `src/links/payment-links.repository.ts`                  | `PAYMENT_LINKS_REPOSITORY`    |
+| Transaction timeline  | `src/transaction-timeline/transaction-timeline.repository.ts` | `TRANSACTION_TIMELINE_REPOSITORY` |
+| Receipts (indexer)    | `src/receipts/receipt-metadata.repository.ts`            | `RECEIPT_METADATA_REPOSITORY` |
+
+Pre-existing concrete repositories that already follow the same spirit (no
+interface token) include `recurring-payments.repository.ts`, `api-keys.repository.ts`,
+`crash-reporting.repository.ts`, `dashboard-feed.repository.ts`, and the
+`ingestion/*.repository.ts` files. New code should prefer the interface + token
+form described here.
+
+## Adding a new repository
+
+1. Create `<domain>.repository.ts` with the interface, DI token, and a
+   `Supabase<Domain>Repository` adapter.
+2. Update the module: import `SupabaseModule`, add the token provider, and (if
+   another module needs the adapter) export the token.
+3. Update services to inject the token:
+   ```ts
+   constructor(
+     @Inject(DOMAIN_REPOSITORY)
+     private readonly repo: DomainRepository,
+   ) {}
+   ```
+4. Update unit tests to supply an in-memory fake instead of `SupabaseService` /
+   `getClient()` chains.
+
+## Testing without Supabase
+
+Unit tests construct the module with a fake repository and never instantiate
+`SupabaseService`:
+
+```ts
+const repoMock = {
+  getPublicKeyByUsername: jest.fn().mockResolvedValue('G...'),
+};
+
+const module = await Test.createTestingModule({
+  providers: [
+    PaymentLinkService,
+    { provide: PAYMENT_LINKS_REPOSITORY, useValue: repoMock },
+    // ...
+  ],
+}).compile();
+```
+
+This is why unit tests need no `SUPABASE_URL` / `SUPABASE_ANON_KEY` and no
+network access.

--- a/app/backend/src/links/__tests__/payment-link-expiry.service.unit.spec.ts
+++ b/app/backend/src/links/__tests__/payment-link-expiry.service.unit.spec.ts
@@ -1,32 +1,23 @@
 import { Test } from '@nestjs/testing';
 import { PaymentLinkExpiryService } from '../payment-link-expiry.service';
-import { SupabaseService } from '../../supabase/supabase.service';
+import { PAYMENT_LINKS_REPOSITORY } from '../payment-links.repository';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { AuditService } from '../../audit/audit.service';
 
 describe('PaymentLinkExpiryService', () => {
   let svc: PaymentLinkExpiryService;
-  let mockSupabase: { getClient: jest.Mock };
+  let mockRepo: {
+    markExpiredLinks: jest.Mock;
+    insertExpiryAudit: jest.Mock;
+  };
   let mockAudit: { log: jest.Mock };
   let events: EventEmitter2;
 
   beforeEach(async () => {
-    mockSupabase = {
-      getClient: jest.fn(),
+    mockRepo = {
+      markExpiredLinks: jest.fn().mockResolvedValue([]),
+      insertExpiryAudit: jest.fn().mockResolvedValue(undefined),
     };
-
-    // Minimal chainable builder used by service
-    const builder = {
-      update: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      not: jest.fn().mockReturnThis(),
-      lte: jest.fn().mockReturnThis(),
-      select: jest.fn().mockResolvedValue({ data: [], error: null }),
-      from: jest.fn().mockReturnThis(),
-      insert: jest.fn().mockResolvedValue({ data: [], error: null }),
-    };
-
-    mockSupabase.getClient.mockReturnValue(builder);
 
     mockAudit = { log: jest.fn().mockResolvedValue(undefined) };
 
@@ -35,7 +26,7 @@ describe('PaymentLinkExpiryService', () => {
     const module = await Test.createTestingModule({
       providers: [
         PaymentLinkExpiryService,
-        { provide: SupabaseService, useValue: mockSupabase },
+        { provide: PAYMENT_LINKS_REPOSITORY, useValue: mockRepo },
         { provide: EventEmitter2, useValue: events },
         { provide: AuditService, useValue: mockAudit },
       ],
@@ -52,24 +43,25 @@ describe('PaymentLinkExpiryService', () => {
       expires_at: new Date().toISOString(),
     };
 
-    const client = mockSupabase.getClient();
-    client.select.mockResolvedValue({ data: [updatedRow], error: null });
-    client.insert.mockResolvedValue({ data: [{ id: 'audit1' }], error: null });
+    mockRepo.markExpiredLinks.mockResolvedValue([updatedRow]);
 
     const spyEmit = jest.spyOn(events, 'emit');
 
     const count = await svc.runExpirySweep('run-1');
     expect(count).toBe(1);
     expect(mockAudit.log).toHaveBeenCalledWith('system:expiry-worker', 'payment_link.expired', String(updatedRow.id), expect.any(Object));
+    expect(mockRepo.insertExpiryAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ linkId: String(updatedRow.id), runId: 'run-1' }),
+    );
     expect(spyEmit).toHaveBeenCalledWith('payment.link.expired', expect.objectContaining({ linkId: String(updatedRow.id) }));
   });
 
   it('is idempotent when there are no open expired links', async () => {
-    const client = mockSupabase.getClient();
-    client.select.mockResolvedValue({ data: [], error: null });
+    mockRepo.markExpiredLinks.mockResolvedValue([]);
 
     const count = await svc.runExpirySweep('run-2');
     expect(count).toBe(0);
     expect(mockAudit.log).not.toHaveBeenCalled();
+    expect(mockRepo.insertExpiryAudit).not.toHaveBeenCalled();
   });
 });

--- a/app/backend/src/links/links.module.ts
+++ b/app/backend/src/links/links.module.ts
@@ -11,6 +11,10 @@ import { RecurringPaymentProcessor } from "../stellar/recurring-payment-processo
 import { PaymentLinkController } from "./payment-link.controller";
 import { PaymentLinkService } from "./payment-link.service";
 import { PaymentLinkExpiryService } from './payment-link-expiry.service';
+import {
+  PAYMENT_LINKS_REPOSITORY,
+  SupabasePaymentLinksRepository,
+} from "./payment-links.repository";
 import { SupabaseModule } from "../supabase/supabase.module";
 import { StellarModule } from "../stellar/stellar.module";
 import { ApiKeysModule } from "../api-keys/api-keys.module";
@@ -37,6 +41,10 @@ import { MetricsModule } from "../metrics/metrics.module";
     RecurringPaymentsRepository,
     RecurringPaymentProcessor,
     PaymentLinkService,
+    {
+      provide: PAYMENT_LINKS_REPOSITORY,
+      useClass: SupabasePaymentLinksRepository,
+    },
   ],
   exports: [
     LinksService,

--- a/app/backend/src/links/payment-link-expiry.service.ts
+++ b/app/backend/src/links/payment-link-expiry.service.ts
@@ -1,17 +1,21 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { v4 as uuidv4 } from 'uuid';
 
-import { SupabaseService } from '../supabase/supabase.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { AuditService } from '../audit/audit.service';
+import {
+  PAYMENT_LINKS_REPOSITORY,
+  type PaymentLinksRepository,
+} from './payment-links.repository';
 
 @Injectable()
 export class PaymentLinkExpiryService {
   private readonly logger = new Logger(PaymentLinkExpiryService.name);
 
   constructor(
-    private readonly supabase: SupabaseService,
+    @Inject(PAYMENT_LINKS_REPOSITORY)
+    private readonly paymentLinksRepository: PaymentLinksRepository,
     private readonly eventEmitter: EventEmitter2,
     private readonly auditService: AuditService,
   ) {}
@@ -34,29 +38,13 @@ export class PaymentLinkExpiryService {
    * run concurrently or replayed — idempotent and replay-safe.
    */
   async runExpirySweep(runId: string): Promise<number> {
-    const client = this.supabase.getClient();
     const nowIso = new Date().toISOString();
     try {
-      // Update matched rows and return their representation so we can audit and emit events.
-      const { data, error } = await client
-        .from('payment_links')
-        .update({
-          status: 'expired',
-          expiry_processed_at: nowIso,
-          expiry_processed_by: 'expiry-worker',
-          expiry_note: `expired by sweep ${runId}`,
-        })
-        .eq('status', 'open')
-        .not('expires_at', 'is', null)
-        .lte('expires_at', nowIso)
-        .select('id,owner_public_key,destination_public_key,amount,asset_code,memo,expires_at,matched_tx_hash,matched_at');
+      const updated = await this.paymentLinksRepository.markExpiredLinks(
+        nowIso,
+        runId,
+      );
 
-      if (error) {
-        this.logger.error(`Failed to mark expired links: ${error.message}`);
-        return 0;
-      }
-
-      const updated = (data ?? []) as Array<Record<string, unknown>>;
       if (updated.length === 0) return 0;
 
       // For each updated link write an audit row and emit a notification event
@@ -65,20 +53,16 @@ export class PaymentLinkExpiryService {
         const expiresAt = row.expires_at ? String(row.expires_at) : null;
 
         // Persist to expiry audit table
-        try {
-          await client.from('payment_link_expiry_audit').insert({
-            link_id: linkId,
-            previous_status: 'open',
-            new_status: 'expired',
-            expires_at: expiresAt,
-            processed_at: nowIso,
-            processed_by: 'expiry-worker',
-            run_id: runId,
-            note: `sweep`,
-          });
-        } catch (err) {
-          this.logger.warn(`Failed to record expiry audit for ${linkId}: ${(err as Error).message}`);
-        }
+        await this.paymentLinksRepository.insertExpiryAudit({
+          linkId,
+          previousStatus: 'open',
+          newStatus: 'expired',
+          expiresAt,
+          processedAt: nowIso,
+          processedBy: 'expiry-worker',
+          runId,
+          note: 'sweep',
+        });
 
         // Emit an audit log for operators
         await this.auditService.log('system:expiry-worker', 'payment_link.expired', linkId, {

--- a/app/backend/src/links/payment-link.service.ts
+++ b/app/backend/src/links/payment-link.service.ts
@@ -1,10 +1,13 @@
-import { Injectable, Logger, NotFoundException, Optional } from "@nestjs/common";
+import { Inject, Injectable, Logger, NotFoundException, Optional } from "@nestjs/common";
 import { LinkState } from "../links/link-state-machine";
 import { PaymentLinkStatusDto } from "../dto/link/payment-link-status.dto";
 import { HorizonService } from "../transactions/horizon.service";
-import { SupabaseService } from "../supabase/supabase.service";
 import { LinksService } from "../links/links.service";
 import { PathPreviewService } from "../stellar/path-preview.service";
+import {
+  PAYMENT_LINKS_REPOSITORY,
+  type PaymentLinksRepository,
+} from "../links/payment-links.repository";
 
 import { LinkMetadataResponseDto } from "../dto/link/link-metadata-response.dto";
 
@@ -15,7 +18,8 @@ export class PaymentLinkService {
 
   constructor(
     private readonly horizonService: HorizonService,
-    private readonly supabaseService: SupabaseService,
+    @Inject(PAYMENT_LINKS_REPOSITORY)
+    private readonly paymentLinksRepository: PaymentLinksRepository,
     private readonly linksService: LinksService,
     @Optional() private readonly pathPreviewService?: PathPreviewService,
   ) {}
@@ -91,18 +95,15 @@ export class PaymentLinkService {
   private async getUsernameRecord(
     username: string,
   ): Promise<{ public_key: string }> {
-    const { data, error } = await this.supabaseService
-      .getClient()
-      .from("usernames")
-      .select("public_key")
-      .eq("username", username.toLowerCase())
-      .single();
+    const publicKey = await this.paymentLinksRepository.getPublicKeyByUsername(
+      username,
+    );
 
-    if (error || !data) {
+    if (!publicKey) {
       throw new NotFoundException(`Username '${username}' not found`);
     }
 
-    return data;
+    return { public_key: publicKey };
   }
 
   /**

--- a/app/backend/src/links/payment-link.service.unit.spec.ts
+++ b/app/backend/src/links/payment-link.service.unit.spec.ts
@@ -2,14 +2,14 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { NotFoundException } from "@nestjs/common";
 import { PaymentLinkService } from "./payment-link.service";
 import { HorizonService } from "../transactions/horizon.service";
-import { SupabaseService } from "../supabase/supabase.service";
+import { PAYMENT_LINKS_REPOSITORY } from "./payment-links.repository";
 import { LinksService } from "./links.service";
 import { LinkState } from "./link-state-machine";
 
 describe("PaymentLinkService", () => {
   let service: PaymentLinkService;
   let horizonService: jest.Mocked<HorizonService>;
-  let supabaseService: jest.Mocked<SupabaseService>;
+  let paymentLinksRepository: { getPublicKeyByUsername: jest.Mock };
   let linksService: jest.Mocked<LinksService>;
 
   const mockUsernameRecord = {
@@ -63,17 +63,9 @@ describe("PaymentLinkService", () => {
           },
         },
         {
-          provide: SupabaseService,
+          provide: PAYMENT_LINKS_REPOSITORY,
           useValue: {
-            getClient: jest.fn().mockReturnValue({
-              from: jest.fn().mockReturnValue({
-                select: jest.fn().mockReturnValue({
-                  eq: jest.fn().mockReturnValue({
-                    single: jest.fn(),
-                  }),
-                }),
-              }),
-            }),
+            getPublicKeyByUsername: jest.fn(),
           },
         },
         {
@@ -87,7 +79,7 @@ describe("PaymentLinkService", () => {
 
     service = module.get<PaymentLinkService>(PaymentLinkService);
     horizonService = module.get(HorizonService);
-    supabaseService = module.get(SupabaseService);
+    paymentLinksRepository = module.get(PAYMENT_LINKS_REPOSITORY);
     linksService = module.get(LinksService);
   });
 
@@ -98,15 +90,9 @@ describe("PaymentLinkService", () => {
   describe("getPaymentLinkStatus", () => {
     it("should return ACTIVE state when no payment found", async () => {
       // Mock username lookup
-      (supabaseService.getClient().from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest
-              .fn()
-              .mockResolvedValue({ data: mockUsernameRecord, error: null }),
-          }),
-        }),
-      });
+      paymentLinksRepository.getPublicKeyByUsername.mockResolvedValue(
+        mockUsernameRecord.public_key,
+      );
 
       // Mock metadata generation
       linksService.generateMetadata.mockResolvedValue(mockMetadata);
@@ -133,15 +119,9 @@ describe("PaymentLinkService", () => {
 
     it("should return PAID state when matching payment found", async () => {
       // Mock username lookup
-      (supabaseService.getClient().from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest
-              .fn()
-              .mockResolvedValue({ data: mockUsernameRecord, error: null }),
-          }),
-        }),
-      });
+      paymentLinksRepository.getPublicKeyByUsername.mockResolvedValue(
+        mockUsernameRecord.public_key,
+      );
 
       // Mock metadata generation
       linksService.generateMetadata.mockResolvedValue(mockMetadata);
@@ -168,15 +148,9 @@ describe("PaymentLinkService", () => {
       };
 
       // Mock username lookup
-      (supabaseService.getClient().from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest
-              .fn()
-              .mockResolvedValue({ data: mockUsernameRecord, error: null }),
-          }),
-        }),
-      });
+      paymentLinksRepository.getPublicKeyByUsername.mockResolvedValue(
+        mockUsernameRecord.public_key,
+      );
 
       // Mock metadata generation
       linksService.generateMetadata.mockResolvedValue(expiredMetadata);
@@ -198,15 +172,7 @@ describe("PaymentLinkService", () => {
 
     it("should throw NotFoundException when username not found", async () => {
       // Mock username lookup failure
-      (supabaseService.getClient().from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest
-              .fn()
-              .mockResolvedValue({ data: null, error: new Error("Not found") }),
-          }),
-        }),
-      });
+      paymentLinksRepository.getPublicKeyByUsername.mockResolvedValue(null);
 
       await expect(
         service.getPaymentLinkStatus({

--- a/app/backend/src/links/payment-links.repository.ts
+++ b/app/backend/src/links/payment-links.repository.ts
@@ -1,0 +1,140 @@
+/**
+ * Payment links repository port.
+ *
+ * Defines the persistence contract for payment-link related data access used by
+ * `PaymentLinkService` and `PaymentLinkExpiryService`. Services depend on the
+ * `PaymentLinksRepository` interface (via the `PAYMENT_LINKS_REPOSITORY` DI
+ * token) instead of a concrete storage implementation.
+ *
+ * The Supabase-backed adapter lives in the same file as the concrete
+ * `SupabasePaymentLinksRepository`.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SupabaseService } from '../supabase/supabase.service';
+
+export interface ExpiredPaymentLinkRow {
+  id: string;
+  owner_public_key: string | null;
+  destination_public_key: string | null;
+  amount: string | number;
+  asset_code: string | null;
+  memo: string | null;
+  expires_at: string | null;
+  matched_tx_hash: string | null;
+  matched_at: string | null;
+}
+
+export interface PaymentLinkExpiryAuditRow {
+  linkId: string;
+  previousStatus: 'open' | string;
+  newStatus: 'expired' | string;
+  expiresAt: string | null;
+  processedAt: string;
+  processedBy: string;
+  runId: string;
+  note: string;
+}
+
+// ---------------------------------------------------------------------------
+// Port
+// ---------------------------------------------------------------------------
+
+export interface PaymentLinksRepository {
+  /**
+   * Resolve the destination public key for a username, or null if unknown.
+   */
+  getPublicKeyByUsername(username: string): Promise<string | null>;
+
+  /**
+   * Mark open payment_links whose `expires_at` <= now as expired and return
+   * the affected rows so callers can audit and emit events. Idempotent and
+   * replay-safe: the update is constrained to rows with status='open'.
+   */
+  markExpiredLinks(
+    nowIso: string,
+    runId: string,
+  ): Promise<ExpiredPaymentLinkRow[]>;
+
+  /**
+   * Persist an audit record for an expired payment link.
+   */
+  insertExpiryAudit(row: PaymentLinkExpiryAuditRow): Promise<void>;
+}
+
+export const PAYMENT_LINKS_REPOSITORY = Symbol('PAYMENT_LINKS_REPOSITORY');
+
+// ---------------------------------------------------------------------------
+// Supabase adapter
+// ---------------------------------------------------------------------------
+
+@Injectable()
+export class SupabasePaymentLinksRepository implements PaymentLinksRepository {
+  private readonly logger = new Logger(SupabasePaymentLinksRepository.name);
+
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  async getPublicKeyByUsername(username: string): Promise<string | null> {
+    const { data, error } = await this.supabaseService
+      .getClient()
+      .from('usernames')
+      .select('public_key')
+      .eq('username', username.toLowerCase())
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return data.public_key as string;
+  }
+
+  async markExpiredLinks(
+    nowIso: string,
+    runId: string,
+  ): Promise<ExpiredPaymentLinkRow[]> {
+    const client = this.supabaseService.getClient();
+    const { data, error } = await client
+      .from('payment_links')
+      .update({
+        status: 'expired',
+        expiry_processed_at: nowIso,
+        expiry_processed_by: 'expiry-worker',
+        expiry_note: `expired by sweep ${runId}`,
+      })
+      .eq('status', 'open')
+      .not('expires_at', 'is', null)
+      .lte('expires_at', nowIso)
+      .select(
+        'id,owner_public_key,destination_public_key,amount,asset_code,memo,expires_at,matched_tx_hash,matched_at',
+      );
+
+    if (error) {
+      this.logger.error(`Failed to mark expired links: ${error.message}`);
+      return [];
+    }
+
+    return (data ?? []) as ExpiredPaymentLinkRow[];
+  }
+
+  async insertExpiryAudit(row: PaymentLinkExpiryAuditRow): Promise<void> {
+    const client = this.supabaseService.getClient();
+    const { error } = await client.from('payment_link_expiry_audit').insert({
+      link_id: row.linkId,
+      previous_status: row.previousStatus,
+      new_status: row.newStatus,
+      expires_at: row.expiresAt,
+      processed_at: row.processedAt,
+      processed_by: row.processedBy,
+      run_id: row.runId,
+      note: row.note,
+    });
+
+    if (error) {
+      this.logger.warn(
+        `Failed to record expiry audit for ${row.linkId}: ${error.message}`,
+      );
+    }
+  }
+}

--- a/app/backend/src/receipts/receipt-metadata.repository.ts
+++ b/app/backend/src/receipts/receipt-metadata.repository.ts
@@ -1,0 +1,97 @@
+/**
+ * Receipt metadata repository port.
+ *
+ * Defines the persistence contract for indexer/database-backed receipt
+ * metadata. `ReceiptsService` depends on the `ReceiptMetadataRepository`
+ * interface (via the `RECEIPT_METADATA_REPOSITORY` DI token) rather than on a
+ * concrete storage implementation, so unit tests can substitute an in-memory
+ * fake without touching Supabase.
+ *
+ * The Supabase-backed adapter lives in the same file as the concrete
+ * `SupabaseReceiptMetadataRepository`.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SupabaseService } from '../supabase/supabase.service';
+
+export interface IndexerMetadata {
+  txHash: string;
+  submittedAt: string;
+  network: 'testnet' | 'mainnet';
+}
+
+// ---------------------------------------------------------------------------
+// Port
+// ---------------------------------------------------------------------------
+
+export interface ReceiptMetadataRepository {
+  /**
+   * Fetch indexer metadata for a transaction. Implementations must degrade
+   * gracefully to sensible defaults when the tx is not yet indexed (e.g. a
+   * new submission).
+   */
+  getIndexerMetadata(
+    txHash: string,
+    network: 'testnet' | 'mainnet',
+  ): Promise<IndexerMetadata>;
+}
+
+export const RECEIPT_METADATA_REPOSITORY = Symbol(
+  'RECEIPT_METADATA_REPOSITORY',
+);
+
+// ---------------------------------------------------------------------------
+// Supabase adapter
+// ---------------------------------------------------------------------------
+
+@Injectable()
+export class SupabaseReceiptMetadataRepository
+  implements ReceiptMetadataRepository
+{
+  private readonly logger = new Logger(SupabaseReceiptMetadataRepository.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async getIndexerMetadata(
+    txHash: string,
+    network: 'testnet' | 'mainnet',
+  ): Promise<IndexerMetadata> {
+    const defaults: IndexerMetadata = {
+      txHash,
+      submittedAt: new Date().toISOString(),
+      network,
+    };
+
+    // Best-effort lookup against the indexer `receipts` table. The table may
+    // not exist in all environments; fall back to defaults if so.
+    try {
+      const { data, error } = await this.supabase
+        .getClient()
+        .from('receipts')
+        .select('*')
+        .eq('tx_hash', txHash)
+        .maybeSingle();
+
+      if (error) {
+        this.logger.debug(
+          `receipts lookup failed for ${txHash}: ${error.message}`,
+        );
+        return defaults;
+      }
+
+      if (!data) return defaults;
+
+      return {
+        txHash,
+        submittedAt: String(data.created_at ?? defaults.submittedAt),
+        network,
+      };
+    } catch (err) {
+      this.logger.debug(
+        `receipts lookup threw for ${txHash}: ${(err as Error).message}`,
+      );
+      return defaults;
+    }
+  }
+}

--- a/app/backend/src/receipts/receipts.module.ts
+++ b/app/backend/src/receipts/receipts.module.ts
@@ -9,10 +9,24 @@ import { ReceiptsController } from "./receipts.controller";
 import { ReceiptsService } from "./receipts.service";
 import { ReceiptNormalizer } from "./normalizers/receipt.normalizer";
 import { ReceiptHashService } from "./receipt-hash.service";
+import { SupabaseModule } from "../supabase/supabase.module";
+import {
+  RECEIPT_METADATA_REPOSITORY,
+  SupabaseReceiptMetadataRepository,
+} from "./receipt-metadata.repository";
 
 @Module({
+  imports: [SupabaseModule],
   controllers: [ReceiptsController],
-  providers: [ReceiptsService, ReceiptNormalizer, ReceiptHashService],
+  providers: [
+    ReceiptsService,
+    ReceiptNormalizer,
+    ReceiptHashService,
+    {
+      provide: RECEIPT_METADATA_REPOSITORY,
+      useClass: SupabaseReceiptMetadataRepository,
+    },
+  ],
   exports: [ReceiptsService, ReceiptHashService],
 })
 export class ReceiptsModule {}

--- a/app/backend/src/receipts/receipts.service.ts
+++ b/app/backend/src/receipts/receipts.service.ts
@@ -12,6 +12,7 @@ import {
   Logger,
   NotFoundException,
   BadRequestException,
+  Inject,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
@@ -19,22 +20,33 @@ import {
   HorizonOperation,
   HorizonTransaction,
   SorobanRpcResult,
-  IndexerMetadata,
 } from './normalizers/receipt.normalizer';
 import { NormalizedReceipt } from './schemas/receipt.schema';
 import { GetReceiptByTxDto, GetReceiptsByAddressDto } from './dto/receipt.dto';
+import {
+  RECEIPT_METADATA_REPOSITORY,
+  type IndexerMetadata,
+  type ReceiptMetadataRepository,
+} from './receipt-metadata.repository';
 
 @Injectable()
 export class ReceiptsService {
   private readonly logger = new Logger(ReceiptsService.name);
   private readonly horizonUrl: string;
   private readonly sorobanRpcUrl: string;
+  private readonly network: 'testnet' | 'mainnet';
 
   constructor(
     private readonly normalizer: ReceiptNormalizer,
     private readonly config: ConfigService,
+    @Inject(RECEIPT_METADATA_REPOSITORY)
+    private readonly receiptMetadataRepository: ReceiptMetadataRepository,
   ) {
-    const network = this.config.get<string>('STELLAR_NETWORK', 'testnet');
+    const network = this.config.get<'testnet' | 'mainnet'>(
+      'STELLAR_NETWORK',
+      'testnet',
+    );
+    this.network = network;
     this.horizonUrl =
       network === 'mainnet'
         ? 'https://horizon.stellar.org'
@@ -199,17 +211,13 @@ export class ReceiptsService {
   }
 
   /**
-   * Fetches from the QuickEx indexer/database.
-   * Falls back to defaults if the tx isn't yet indexed (e.g. new submission).
+   * Fetches from the QuickEx indexer/database via the receipt metadata
+   * repository. Falls back to defaults if the tx isn't yet indexed (e.g. new
+   * submission).
    */
-  private async fetchIndexerMetadata(txHash: string): Promise<IndexerMetadata> {
-    // TODO: replace with actual Supabase/database call
-    // e.g. await this.supabase.from('receipts').select('*').eq('tx_hash', txHash).single()
-    const network = this.config.get<'testnet' | 'mainnet'>('STELLAR_NETWORK', 'testnet');
-    return {
-      txHash,
-      submittedAt: new Date().toISOString(),
-      network,
-    };
+  private async fetchIndexerMetadata(
+    txHash: string,
+  ): Promise<IndexerMetadata> {
+    return this.receiptMetadataRepository.getIndexerMetadata(txHash, this.network);
   }
 }

--- a/app/backend/src/transaction-timeline/transaction-timeline.module.ts
+++ b/app/backend/src/transaction-timeline/transaction-timeline.module.ts
@@ -3,6 +3,10 @@ import { TransactionTimelineController } from './transaction-timeline.controller
 import { TransactionTimelineService } from './transaction-timeline.service';
 import { SupabaseModule } from '../supabase/supabase.module';
 import { TransactionsModule } from '../transactions/transactions.module';
+import {
+  SupabaseTransactionTimelineRepository,
+  TRANSACTION_TIMELINE_REPOSITORY,
+} from './transaction-timeline.repository';
 
 @Module({
   imports: [
@@ -10,7 +14,13 @@ import { TransactionsModule } from '../transactions/transactions.module';
     TransactionsModule,   // provides HorizonService
   ],
   controllers: [TransactionTimelineController],
-  providers: [TransactionTimelineService],
+  providers: [
+    TransactionTimelineService,
+    {
+      provide: TRANSACTION_TIMELINE_REPOSITORY,
+      useClass: SupabaseTransactionTimelineRepository,
+    },
+  ],
   exports: [TransactionTimelineService],
 })
 export class TransactionTimelineModule {}

--- a/app/backend/src/transaction-timeline/transaction-timeline.repository.ts
+++ b/app/backend/src/transaction-timeline/transaction-timeline.repository.ts
@@ -1,0 +1,162 @@
+/**
+ * Transaction timeline repository port.
+ *
+ * Defines the persistence contract for the database-backed sources aggregated
+ * by `TransactionTimelineService` (payment records, refund attempts, webhook
+ * notification logs, and contract change webhooks). The service depends on the
+ * `TransactionTimelineRepository` interface (via the
+ * `TRANSACTION_TIMELINE_REPOSITORY` DI token) rather than on Supabase directly.
+ *
+ * The Supabase-backed adapter lives in the same file as the concrete
+ * `SupabaseTransactionTimelineRepository`.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SupabaseService } from '../supabase/supabase.service';
+
+export interface TimelinePaymentRecordRow {
+  id: string;
+  status: string | null;
+  created_at: string;
+  amount: string | number | null;
+  asset_code: string | null;
+  sender_address: string | null;
+  receiver_address: string | null;
+}
+
+export interface TimelineRefundAttemptRow {
+  id: string;
+  entity_type: string | null;
+  entity_id: string | null;
+  reason_code: string | null;
+  status: string | null;
+  actor_id: string | null;
+  created_at: string;
+}
+
+export interface TimelineNotificationLogRow {
+  id: string;
+  event_type: string | null;
+  event_id: string | null;
+  status: string | null;
+  attempts: number | null;
+  last_error: string | null;
+  webhook_response_status: number | null;
+  webhook_delivered_at: string | null;
+  created_at: string;
+}
+
+export interface TimelineContractWebhookRow {
+  id: string;
+  webhook_url: string | null;
+  enabled: boolean | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Port
+// ---------------------------------------------------------------------------
+
+export interface TransactionTimelineRepository {
+  /** Payment records matching a transaction hash (fallback when no address). */
+  getPaymentRecordsByTxHash(txHash: string): Promise<TimelinePaymentRecordRow[]>;
+
+  /** Refund attempts correlated with a transaction hash. */
+  getRefundAttempts(txHash: string): Promise<TimelineRefundAttemptRow[]>;
+
+  /** Webhook delivery notification logs for a public key / tx hash. */
+  getNotificationLogs(
+    txHash: string,
+    publicKey: string,
+    limit?: number,
+  ): Promise<TimelineNotificationLogRow[]>;
+
+  /** Enabled contract change webhooks (best-effort contract signal). */
+  getEnabledContractWebhooks(limit?: number): Promise<TimelineContractWebhookRow[]>;
+}
+
+export const TRANSACTION_TIMELINE_REPOSITORY = Symbol(
+  'TRANSACTION_TIMELINE_REPOSITORY',
+);
+
+// ---------------------------------------------------------------------------
+// Supabase adapter
+// ---------------------------------------------------------------------------
+
+@Injectable()
+export class SupabaseTransactionTimelineRepository
+  implements TransactionTimelineRepository
+{
+  private readonly logger = new Logger(SupabaseTransactionTimelineRepository.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async getPaymentRecordsByTxHash(
+    txHash: string,
+  ): Promise<TimelinePaymentRecordRow[]> {
+    const client = this.supabase.getClient();
+    const { data, error } = await client
+      .from('payment_records')
+      .select('id, status, created_at, amount, asset_code, sender_address, receiver_address')
+      .eq('tx_hash', txHash);
+
+    if (error) throw error;
+    return (data ?? []) as TimelinePaymentRecordRow[];
+  }
+
+  async getRefundAttempts(txHash: string): Promise<TimelineRefundAttemptRow[]> {
+    const client = this.supabase.getClient();
+    const { data, error } = await client
+      .from('refund_attempts')
+      .select('id, entity_type, entity_id, reason_code, status, actor_id, created_at')
+      .or(`entity_id.eq.${txHash},id.eq.${txHash}`);
+
+    if (error) throw error;
+    return (data ?? []) as TimelineRefundAttemptRow[];
+  }
+
+  async getNotificationLogs(
+    txHash: string,
+    publicKey: string,
+    limit = 50,
+  ): Promise<TimelineNotificationLogRow[]> {
+    const client = this.supabase.getClient();
+    const { data, error } = await client
+      .from('notification_log')
+      .select(
+        'id, event_type, event_id, status, attempts, last_error, webhook_response_status, webhook_delivered_at, created_at',
+      )
+      .eq('public_key', publicKey)
+      .eq('channel', 'webhook')
+      .ilike('event_id', `%${txHash}%`)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error) throw error;
+    return (data ?? []) as TimelineNotificationLogRow[];
+  }
+
+  async getEnabledContractWebhooks(
+    limit = 10,
+  ): Promise<TimelineContractWebhookRow[]> {
+    const client = this.supabase.getClient();
+    const { data, error } = await client
+      .from('contract_change_webhooks')
+      .select('id, webhook_url, enabled, created_at, updated_at')
+      .eq('enabled', true)
+      .order('updated_at', { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      // Table may not exist yet in all environments — degrade gracefully
+      this.logger.debug(
+        `contract_change_webhooks query failed: ${error.message}`,
+      );
+      return [];
+    }
+
+    return (data ?? []) as TimelineContractWebhookRow[];
+  }
+}

--- a/app/backend/src/transaction-timeline/transaction-timeline.service.ts
+++ b/app/backend/src/transaction-timeline/transaction-timeline.service.ts
@@ -1,5 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { SupabaseService } from '../supabase/supabase.service';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { HorizonService } from '../transactions/horizon.service';
 import type {
   TimelineItem,
@@ -9,13 +8,18 @@ import type {
   WebhookTimelineDetail,
 } from './transaction-timeline.types';
 import type { GetTimelineQueryDto } from './dto/get-timeline.dto';
+import {
+  TRANSACTION_TIMELINE_REPOSITORY,
+  type TransactionTimelineRepository,
+} from './transaction-timeline.repository';
 
 @Injectable()
 export class TransactionTimelineService {
   private readonly logger = new Logger(TransactionTimelineService.name);
 
   constructor(
-    private readonly supabase: SupabaseService,
+    @Inject(TRANSACTION_TIMELINE_REPOSITORY)
+    private readonly timelineRepository: TransactionTimelineRepository,
     private readonly horizonService: HorizonService,
   ) {}
 
@@ -133,18 +137,12 @@ export class TransactionTimelineService {
     });
   }
 
-  /** Fallback: read payment_records from Supabase when no address is provided. */
+  /** Fallback: read payment_records from the repository when no address is provided. */
   private async collectPaymentItemsFromDb(txHash: string): Promise<TimelineItem[]> {
-    const client = this.supabase.getClient();
-    const { data, error } = await client
-      .from('payment_records')
-      .select('id, status, created_at, amount, asset_code, sender_address, receiver_address')
-      .eq('tx_hash', txHash);
+    const data = await this.timelineRepository.getPaymentRecordsByTxHash(txHash);
+    if (data.length === 0) return [];
 
-    if (error) throw error;
-    if (!data || data.length === 0) return [];
-
-    return (data as Record<string, unknown>[]).map<TimelineItem>((row, idx) => {
+    return data.map<TimelineItem>((row, idx) => {
       const detail: PaymentTimelineDetail = {
         txHash,
         amount: String(row.amount ?? '0'),
@@ -181,20 +179,12 @@ export class TransactionTimelineService {
   // ── Refund source ─────────────────────────────────────────────────────────
 
   private async collectRefundItems(txHash: string): Promise<TimelineItem[]> {
-    const client = this.supabase.getClient();
-
     // Refunds are correlated via entity_id (which is either a payment/link ID)
-    // or via notes/correlation stored on the record. We join on tx_hash where
-    // possible (column may not exist yet; fall back gracefully).
-    const { data, error } = await client
-      .from('refund_attempts')
-      .select('id, entity_type, entity_id, reason_code, status, actor_id, created_at')
-      .or(`entity_id.eq.${txHash},id.eq.${txHash}`);
+    // or via notes/correlation stored on the record.
+    const data = await this.timelineRepository.getRefundAttempts(txHash);
+    if (data.length === 0) return [];
 
-    if (error) throw error;
-    if (!data || data.length === 0) return [];
-
-    return (data as Record<string, unknown>[]).map<TimelineItem>((row) => {
+    return data.map<TimelineItem>((row) => {
       const detail: RefundTimelineDetail = {
         refundId: String(row.id),
         entityType: String(row.entity_type),
@@ -234,23 +224,14 @@ export class TransactionTimelineService {
     txHash: string,
     address: string,
   ): Promise<TimelineItem[]> {
-    const client = this.supabase.getClient();
-
     // Webhook logs are keyed by event_id. For payment events the event_id is
     // typically the tx hash or a derivative. We do a best-effort match.
-    const { data, error } = await client
-      .from('notification_log')
-      .select(
-        'id, event_type, event_id, status, attempts, last_error, webhook_response_status, webhook_delivered_at, created_at',
-      )
-      .eq('public_key', address)
-      .eq('channel', 'webhook')
-      .ilike('event_id', `%${txHash}%`)
-      .order('created_at', { ascending: false })
-      .limit(50);
-
-    if (error) throw error;
-    if (!data || data.length === 0) return [];
+    const data = await this.timelineRepository.getNotificationLogs(
+      txHash,
+      address,
+      50,
+    );
+    if (data.length === 0) return [];
 
     const statusMap: Record<string, TimelineItem['status']> = {
       sent: 'success',
@@ -259,7 +240,7 @@ export class TransactionTimelineService {
       dlq: 'dlq',
     };
 
-    return (data as Record<string, unknown>[]).map<TimelineItem>((row) => {
+    return data.map<TimelineItem>((row) => {
       const detail: WebhookTimelineDetail = {
         webhookLogId: String(row.id),
         eventType: String(row.event_type),
@@ -293,27 +274,14 @@ export class TransactionTimelineService {
   // ── Contract event source ─────────────────────────────────────────────────
 
   private async collectContractItems(txHash: string): Promise<TimelineItem[]> {
-    const client = this.supabase.getClient();
-
     // Contract change webhooks don't store tx_hash natively; we pull
     // recent enabled webhooks as a best-effort signal.
     // A real production query would join through an event log table.
-    const { data, error } = await client
-      .from('contract_change_webhooks')
-      .select('id, webhook_url, enabled, created_at, updated_at')
-      .eq('enabled', true)
-      .order('updated_at', { ascending: false })
-      .limit(10);
+    const data = await this.timelineRepository.getEnabledContractWebhooks(10);
 
-    if (error) {
-      // Table may not exist yet in all environments — degrade gracefully
-      this.logger.debug(`contract_change_webhooks query failed: ${error.message}`);
-      return [];
-    }
+    if (data.length === 0) return [];
 
-    if (!data || data.length === 0) return [];
-
-    return (data as Record<string, unknown>[]).map<TimelineItem>((row) => ({
+    return data.map<TimelineItem>((row) => ({
       id: `ctr_${row.id as string}_${txHash}`,
       kind: 'contract_event',
       timestamp: String(row.updated_at ?? row.created_at),

--- a/app/backend/src/transaction-timeline/transaction-timeline.service.unit.spec.ts
+++ b/app/backend/src/transaction-timeline/transaction-timeline.service.unit.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { TransactionTimelineService } from "./transaction-timeline.service";
-import { SupabaseService } from "../supabase/supabase.service";
+import { TRANSACTION_TIMELINE_REPOSITORY } from "./transaction-timeline.repository";
 import { HorizonService } from "../transactions/horizon.service";
 import type { TimelineResponse } from "./transaction-timeline.types";
 
@@ -12,7 +12,7 @@ function makeHorizonResp(items: object[] = []) {
   return { items, nextCursor: undefined };
 }
 
-function buildSupabaseMock(
+function buildTimelineRepositoryMock(
   overrides: {
     payment?: object[] | null;
     refund?: object[] | null;
@@ -24,58 +24,24 @@ function buildSupabaseMock(
     contractError?: object;
   } = {},
 ) {
-  const makeChain = (rows: object[] | null, err: object | null = null) => {
-    const chain: Record<string, jest.Mock> = {};
-    // Every chain method returns `chain` for further chaining AND resolves as a
-    // thenable so that `await client.from(...).select(...).eq(...)` works even
-    // when the last chained call is not `.limit()`.
-    const thenable = {
-      then: jest.fn((resolve: (v: unknown) => void) =>
-        resolve({ data: rows, error: err }),
-      ),
-    };
-    for (const key of [
-      "select",
-      "from",
-      "eq",
-      "or",
-      "ilike",
-      "order",
-      "limit",
-    ]) {
-      chain[key] = jest.fn().mockReturnValue(chain);
-    }
-    // Make the chain itself thenable so any terminal call resolves
-    Object.assign(chain, { then: thenable.then });
-    return chain;
-  };
-
-  const tableChains: Record<string, ReturnType<typeof makeChain>> = {
-    payment_records: makeChain(
-      overrides.payment ?? [],
-      overrides.paymentError ?? null,
-    ),
-    refund_attempts: makeChain(
-      overrides.refund ?? [],
-      overrides.refundError ?? null,
-    ),
-    notification_log: makeChain(
-      overrides.webhook ?? [],
-      overrides.webhookError ?? null,
-    ),
-    contract_change_webhooks: makeChain(
-      overrides.contract ?? [],
-      overrides.contractError ?? null,
-    ),
-  };
-
-  const getClient = jest.fn(() => ({
-    from: jest.fn((table: string) => {
-      return tableChains[table] ?? makeChain([]);
+  return {
+    getPaymentRecordsByTxHash: jest.fn(async () => {
+      if (overrides.paymentError) throw overrides.paymentError;
+      return overrides.payment ?? [];
     }),
-  }));
-
-  return { getClient };
+    getRefundAttempts: jest.fn(async () => {
+      if (overrides.refundError) throw overrides.refundError;
+      return overrides.refund ?? [];
+    }),
+    getNotificationLogs: jest.fn(async () => {
+      if (overrides.webhookError) throw overrides.webhookError;
+      return overrides.webhook ?? [];
+    }),
+    getEnabledContractWebhooks: jest.fn(async () => {
+      if (overrides.contractError) throw overrides.contractError;
+      return overrides.contract ?? [];
+    }),
+  };
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -85,7 +51,7 @@ describe("TransactionTimelineService", () => {
   let horizonService: { getPayments: jest.Mock };
 
   async function init(
-    supabaseMock: ReturnType<typeof buildSupabaseMock>,
+    timelineRepositoryMock: ReturnType<typeof buildTimelineRepositoryMock>,
     horizonMock?: object,
   ) {
     horizonService = {
@@ -97,7 +63,10 @@ describe("TransactionTimelineService", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionTimelineService,
-        { provide: SupabaseService, useValue: supabaseMock },
+        {
+          provide: TRANSACTION_TIMELINE_REPOSITORY,
+          useValue: timelineRepositoryMock,
+        },
         { provide: HorizonService, useValue: horizonService },
       ],
     }).compile();
@@ -155,7 +124,7 @@ describe("TransactionTimelineService", () => {
       ];
 
       await init(
-        buildSupabaseMock({
+        buildTimelineRepositoryMock({
           payment: paymentRows,
           refund: refundRows,
           webhook: webhookRows,
@@ -210,7 +179,7 @@ describe("TransactionTimelineService", () => {
         },
       ];
 
-      await init(buildSupabaseMock({ refund: refundRows }));
+      await init(buildTimelineRepositoryMock({ refund: refundRows }));
 
       const result = await service.getTimeline({
         txHash: TX_HASH,
@@ -248,7 +217,7 @@ describe("TransactionTimelineService", () => {
         },
       ];
 
-      await init(buildSupabaseMock({ refund: refundRows }));
+      await init(buildTimelineRepositoryMock({ refund: refundRows }));
 
       const result = await service.getTimeline({
         txHash: TX_HASH,
@@ -265,7 +234,7 @@ describe("TransactionTimelineService", () => {
   describe("partial timeline", () => {
     it("returns isPartial=true when one source throws", async () => {
       await init(
-        buildSupabaseMock({
+        buildTimelineRepositoryMock({
           refundError: { message: "DB error", code: "PGRST000" },
         }),
       );
@@ -292,7 +261,7 @@ describe("TransactionTimelineService", () => {
       ];
 
       await init(
-        buildSupabaseMock({
+        buildTimelineRepositoryMock({
           refundError: { message: "DB error", code: "PGRST000" },
           webhook: webhookRows,
         }),
@@ -309,7 +278,7 @@ describe("TransactionTimelineService", () => {
     });
 
     it("returns empty items array (not an error) when all sources have no data", async () => {
-      await init(buildSupabaseMock({}));
+      await init(buildTimelineRepositoryMock({}));
 
       const result = await service.getTimeline({ txHash: TX_HASH });
 
@@ -335,7 +304,7 @@ describe("TransactionTimelineService", () => {
         },
       ];
 
-      await init(buildSupabaseMock({ refund: refundRows }));
+      await init(buildTimelineRepositoryMock({ refund: refundRows }));
 
       const result = await service.getTimeline({
         txHash: TX_HASH,
@@ -361,7 +330,7 @@ describe("TransactionTimelineService", () => {
         created_at: `2024-01-${String(k + 1).padStart(2, "0")}T00:00:00Z`,
       }));
 
-      await init(buildSupabaseMock({ refund: refundRows }));
+      await init(buildTimelineRepositoryMock({ refund: refundRows }));
 
       const result = await service.getTimeline({
         txHash: TX_HASH,
@@ -392,7 +361,7 @@ describe("TransactionTimelineService", () => {
         },
       ];
 
-      await init(buildSupabaseMock({}), makeHorizonResp(horizonItems));
+      await init(buildTimelineRepositoryMock({}), makeHorizonResp(horizonItems));
 
       const result = await service.getTimeline({
         txHash: TX_HASH,
@@ -421,7 +390,7 @@ describe("TransactionTimelineService", () => {
         },
       ];
 
-      await init(buildSupabaseMock({ refund: refundRows }));
+      await init(buildTimelineRepositoryMock({ refund: refundRows }));
 
       const result = await service.getTimeline({
         txHash: TX_HASH,
@@ -450,7 +419,7 @@ describe("TransactionTimelineService", () => {
         },
       ];
 
-      await init(buildSupabaseMock({ refund: refundRows }));
+      await init(buildTimelineRepositoryMock({ refund: refundRows }));
 
       const result = await service.getTimeline({ txHash: TX_HASH });
 

--- a/app/backend/src/usernames/cache/discovery-cache.service.ts
+++ b/app/backend/src/usernames/cache/discovery-cache.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { LRUCache } from 'lru-cache';
-import { SearchProfileResult, TrendingCreatorResult } from '../../supabase/supabase.service';
+import {
+  SearchProfileResult,
+  TrendingCreatorResult,
+} from '../usernames.repository';
 
 interface CachedSearchResult {
   results: SearchProfileResult[];

--- a/app/backend/src/usernames/usernames.module.ts
+++ b/app/backend/src/usernames/usernames.module.ts
@@ -4,11 +4,22 @@ import { SupabaseModule } from "../supabase/supabase.module";
 import { UsernamesController } from "./usernames.controller";
 import { UsernamesService } from "./usernames.service";
 import { DiscoveryCacheService } from "./cache/discovery-cache.service";
+import {
+  SupabaseUsernamesRepository,
+  USERNAMES_REPOSITORY,
+} from "./usernames.repository";
 
 @Module({
   imports: [SupabaseModule],
   controllers: [UsernamesController],
-  providers: [UsernamesService, DiscoveryCacheService],
+  providers: [
+    UsernamesService,
+    DiscoveryCacheService,
+    {
+      provide: USERNAMES_REPOSITORY,
+      useClass: SupabaseUsernamesRepository,
+    },
+  ],
   exports: [UsernamesService],
 })
 export class UsernamesModule {}

--- a/app/backend/src/usernames/usernames.repository.ts
+++ b/app/backend/src/usernames/usernames.repository.ts
@@ -1,0 +1,191 @@
+/**
+ * Usernames repository port.
+ *
+ * Defines the persistence contract the usernames domain depends on. Services
+ * depend on the `UsernamesRepository` interface (via the `USERNAMES_REPOSITORY`
+ * DI token) rather than on a concrete storage implementation, so unit tests can
+ * substitute an in-memory fake without touching Supabase.
+ *
+ * The Supabase-backed adapter lives in the same file as the concrete
+ * `SupabaseUsernamesRepository`.
+ */
+
+import { Injectable } from '@nestjs/common';
+
+import { SupabaseService } from '../supabase/supabase.service';
+import { SupabaseUniqueConstraintError } from '../supabase/supabase.errors';
+import { UsernameConflictError } from './errors';
+
+// ---------------------------------------------------------------------------
+// Domain types (persistence shape for the usernames domain)
+// ---------------------------------------------------------------------------
+
+export interface SearchProfileResult {
+  id: string;
+  username: string;
+  public_key: string;
+  created_at: string;
+  last_active_at: string | null;
+  is_public: boolean;
+  similarity_score?: number;
+}
+
+export interface TrendingCreatorResult extends SearchProfileResult {
+  transaction_volume: number;
+  transaction_count: number;
+}
+
+export interface FeaturedProfileResult extends SearchProfileResult {
+  featured_rank: number | null;
+}
+
+export interface MarketplaceListing {
+  id: string;
+  username: string;
+  seller_public_key: string;
+  asking_price: number;
+  status: 'active' | 'sold' | 'cancelled';
+  created_at: string;
+  updated_at: string;
+  sold_at: string | null;
+  buyer_public_key: string | null;
+  final_price: number | null;
+}
+
+export interface UsernameRow {
+  id: string;
+  username: string;
+  public_key: string;
+  created_at: string;
+}
+
+export interface ListingPage {
+  listings: MarketplaceListing[];
+  next_cursor: string | null;
+  has_more: boolean;
+  total: number;
+}
+
+// ---------------------------------------------------------------------------
+// Port
+// ---------------------------------------------------------------------------
+
+export interface UsernamesRepository {
+  /**
+   * Atomically claim a username and record the `username.claimed` domain event
+   * in the outbox. Throws `UsernameConflictError` on a unique violation.
+   */
+  claimUsernameWithOutbox(
+    username: string,
+    publicKey: string,
+    eventId: string,
+    payload: Record<string, unknown>,
+  ): Promise<void>;
+
+  countUsernamesByPublicKey(publicKey: string): Promise<number>;
+  listUsernamesByPublicKey(publicKey: string): Promise<UsernameRow[]>;
+  getUsername(username: string): Promise<SearchProfileResult | null>;
+
+  searchPublicUsernames(
+    query: string,
+    limit?: number,
+  ): Promise<SearchProfileResult[]>;
+  searchActiveListings(query: string, limit?: number): Promise<ListingPage>;
+  getTrendingCreators(
+    timeWindowHours: number,
+    limit?: number,
+  ): Promise<TrendingCreatorResult[]>;
+  getRecentlyActiveUsers(
+    timeWindowHours: number,
+    limit?: number,
+  ): Promise<SearchProfileResult[]>;
+  getFeaturedUsernames(limit?: number): Promise<FeaturedProfileResult[]>;
+  getPublicProfile(username: string): Promise<SearchProfileResult | null>;
+  togglePublicProfile(username: string, isPublic: boolean): Promise<void>;
+  updateUsernameActivity(username: string): Promise<void>;
+}
+
+export const USERNAMES_REPOSITORY = Symbol('USERNAMES_REPOSITORY');
+
+// ---------------------------------------------------------------------------
+// Supabase adapter
+// ---------------------------------------------------------------------------
+
+@Injectable()
+export class SupabaseUsernamesRepository implements UsernamesRepository {
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async claimUsernameWithOutbox(
+    username: string,
+    publicKey: string,
+    eventId: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      await this.supabase.claimUsernameWithOutbox(
+        username,
+        publicKey,
+        eventId,
+        payload,
+      );
+    } catch (error) {
+      if (error instanceof SupabaseUniqueConstraintError) {
+        throw new UsernameConflictError(username);
+      }
+      throw error;
+    }
+  }
+
+  countUsernamesByPublicKey(publicKey: string): Promise<number> {
+    return this.supabase.countUsernamesByPublicKey(publicKey);
+  }
+
+  listUsernamesByPublicKey(publicKey: string): Promise<UsernameRow[]> {
+    return this.supabase.listUsernamesByPublicKey(publicKey);
+  }
+
+  getUsername(username: string): Promise<SearchProfileResult | null> {
+    return this.supabase.getUsername(username);
+  }
+
+  searchPublicUsernames(
+    query: string,
+    limit?: number,
+  ): Promise<SearchProfileResult[]> {
+    return this.supabase.searchPublicUsernames(query, limit);
+  }
+
+  searchActiveListings(query: string, limit?: number): Promise<ListingPage> {
+    return this.supabase.searchActiveListings(query, limit);
+  }
+
+  getTrendingCreators(
+    timeWindowHours: number,
+    limit?: number,
+  ): Promise<TrendingCreatorResult[]> {
+    return this.supabase.getTrendingCreators(timeWindowHours, limit);
+  }
+
+  getRecentlyActiveUsers(
+    timeWindowHours: number,
+    limit?: number,
+  ): Promise<SearchProfileResult[]> {
+    return this.supabase.getRecentlyActiveUsers(timeWindowHours, limit);
+  }
+
+  getFeaturedUsernames(limit?: number): Promise<FeaturedProfileResult[]> {
+    return this.supabase.getFeaturedUsernames(limit);
+  }
+
+  getPublicProfile(username: string): Promise<SearchProfileResult | null> {
+    return this.supabase.getPublicProfile(username);
+  }
+
+  togglePublicProfile(username: string, isPublic: boolean): Promise<void> {
+    return this.supabase.togglePublicProfile(username, isPublic);
+  }
+
+  updateUsernameActivity(username: string): Promise<void> {
+    return this.supabase.updateUsernameActivity(username);
+  }
+}

--- a/app/backend/src/usernames/usernames.service.cache-invalidation.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.cache-invalidation.unit.spec.ts
@@ -1,18 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsernamesService } from './usernames.service';
-import { SupabaseService } from '../supabase/supabase.service';
+import { USERNAMES_REPOSITORY } from './usernames.repository';
 import { AppConfigService } from '../config';
 import { DiscoveryCacheService } from './cache/discovery-cache.service';
 import { UsernameValidationError } from './errors';
 
 describe('UsernamesService - Cache Invalidation', () => {
   let service: UsernamesService;
-  let supabaseMock: jest.Mocked<Partial<SupabaseService>>;
+  let usernamesRepositoryMock: Record<string, jest.Mock>;
   let cacheMock: jest.Mocked<Partial<DiscoveryCacheService>>;
   let configMock: Partial<AppConfigService>;
 
   beforeEach(async () => {
-    supabaseMock = {
+    usernamesRepositoryMock = {
       searchPublicUsernames: jest.fn(),
       getTrendingCreators: jest.fn(),
       getRecentlyActiveUsers: jest.fn(),
@@ -41,12 +41,12 @@ describe('UsernamesService - Cache Invalidation', () => {
 
     configMock = { maxUsernamesPerWallet: 5 };
 
-    supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
+    usernamesRepositoryMock.updateUsernameActivity!.mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UsernamesService,
-        { provide: SupabaseService, useValue: supabaseMock },
+        { provide: USERNAMES_REPOSITORY, useValue: usernamesRepositoryMock },
         { provide: AppConfigService, useValue: configMock },
         { provide: DiscoveryCacheService, useValue: cacheMock },
       ],
@@ -61,10 +61,10 @@ describe('UsernamesService - Cache Invalidation', () => {
 
   describe('togglePublicProfile invalidation', () => {
     it('calls invalidateForUsername after successful toggle', async () => {
-      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([
+      usernamesRepositoryMock.listUsernamesByPublicKey!.mockResolvedValue([
         { id: '1', username: 'alice', public_key: 'pk1', created_at: '' },
       ]);
-      supabaseMock.togglePublicProfile!.mockResolvedValue();
+      usernamesRepositoryMock.togglePublicProfile!.mockResolvedValue(undefined);
 
       await service.togglePublicProfile('alice', 'pk1', true);
 
@@ -72,10 +72,10 @@ describe('UsernamesService - Cache Invalidation', () => {
     });
 
     it('normalizes username before invalidation', async () => {
-      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([
+      usernamesRepositoryMock.listUsernamesByPublicKey!.mockResolvedValue([
         { id: '1', username: 'alice', public_key: 'pk1', created_at: '' },
       ]);
-      supabaseMock.togglePublicProfile!.mockResolvedValue();
+      usernamesRepositoryMock.togglePublicProfile!.mockResolvedValue(undefined);
 
       await service.togglePublicProfile('Alice', 'pk1', false);
 
@@ -83,7 +83,7 @@ describe('UsernamesService - Cache Invalidation', () => {
     });
 
     it('does not invalidate cache when username not found', async () => {
-      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([]);
+      usernamesRepositoryMock.listUsernamesByPublicKey!.mockResolvedValue([]);
 
       await expect(
         service.togglePublicProfile('ghost', 'pk1', true),
@@ -93,13 +93,13 @@ describe('UsernamesService - Cache Invalidation', () => {
     });
 
     it('does not call Supabase toggle when username not found', async () => {
-      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([]);
+      usernamesRepositoryMock.listUsernamesByPublicKey!.mockResolvedValue([]);
 
       await expect(
         service.togglePublicProfile('ghost', 'pk1', true),
       ).rejects.toThrow();
 
-      expect(supabaseMock.togglePublicProfile).not.toHaveBeenCalled();
+      expect(usernamesRepositoryMock.togglePublicProfile).not.toHaveBeenCalled();
     });
   });
 
@@ -119,22 +119,22 @@ describe('UsernamesService - Cache Invalidation', () => {
       const result = await service.getPublicProfile('alice');
 
       expect(result).toEqual(profile);
-      expect(supabaseMock.getPublicProfile).not.toHaveBeenCalled();
+      expect(usernamesRepositoryMock.getPublicProfile).not.toHaveBeenCalled();
       expect(cacheMock.setProfile).not.toHaveBeenCalled();
     });
 
     it('fetches from Supabase and caches on miss', async () => {
-      supabaseMock.getPublicProfile!.mockResolvedValue(profile);
+      usernamesRepositoryMock.getPublicProfile!.mockResolvedValue(profile);
 
       const result = await service.getPublicProfile('alice');
 
       expect(result).toEqual(profile);
-      expect(supabaseMock.getPublicProfile).toHaveBeenCalledWith('alice');
+      expect(usernamesRepositoryMock.getPublicProfile).toHaveBeenCalledWith('alice');
       expect(cacheMock.setProfile).toHaveBeenCalledWith('alice', profile);
     });
 
     it('does not cache null profiles', async () => {
-      supabaseMock.getPublicProfile!.mockResolvedValue(null);
+      usernamesRepositoryMock.getPublicProfile!.mockResolvedValue(null);
 
       const result = await service.getPublicProfile('ghost');
 
@@ -143,12 +143,12 @@ describe('UsernamesService - Cache Invalidation', () => {
     });
 
     it('normalizes username before lookup', async () => {
-      supabaseMock.getPublicProfile!.mockResolvedValue(profile);
+      usernamesRepositoryMock.getPublicProfile!.mockResolvedValue(profile);
 
       await service.getPublicProfile('Alice');
 
       expect(cacheMock.getProfile).toHaveBeenCalledWith('alice');
-      expect(supabaseMock.getPublicProfile).toHaveBeenCalledWith('alice');
+      expect(usernamesRepositoryMock.getPublicProfile).toHaveBeenCalledWith('alice');
     });
   });
 
@@ -158,25 +158,25 @@ describe('UsernamesService - Cache Invalidation', () => {
         { id: '1', username: 'alice', public_key: 'pk', created_at: '', last_active_at: null, is_public: true },
       ];
       cacheMock.getSearchResults!.mockReturnValue(cached);
-      supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
+      usernamesRepositoryMock.updateUsernameActivity!.mockResolvedValue(undefined);
 
       const result = await service.searchPublicUsernames('alice', 10);
 
       expect(result.data).toEqual(cached);
-      expect(supabaseMock.searchPublicUsernames).not.toHaveBeenCalled();
+      expect(usernamesRepositoryMock.searchPublicUsernames).not.toHaveBeenCalled();
     });
 
     it('fetches from Supabase and caches on miss', async () => {
       const fresh = [
         { id: '1', username: 'alice', public_key: 'pk', created_at: '', last_active_at: null, is_public: true },
       ];
-      supabaseMock.searchPublicUsernames!.mockResolvedValue(fresh);
-      supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
-      supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
+      usernamesRepositoryMock.searchPublicUsernames!.mockResolvedValue(fresh);
+      usernamesRepositoryMock.updateUsernameActivity!.mockResolvedValue(undefined);
+      usernamesRepositoryMock.updateUsernameActivity!.mockResolvedValue(undefined);
 
       await service.searchPublicUsernames('alice', 10);
 
-      expect(supabaseMock.searchPublicUsernames).toHaveBeenCalled();
+      expect(usernamesRepositoryMock.searchPublicUsernames).toHaveBeenCalled();
       expect(cacheMock.setSearchResults).toHaveBeenCalled();
     });
   });
@@ -188,7 +188,7 @@ describe('UsernamesService - Cache Invalidation', () => {
       const result = await service.getTrendingCreators(24, 10);
 
       expect(result.data).toEqual([]);
-      expect(supabaseMock.getTrendingCreators).not.toHaveBeenCalled();
+      expect(usernamesRepositoryMock.getTrendingCreators).not.toHaveBeenCalled();
     });
   });
 
@@ -199,7 +199,7 @@ describe('UsernamesService - Cache Invalidation', () => {
       const result = await service.getRecentlyActiveUsers(24, 10);
 
       expect(result.data).toEqual([]);
-      expect(supabaseMock.getRecentlyActiveUsers).not.toHaveBeenCalled();
+      expect(usernamesRepositoryMock.getRecentlyActiveUsers).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/backend/src/usernames/usernames.service.public-profile.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.public-profile.unit.spec.ts
@@ -1,18 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsernamesService } from './usernames.service';
-import { SupabaseService } from '../supabase/supabase.service';
+import { USERNAMES_REPOSITORY } from './usernames.repository';
 import { AppConfigService } from '../config/app-config.service';
 import { DiscoveryCacheService } from './cache/discovery-cache.service';
 import { UsernameValidationError } from './errors';
 
 describe('UsernamesService - Public Profile Discovery', () => {
   let service: UsernamesService;
-  let supabaseMock: jest.Mocked<Partial<SupabaseService>>;
+  let usernamesRepositoryMock: Record<string, jest.Mock>;
   let configMock: Partial<AppConfigService>;
   let discoveryCacheMock: jest.Mocked<Partial<DiscoveryCacheService>>;
 
   beforeEach(async () => {
-    supabaseMock = {
+    usernamesRepositoryMock = {
       searchPublicUsernames: jest.fn(),
       searchActiveListings: jest.fn(),
       getTrendingCreators: jest.fn(),
@@ -45,7 +45,7 @@ describe('UsernamesService - Public Profile Discovery', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UsernamesService,
-        { provide: SupabaseService, useValue: supabaseMock },
+        { provide: USERNAMES_REPOSITORY, useValue: usernamesRepositoryMock },
         { provide: AppConfigService, useValue: configMock },
         { provide: DiscoveryCacheService, useValue: discoveryCacheMock },
       ],
@@ -65,14 +65,14 @@ describe('UsernamesService - Public Profile Discovery', () => {
         { id: '2', username: 'alicen', public_key: 'pk2', created_at: '', last_active_at: '', is_public: true, similarity_score: 85 },
       ];
 
-      supabaseMock.searchPublicUsernames!.mockResolvedValue(mockResults);
-      supabaseMock.updateUsernameActivity!.mockResolvedValue(undefined);
+      usernamesRepositoryMock.searchPublicUsernames!.mockResolvedValue(mockResults);
+      usernamesRepositoryMock.updateUsernameActivity!.mockResolvedValue(undefined);
 
       const res = await service.searchPublicUsernames('alice', 10);
       expect(res.data).toHaveLength(2);
       expect(res.data[0].username).toBe('alice');
-      expect(supabaseMock.updateUsernameActivity).toHaveBeenCalledWith('alice');
-      expect(supabaseMock.searchPublicUsernames).toHaveBeenCalledWith('alice', 11);
+      expect(usernamesRepositoryMock.updateUsernameActivity).toHaveBeenCalledWith('alice');
+      expect(usernamesRepositoryMock.searchPublicUsernames).toHaveBeenCalledWith('alice', 11);
     });
 
     it('throws for short queries', async () => {
@@ -83,10 +83,10 @@ describe('UsernamesService - Public Profile Discovery', () => {
 
   describe('searchDiscovery', () => {
     it('returns a mixed shared-result payload for profiles and listings', async () => {
-      supabaseMock.searchPublicUsernames!.mockResolvedValue([
+      usernamesRepositoryMock.searchPublicUsernames!.mockResolvedValue([
         { id: '1', username: 'alice', public_key: 'pk1', created_at: '2024-01-01', last_active_at: '2024-01-02', is_public: true, similarity_score: 95 },
       ]);
-      supabaseMock.searchActiveListings!.mockResolvedValue({
+      usernamesRepositoryMock.searchActiveListings!.mockResolvedValue({
         listings: [
           { id: 'listing-1', username: 'alice', seller_public_key: 'pk2', asking_price: 250, status: 'active', created_at: '2024-01-03', updated_at: '2024-01-03', sold_at: null, buyer_public_key: null, final_price: null },
         ],
@@ -112,16 +112,16 @@ describe('UsernamesService - Public Profile Discovery', () => {
       expect(res.total).toBe(0);
       expect(res.empty).toBe(true);
       expect(res.has_more).toBe(false);
-      expect(supabaseMock.searchPublicUsernames).not.toHaveBeenCalled();
-      expect(supabaseMock.searchActiveListings).not.toHaveBeenCalled();
+      expect(usernamesRepositoryMock.searchPublicUsernames).not.toHaveBeenCalled();
+      expect(usernamesRepositoryMock.searchActiveListings).not.toHaveBeenCalled();
     });
   });
 
   describe('getTrendingCreators', () => {
     it('returns trending creators', async () => {
-      supabaseMock.getTrendingCreators!.mockResolvedValue([]);
+      usernamesRepositoryMock.getTrendingCreators!.mockResolvedValue([]);
       await service.getTrendingCreators(24, 10);
-      expect(supabaseMock.getTrendingCreators).toHaveBeenCalledWith(24, 11);
+      expect(usernamesRepositoryMock.getTrendingCreators).toHaveBeenCalledWith(24, 11);
     });
 
     it('throws on invalid time window', async () => {
@@ -132,15 +132,15 @@ describe('UsernamesService - Public Profile Discovery', () => {
 
   describe('togglePublicProfile', () => {
     it('toggles successfully', async () => {
-      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([{ id: '1', username: 'alice', public_key: 'pk1', created_at: '' }]);
-      supabaseMock.togglePublicProfile!.mockResolvedValue();
+      usernamesRepositoryMock.listUsernamesByPublicKey!.mockResolvedValue([{ id: '1', username: 'alice', public_key: 'pk1', created_at: '' }]);
+      usernamesRepositoryMock.togglePublicProfile!.mockResolvedValue(undefined);
 
       await expect(service.togglePublicProfile('alice', 'pk1', true)).resolves.toBeUndefined();
-      expect(supabaseMock.togglePublicProfile).toHaveBeenCalledWith('alice', true);
+      expect(usernamesRepositoryMock.togglePublicProfile).toHaveBeenCalledWith('alice', true);
     });
 
     it('throws if username not found', async () => {
-      supabaseMock.listUsernamesByPublicKey!.mockResolvedValue([]);
+      usernamesRepositoryMock.listUsernamesByPublicKey!.mockResolvedValue([]);
       await expect(service.togglePublicProfile('alice', 'pk1', true)).rejects.toThrow(UsernameValidationError);
     });
   });
@@ -148,15 +148,15 @@ describe('UsernamesService - Public Profile Discovery', () => {
   describe('getProfileByUsername', () => {
     it('returns the profile if found', async () => {
       const mockProfile = { id: '1', username: 'alice', public_key: 'pk1', created_at: '', last_active_at: '', is_public: true };
-      supabaseMock.getUsername!.mockResolvedValue(mockProfile);
+      usernamesRepositoryMock.getUsername!.mockResolvedValue(mockProfile);
 
       const res = await service.getProfileByUsername('alice');
       expect(res).toEqual(mockProfile);
-      expect(supabaseMock.getUsername).toHaveBeenCalledWith('alice');
+      expect(usernamesRepositoryMock.getUsername).toHaveBeenCalledWith('alice');
     });
 
     it('throws UsernameValidationError if not found', async () => {
-      supabaseMock.getUsername!.mockResolvedValue(null);
+      usernamesRepositoryMock.getUsername!.mockResolvedValue(null);
       await expect(service.getProfileByUsername('nonexistent')).rejects.toThrow(UsernameValidationError);
     });
   });

--- a/app/backend/src/usernames/usernames.service.ts
+++ b/app/backend/src/usernames/usernames.service.ts
@@ -1,13 +1,5 @@
-import { Injectable } from "@nestjs/common";
-import {
-  SupabaseService,
-  SearchProfileResult,
-  TrendingCreatorResult,
-  FeaturedProfileResult,
-  MarketplaceListing,
-} from "../supabase/supabase.service";
+import { Inject, Injectable } from "@nestjs/common";
 import { decodeCursor } from "../common/pagination/cursor.util";
-import { SupabaseUniqueConstraintError } from "../supabase/supabase.errors";
 import { AppConfigService } from "../config";
 import { DiscoveryCacheService } from "./cache/discovery-cache.service";
 import { buildDeterministicEventId } from "../events/outbox/outbox.types";
@@ -17,23 +9,25 @@ import {
   USERNAME_PATTERN,
 } from "./constants";
 import {
-  UsernameConflictError,
   UsernameLimitExceededError,
   UsernameValidationError,
   UsernameErrorCode,
 } from "./errors";
-
-export interface UsernameRow {
-  id: string;
-  username: string;
-  public_key: string;
-  created_at: string;
-}
+import {
+  USERNAMES_REPOSITORY,
+  type UsernamesRepository,
+  type SearchProfileResult,
+  type TrendingCreatorResult,
+  type FeaturedProfileResult,
+  type MarketplaceListing,
+  type UsernameRow,
+} from "./usernames.repository";
 
 @Injectable()
 export class UsernamesService {
   constructor(
-    private readonly supabase: SupabaseService,
+    @Inject(USERNAMES_REPOSITORY)
+    private readonly usernamesRepository: UsernamesRepository,
     private readonly config: AppConfigService,
     private readonly cache: DiscoveryCacheService,
   ) {}
@@ -81,23 +75,16 @@ export class UsernamesService {
       }
     }
 
-    try {
-      await this.supabase.claimUsernameWithOutbox(
-        normalized,
+    await this.usernamesRepository.claimUsernameWithOutbox(
+      normalized,
+      publicKey,
+      buildDeterministicEventId("username.claimed", normalized),
+      {
+        username: normalized,
         publicKey,
-        buildDeterministicEventId("username.claimed", normalized),
-        {
-          username: normalized,
-          publicKey,
-          timestamp: new Date().toISOString(),
-        },
-      );
-    } catch (error) {
-      if (error instanceof SupabaseUniqueConstraintError) {
-        throw new UsernameConflictError(normalized);
-      }
-      throw error;
-    }
+        timestamp: new Date().toISOString(),
+      },
+    );
 
     return { ok: true };
   }
@@ -106,16 +93,14 @@ export class UsernamesService {
    * Count usernames registered for a wallet (for limit enforcement).
    */
   async countByPublicKey(publicKey: string): Promise<number> {
-    return this.supabase.countUsernamesByPublicKey(publicKey);
+    return this.usernamesRepository.countUsernamesByPublicKey(publicKey);
   }
 
   /**
    * List usernames for a wallet.
    */
   async listByPublicKey(publicKey: string): Promise<UsernameRow[]> {
-    return this.supabase.listUsernamesByPublicKey(publicKey) as Promise<
-      UsernameRow[]
-    >;
+    return this.usernamesRepository.listUsernamesByPublicKey(publicKey);
   }
 
   async searchDiscovery(
@@ -140,8 +125,8 @@ export class UsernamesService {
     const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
 
     const [profilesResult, listingsResult] = await Promise.all([
-      this.supabase.searchPublicUsernames(normalizedQuery, fetchWindow),
-      this.supabase.searchActiveListings(normalizedQuery, fetchWindow),
+      this.usernamesRepository.searchPublicUsernames(normalizedQuery, fetchWindow),
+      this.usernamesRepository.searchActiveListings(normalizedQuery, fetchWindow),
     ]);
 
     const profileResults = profilesResult.map((profile) => ({
@@ -226,7 +211,7 @@ export class UsernamesService {
     if (cachedResults) {
       results = cachedResults;
     } else {
-      results = await this.supabase.searchPublicUsernames(
+      results = await this.usernamesRepository.searchPublicUsernames(
         normalizedQuery,
         fetchWindow,
       );
@@ -265,7 +250,7 @@ export class UsernamesService {
 
     // Update activity timestamp for clicked results (async, non-blocking)
     if (data.length > 0) {
-      this.supabase.updateUsernameActivity(data[0].username).catch(() => {
+      this.usernamesRepository.updateUsernameActivity(data[0].username).catch(() => {
         // Ignore errors - activity tracking is best-effort
       });
     }
@@ -300,7 +285,7 @@ export class UsernamesService {
     if (cachedResults) {
       results = cachedResults;
     } else {
-      results = await this.supabase.getTrendingCreators(
+      results = await this.usernamesRepository.getTrendingCreators(
         timeWindowHours,
         fetchWindow,
       );
@@ -370,7 +355,7 @@ export class UsernamesService {
     if (cachedResults) {
       results = cachedResults;
     } else {
-      results = await this.supabase.getRecentlyActiveUsers(
+      results = await this.usernamesRepository.getRecentlyActiveUsers(
         timeWindowHours,
         fetchWindow,
       );
@@ -429,7 +414,7 @@ export class UsernamesService {
 
     const effectiveLimit = Math.min(100, Math.max(1, limit));
     const fetchWindow = decodedCursor ? 100 : effectiveLimit + 1;
-    const results = await this.supabase.getFeaturedUsernames(fetchWindow);
+    const results = await this.usernamesRepository.getFeaturedUsernames(fetchWindow);
 
     let windowed = results;
     if (decodedCursor) {
@@ -482,7 +467,7 @@ export class UsernamesService {
     const cached = this.cache.getProfile(normalized);
     if (cached) return cached;
 
-    const profile = await this.supabase.getPublicProfile(normalized);
+    const profile = await this.usernamesRepository.getPublicProfile(normalized);
     if (profile) {
       this.cache.setProfile(normalized, profile);
     }
@@ -511,7 +496,7 @@ export class UsernamesService {
       );
     }
 
-    await this.supabase.togglePublicProfile(normalized, isPublic);
+    await this.usernamesRepository.togglePublicProfile(normalized, isPublic);
 
     // Invalidate all caches that may contain this username so visibility
     // changes are reflected immediately on subsequent reads.
@@ -522,7 +507,7 @@ export class UsernamesService {
     const normalized = this.normalizeUsername(username);
     this.validateFormat(normalized);
 
-    const result = await this.supabase.getUsername(normalized);
+    const result = await this.usernamesRepository.getUsername(normalized);
     if (!result) {
       throw new UsernameValidationError(
         UsernameErrorCode.NOT_FOUND,

--- a/app/backend/src/usernames/usernames.service.unit.spec.ts
+++ b/app/backend/src/usernames/usernames.service.unit.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsernamesService } from './usernames.service';
-import { SupabaseService } from '../supabase/supabase.service';
+import { USERNAMES_REPOSITORY } from './usernames.repository';
 import { AppConfigService } from '../config';
 import { DiscoveryCacheService } from './cache/discovery-cache.service';
 import {
@@ -8,13 +8,12 @@ import {
   UsernameLimitExceededError,
   UsernameValidationError,
 } from './errors';
-import { SupabaseUniqueConstraintError } from '../supabase/supabase.errors';
 
 describe('UsernamesService', () => {
   let service: UsernamesService;
   let configMaxPerWallet: number | undefined;
 
-  const mockSupabaseService = {
+  const mockUsernamesRepository = {
     claimUsernameWithOutbox: jest.fn(),
     countUsernamesByPublicKey: jest.fn(),
     listUsernamesByPublicKey: jest.fn(),
@@ -30,14 +29,14 @@ describe('UsernamesService', () => {
     configMaxPerWallet = undefined;
     jest.clearAllMocks();
     // Ensure updateUsernameActivity returns a promise so callers can `.catch()` safely
-    mockSupabaseService.updateUsernameActivity.mockResolvedValue(undefined);
+    mockUsernamesRepository.updateUsernameActivity.mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UsernamesService,
         {
-          provide: SupabaseService,
-          useValue: mockSupabaseService,
+          provide: USERNAMES_REPOSITORY,
+          useValue: mockUsernamesRepository,
         },
         {
           provide: AppConfigService,
@@ -109,10 +108,10 @@ describe('UsernamesService', () => {
 
   describe('create', () => {
     it('creates username and returns ok', async () => {
-      mockSupabaseService.claimUsernameWithOutbox.mockResolvedValueOnce(undefined);
+      mockUsernamesRepository.claimUsernameWithOutbox.mockResolvedValueOnce(undefined);
       const result = await service.create('alice_123', 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR');
       expect(result).toEqual({ ok: true });
-      expect(mockSupabaseService.claimUsernameWithOutbox).toHaveBeenCalledWith(
+      expect(mockUsernamesRepository.claimUsernameWithOutbox).toHaveBeenCalledWith(
         'alice_123',
         'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR',
         expect.any(String),
@@ -121,9 +120,9 @@ describe('UsernamesService', () => {
     });
 
     it('normalizes username to lowercase before insert', async () => {
-      mockSupabaseService.claimUsernameWithOutbox.mockResolvedValueOnce(undefined);
+      mockUsernamesRepository.claimUsernameWithOutbox.mockResolvedValueOnce(undefined);
       await service.create('Alice_99', 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR');
-      expect(mockSupabaseService.claimUsernameWithOutbox).toHaveBeenCalledWith(
+      expect(mockUsernamesRepository.claimUsernameWithOutbox).toHaveBeenCalledWith(
         'alice_99',
         expect.any(String),
         expect.any(String),
@@ -131,9 +130,9 @@ describe('UsernamesService', () => {
       );
     });
 
-    it('throws UsernameConflictError on unique violation (SupabaseUniqueConstraintError)', async () => {
-      mockSupabaseService.claimUsernameWithOutbox.mockRejectedValueOnce(
-        new SupabaseUniqueConstraintError('duplicate key')
+    it('throws UsernameConflictError on unique violation', async () => {
+      mockUsernamesRepository.claimUsernameWithOutbox.mockRejectedValueOnce(
+        new UsernameConflictError('taken')
       );
 
       await expect(
@@ -142,8 +141,8 @@ describe('UsernamesService', () => {
     });
 
     it('conflict error message mentions username is already taken', async () => {
-      mockSupabaseService.claimUsernameWithOutbox.mockRejectedValueOnce(
-        new SupabaseUniqueConstraintError('duplicate key')
+      mockUsernamesRepository.claimUsernameWithOutbox.mockRejectedValueOnce(
+        new UsernameConflictError('taken')
       );
       try {
         await service.create('taken', 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR');
@@ -162,7 +161,7 @@ describe('UsernamesService', () => {
 
     it('throws UsernameLimitExceededError when wallet at limit', async () => {
       configMaxPerWallet = 2;
-      mockSupabaseService.countUsernamesByPublicKey.mockResolvedValueOnce(2);
+      mockUsernamesRepository.countUsernamesByPublicKey.mockResolvedValueOnce(2);
 
       await expect(
         service.create('newuser', 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR'),
@@ -180,7 +179,7 @@ describe('UsernamesService', () => {
           created_at: '2025-01-01T00:00:00Z',
         },
       ];
-      mockSupabaseService.listUsernamesByPublicKey.mockResolvedValueOnce(rows);
+      mockUsernamesRepository.listUsernamesByPublicKey.mockResolvedValueOnce(rows);
 
       const result = await service.listByPublicKey(
         'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR',
@@ -226,18 +225,18 @@ describe('UsernamesService', () => {
     ];
 
     it('returns first page with next_cursor and has_more=true', async () => {
-      mockSupabaseService.searchPublicUsernames.mockResolvedValueOnce(rows.slice(0, 3));
+      mockUsernamesRepository.searchPublicUsernames.mockResolvedValueOnce(rows.slice(0, 3));
 
       const result = await service.searchPublicUsernames('alice', 2);
 
       expect(result.data.map((r: { id: string }) => r.id)).toEqual(['id-4', 'id-3']);
       expect(result.has_more).toBe(true);
       expect(result.next_cursor).toBeTruthy();
-      expect(mockSupabaseService.updateUsernameActivity).toHaveBeenCalledWith('alice4');
+      expect(mockUsernamesRepository.updateUsernameActivity).toHaveBeenCalledWith('alice4');
     });
 
     it('advances to next page when cursor is provided', async () => {
-      mockSupabaseService.searchPublicUsernames.mockResolvedValueOnce(rows);
+      mockUsernamesRepository.searchPublicUsernames.mockResolvedValueOnce(rows);
       const cursor = Buffer.from(
         JSON.stringify({ pk: '2025-01-03T00:00:00.000Z', id: 'id-3' }),
         'utf-8',
@@ -248,7 +247,7 @@ describe('UsernamesService', () => {
       expect(result.data.map((r: { id: string }) => r.id)).toEqual(['id-2', 'id-1']);
       expect(result.has_more).toBe(false);
       expect(result.next_cursor).toBeNull();
-      expect(mockSupabaseService.searchPublicUsernames).toHaveBeenCalledWith('alice', 100);
+      expect(mockUsernamesRepository.searchPublicUsernames).toHaveBeenCalledWith('alice', 100);
     });
   });
 
@@ -268,7 +267,7 @@ describe('UsernamesService', () => {
     });
 
     it('breaks volume ties deterministically by ascending id', async () => {
-      mockSupabaseService.getTrendingCreators.mockResolvedValueOnce(rows.slice(0, 3));
+      mockUsernamesRepository.getTrendingCreators.mockResolvedValueOnce(rows.slice(0, 3));
 
       const result = await service.getTrendingCreators(24, 3);
 
@@ -276,7 +275,7 @@ describe('UsernamesService', () => {
     });
 
     it('returns first page with next_cursor and has_more=true', async () => {
-      mockSupabaseService.getTrendingCreators.mockResolvedValueOnce(rows.slice(0, 3));
+      mockUsernamesRepository.getTrendingCreators.mockResolvedValueOnce(rows.slice(0, 3));
 
       const result = await service.getTrendingCreators(24, 2);
 
@@ -286,7 +285,7 @@ describe('UsernamesService', () => {
     });
 
     it('advances to next page when cursor is provided, without re-returning prior rows', async () => {
-      mockSupabaseService.getTrendingCreators.mockResolvedValueOnce(rows);
+      mockUsernamesRepository.getTrendingCreators.mockResolvedValueOnce(rows);
       const cursor = Buffer.from(
         JSON.stringify({ pk: '200', id: 'id-2' }),
         'utf-8',
@@ -295,11 +294,11 @@ describe('UsernamesService', () => {
       const result = await service.getTrendingCreators(24, 2, cursor);
 
       expect(result.data.map((r) => r.id)).toEqual(['id-3', 'id-1']);
-      expect(mockSupabaseService.getTrendingCreators).toHaveBeenCalledWith(24, 100);
+      expect(mockUsernamesRepository.getTrendingCreators).toHaveBeenCalledWith(24, 100);
     });
 
     it('is stable across repeated calls with identical input (ranking stability)', async () => {
-      mockSupabaseService.getTrendingCreators.mockResolvedValue(rows.slice(0, 3));
+      mockUsernamesRepository.getTrendingCreators.mockResolvedValue(rows.slice(0, 3));
 
       const first = await service.getTrendingCreators(24, 3);
       const second = await service.getTrendingCreators(24, 3);
@@ -324,7 +323,7 @@ describe('UsernamesService', () => {
     });
 
     it('breaks activity-timestamp ties deterministically by ascending id', async () => {
-      mockSupabaseService.getRecentlyActiveUsers.mockResolvedValueOnce(rows.slice(0, 3));
+      mockUsernamesRepository.getRecentlyActiveUsers.mockResolvedValueOnce(rows.slice(0, 3));
 
       const result = await service.getRecentlyActiveUsers(24, 3);
 
@@ -332,7 +331,7 @@ describe('UsernamesService', () => {
     });
 
     it('advances to next page when cursor is provided', async () => {
-      mockSupabaseService.getRecentlyActiveUsers.mockResolvedValueOnce(rows);
+      mockUsernamesRepository.getRecentlyActiveUsers.mockResolvedValueOnce(rows);
       const cursor = Buffer.from(
         JSON.stringify({ pk: '2025-01-02T00:00:00.000Z', id: 'id-2' }),
         'utf-8',
@@ -354,7 +353,7 @@ describe('UsernamesService', () => {
     ];
 
     it('orders by featured_rank ascending with null ranks last, ties broken by id', async () => {
-      mockSupabaseService.getFeaturedUsernames.mockResolvedValueOnce(rows);
+      mockUsernamesRepository.getFeaturedUsernames.mockResolvedValueOnce(rows);
 
       const result = await service.getFeaturedCreators(4);
 
@@ -362,7 +361,7 @@ describe('UsernamesService', () => {
     });
 
     it('advances to next page when cursor is provided, including null-rank rows', async () => {
-      mockSupabaseService.getFeaturedUsernames.mockResolvedValueOnce(rows);
+      mockUsernamesRepository.getFeaturedUsernames.mockResolvedValueOnce(rows);
       const cursor = Buffer.from(
         JSON.stringify({ pk: '5', id: 'id-2' }),
         'utf-8',


### PR DESCRIPTION
## Summary

Decouples the backend services for **links**, **transaction-timeline**, **receipts**, and **usernames** from Supabase by introducing per-domain repository ports (interfaces + DI tokens) backed by Supabase adapters. Services now depend on the interface instead of `SupabaseService` or raw `SupabaseClient` query builders.

Scope:
- `usernames`: `USERNAMES_REPOSITORY` — the adapter translates `SupabaseUniqueConstraintError` into the domain `UsernameConflictError` so services never import `supabase.errors`.
- `links`: `PAYMENT_LINKS_REPOSITORY` — public-key lookup, expiry sweep, and expiry audit.
- `transaction-timeline`: `TRANSACTION_TIMELINE_REPOSITORY` — payment records, refund attempts, webhook logs, and contract webhooks.
- `receipts`: `RECEIPT_METADATA_REPOSITORY` — indexer metadata (previously a stub).

Unit tests now mock the repository fakes and run entirely without Supabase (no `SUPABASE_URL` / `SUPABASE_ANON_KEY`, no network). Adds `app/backend/docs/REPOSITORY-PATTERN.md` documenting the port/adapter convention.

This is a backend-only refactor: it does not change API contracts, event schemas, governance, or any deployment/release flow.

## Deployment Checklist

- [ ] I reviewed [documentation/deployment-checklist.md](../documentation/deployment-checklist.md).
- [x] Required checks are green: format, clippy, full tests, benchmarks, and upgrade harness. (Backend `tsc --noEmit`, `nest build`, and full unit suite — 108 suites / 1312 tests — pass; contract clippy/benchmarks are unaffected.)
- [x] Event schema is locked with the canonical schema test. (No event schema changes.)
- [ ] Governance requirements are documented: threshold keys and pause policy. (N/A — no governance changes.)
- [x] The environment registry has been updated for each affected network. (N/A — no network changes.)
- [ ] Testnet validation was completed before any mainnet promotion. (N/A — not a mainnet release.)
- [ ] Post-deploy validation includes metadata view, health check, and event emission smoke test. (N/A — no on-chain changes.)
- [x] Mainnet steps are explicit and repeatable, or this PR is not a mainnet release. (This PR is not a mainnet release.)

## Notes

Backend-only change. Follow-up candidates for the same pattern: `refunds`, `analytics`, `contracts`, `feature-flags`, and the remaining services that still call `supabaseService.getClient()` directly.
