### PR TITLE
fix: back mobile upgrades with runtime policy

### DIFF
--- a/app/backend/src/config/app-config.service.ts
+++ b/app/backend/src/config/app-config.service.ts
@@ -378,6 +378,31 @@ export class AppConfigService {
     return this.configService.get("APP_VERSION", { infer: true }) || process.env.npm_package_version || "1.0.0";
   }
 
+  get mobileMinSupportedVersion(): string {
+    return this.configService.get("MOBILE_MIN_SUPPORTED_VERSION", { infer: true });
+  }
+
+  get mobileRecommendedVersion(): string {
+    return this.configService.get("MOBILE_RECOMMENDED_VERSION", { infer: true });
+  }
+
+  get mobileLatestVersion(): string {
+    return this.configService.get("MOBILE_LATEST_VERSION", { infer: true });
+  }
+
+  get mobileIosStoreUrl(): string {
+    return this.configService.get("MOBILE_IOS_STORE_URL", { infer: true });
+  }
+
+  get mobileAndroidStoreUrl(): string {
+    return this.configService.get("MOBILE_ANDROID_STORE_URL", { infer: true });
+  }
+
+  get mobileReleaseNotes(): string[] {
+    const raw = this.configService.get("MOBILE_RELEASE_NOTES", { infer: true });
+    return raw ? raw.split("|").map((note) => note.trim()).filter(Boolean) : [];
+  }
+
   /**
    * Get the Router Contract ID
    */

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -23,6 +23,37 @@ export const envSchema = Joi.object({
     .optional()
     .description("Application release version string"),
 
+  MOBILE_MIN_SUPPORTED_VERSION: Joi.string()
+    .empty("")
+    .default("1.0.0")
+    .description("Minimum mobile app version allowed to use the API"),
+
+  MOBILE_RECOMMENDED_VERSION: Joi.string()
+    .empty("")
+    .default("1.0.0")
+    .description("Mobile app version that should trigger a soft upgrade prompt"),
+
+  MOBILE_LATEST_VERSION: Joi.string()
+    .empty("")
+    .default("1.0.0")
+    .description("Latest mobile app version available in stores"),
+
+  MOBILE_IOS_STORE_URL: Joi.string()
+    .uri({ scheme: ["http", "https"] })
+    .empty("")
+    .default("https://apps.apple.com/app/quickex")
+    .description("iOS App Store URL for mobile upgrades"),
+
+  MOBILE_ANDROID_STORE_URL: Joi.string()
+    .empty("")
+    .default("market://details?id=com.pulsefy.quickex")
+    .description("Android Play Store URL for mobile upgrades"),
+
+  MOBILE_RELEASE_NOTES: Joi.string()
+    .empty("")
+    .default("")
+    .description("Pipe-separated mobile release notes for upgrade prompts"),
+
   ROUTER_CONTRACT_ID: Joi.string()
     .empty("")
     .optional()
@@ -468,6 +499,12 @@ export interface EnvConfig {
   PORT: number;
   API_BASE_URL?: string;
   APP_VERSION?: string;
+  MOBILE_MIN_SUPPORTED_VERSION: string;
+  MOBILE_RECOMMENDED_VERSION: string;
+  MOBILE_LATEST_VERSION: string;
+  MOBILE_IOS_STORE_URL: string;
+  MOBILE_ANDROID_STORE_URL: string;
+  MOBILE_RELEASE_NOTES: string;
   ROUTER_CONTRACT_ID?: string;
   ALLOWED_TOKENS?: string;
   STELLAR_NETWORK_PASSPHRASE?: string;

--- a/app/backend/src/runtime-config/dto/runtime-config.dto.ts
+++ b/app/backend/src/runtime-config/dto/runtime-config.dto.ts
@@ -65,6 +65,26 @@ export class PreviewMetadataDto {
   valid: boolean;
 }
 
+export class MobileVersionPolicyDto {
+  @ApiProperty({ example: '1.2.0' })
+  minSupportedVersion: string;
+
+  @ApiProperty({ example: '1.3.0' })
+  recommendedVersion: string;
+
+  @ApiProperty({ example: '1.3.1' })
+  latestVersion: string;
+
+  @ApiProperty({ example: 'https://apps.apple.com/app/quickex' })
+  iosStoreUrl: string;
+
+  @ApiProperty({ example: 'market://details?id=com.pulsefy.quickex' })
+  androidStoreUrl: string;
+
+  @ApiProperty({ example: ['Security fixes', 'Contract registry compatibility'] })
+  releaseNotes: string[];
+}
+
 export class RuntimeConfigResponseDto {
   @ApiProperty({ example: 'production', enum: ['development', 'staging', 'production', 'test'] })
   environment: string;
@@ -80,6 +100,9 @@ export class RuntimeConfigResponseDto {
 
   @ApiProperty({ example: '0.1.0' })
   minAppVersion: string;
+
+  @ApiProperty({ type: MobileVersionPolicyDto })
+  mobileVersionPolicy: MobileVersionPolicyDto;
 
   @ApiProperty({
     type: 'object',

--- a/app/backend/src/runtime-config/runtime-config.service.ts
+++ b/app/backend/src/runtime-config/runtime-config.service.ts
@@ -12,6 +12,7 @@ import {
   ContractEntryDto,
   FeatureFlagEntryDto,
   PreviewMetadataDto,
+  MobileVersionPolicyDto,
 } from './dto/runtime-config.dto';
 
 @Injectable()
@@ -46,14 +47,17 @@ export class RuntimeConfigService {
 
     const contractsConfig = contracts ?? {};
 
-    const etag = this.buildEtag(network, contractsConfig, featureFlags, preview);
+    const mobileVersionPolicy = this.buildMobileVersionPolicy();
+
+    const etag = this.buildEtag(network, contractsConfig, featureFlags, preview, mobileVersionPolicy);
 
     return {
       environment,
       network,
       apiUrl: this.resolveApiUrl(),
       appVersion: '0.1.0',
-      minAppVersion: '0.1.0',
+      minAppVersion: mobileVersionPolicy.minSupportedVersion,
+      mobileVersionPolicy,
       contracts: contractsConfig,
       featureFlags,
       preview,
@@ -143,17 +147,30 @@ export class RuntimeConfigService {
     return 'https://testnet-api.quickex.to';
   }
 
+  private buildMobileVersionPolicy(): MobileVersionPolicyDto {
+    return {
+      minSupportedVersion: this.appConfigService.mobileMinSupportedVersion,
+      recommendedVersion: this.appConfigService.mobileRecommendedVersion,
+      latestVersion: this.appConfigService.mobileLatestVersion,
+      iosStoreUrl: this.appConfigService.mobileIosStoreUrl,
+      androidStoreUrl: this.appConfigService.mobileAndroidStoreUrl,
+      releaseNotes: this.appConfigService.mobileReleaseNotes,
+    };
+  }
+
   private buildEtag(
     network: NetworkConfigDto,
     contracts: Record<string, ContractEntryDto>,
     flags: FeatureFlagEntryDto[],
     preview: PreviewMetadataDto | undefined,
+    mobileVersionPolicy: MobileVersionPolicyDto,
   ): string {
     const stable = JSON.stringify({
       n: network.network,
       c: Object.keys(contracts).sort().map((k) => `${k}:${contracts[k].contractId}`).join(','),
       f: flags.map((f) => `${f.key}:${f.enabled}`).sort().join(','),
       p: preview?.scopeId,
+      v: `${mobileVersionPolicy.minSupportedVersion}:${mobileVersionPolicy.recommendedVersion}:${mobileVersionPolicy.latestVersion}`,
     });
     const hash = createHash('sha256').update(stable).digest('hex').slice(0, 16);
     return `W/"runtime-config-${hash}"`;

--- a/app/backend/src/runtime-config/runtime-config.service.unit.spec.ts
+++ b/app/backend/src/runtime-config/runtime-config.service.unit.spec.ts
@@ -29,6 +29,12 @@ describe("RuntimeConfigService", () => {
       isMainnet: false,
       isStaging: false,
       publicApiUrl: undefined,
+      mobileMinSupportedVersion: "1.2.0",
+      mobileRecommendedVersion: "1.3.0",
+      mobileLatestVersion: "1.3.1",
+      mobileIosStoreUrl: "https://apps.apple.com/app/quickex",
+      mobileAndroidStoreUrl: "market://details?id=com.pulsefy.quickex",
+      mobileReleaseNotes: ["Security fixes", "Contract registry compatibility"],
     };
 
     mockFeatureFlagsService = {
@@ -159,7 +165,15 @@ describe("RuntimeConfigService", () => {
     expect(config.featureFlags[0].enabled).toBe(true);
 
     expect(config.appVersion).toBe("0.1.0");
-    expect(config.minAppVersion).toBe("0.1.0");
+    expect(config.minAppVersion).toBe("1.2.0");
+    expect(config.mobileVersionPolicy).toEqual({
+      minSupportedVersion: "1.2.0",
+      recommendedVersion: "1.3.0",
+      latestVersion: "1.3.1",
+      iosStoreUrl: "https://apps.apple.com/app/quickex",
+      androidStoreUrl: "market://details?id=com.pulsefy.quickex",
+      releaseNotes: ["Security fixes", "Contract registry compatibility"],
+    });
     expect(config.generatedAt).toBeDefined();
     expect(config.etag).toMatch(/^W\/"runtime-config-/);
   });

--- a/app/backend/test/runtime-config.e2e-spec.ts
+++ b/app/backend/test/runtime-config.e2e-spec.ts
@@ -26,7 +26,15 @@ describe('Runtime Config Endpoints', () => {
     },
     apiUrl: 'https://testnet-api.quickex.to',
     appVersion: '0.1.0',
-    minAppVersion: '0.1.0',
+    minAppVersion: '1.2.0',
+    mobileVersionPolicy: {
+      minSupportedVersion: '1.2.0',
+      recommendedVersion: '1.3.0',
+      latestVersion: '1.3.1',
+      iosStoreUrl: 'https://apps.apple.com/app/quickex',
+      androidStoreUrl: 'market://details?id=com.pulsefy.quickex',
+      releaseNotes: ['Security fixes'],
+    },
     contracts: {},
     featureFlags: [
       {
@@ -126,7 +134,11 @@ describe('Runtime Config Endpoints', () => {
         expect.objectContaining({ key: 'testnet.contract_writes' }),
       ]),
       appVersion: '0.1.0',
-      minAppVersion: '0.1.0',
+      minAppVersion: '1.2.0',
+      mobileVersionPolicy: expect.objectContaining({
+        minSupportedVersion: '1.2.0',
+        recommendedVersion: '1.3.0',
+      }),
     });
   });
 

--- a/app/mobile/__tests__/ForceUpgradeGate.test.tsx
+++ b/app/mobile/__tests__/ForceUpgradeGate.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text, TouchableOpacity } from 'react-native';
+
+import { ForceUpgradeGate } from '../components/ForceUpgradeGate';
+import { VersionCheckService } from '../services/VersionCheckService';
+
+jest.mock('../components/ReleaseNotes', () => {
+  const React = require('react');
+  const { Text, TouchableOpacity, View } = require('react-native');
+
+  return {
+    ReleaseNotes: ({ visible, onClose }: { visible: boolean; onClose: () => void }) =>
+      visible
+        ? React.createElement(
+            View,
+            null,
+            React.createElement(Text, null, 'New Version Available'),
+            React.createElement(TouchableOpacity, { onPress: onClose }, React.createElement(Text, null, 'Later')),
+          )
+        : null,
+  };
+});
+
+jest.mock('../services/VersionCheckService', () => ({
+  VersionCheckService: {
+    checkVersion: jest.fn(),
+  },
+}));
+
+describe('ForceUpgradeGate', () => {
+  it('blocks unsupported versions with a clear update message', async () => {
+    (VersionCheckService.checkVersion as jest.Mock).mockResolvedValue({
+      status: 'force_upgrade',
+      latestVersion: '1.4.0',
+      releaseNotes: ['Security fixes'],
+      storeUrl: 'https://apps.apple.com/app/quickex',
+      message: 'Version 1.0.0 is no longer supported. Update to continue.',
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <ForceUpgradeGate>
+          <Text>App content</Text>
+        </ForceUpgradeGate>,
+      );
+    });
+
+    const text = tree!.root.findAllByType(Text).map((node) => node.props.children).flat().join(' ');
+    expect(text).toContain('Update Required');
+    expect(text).toContain('no longer supported');
+    expect(text).not.toContain('App content');
+  });
+
+  it('shows a dismissible optional upgrade prompt', async () => {
+    (VersionCheckService.checkVersion as jest.Mock).mockResolvedValue({
+      status: 'optional_upgrade',
+      latestVersion: '1.4.0',
+      releaseNotes: ['Recommended update'],
+      storeUrl: 'https://apps.apple.com/app/quickex',
+      message: 'Version 1.4.0 is recommended.',
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <ForceUpgradeGate>
+          <Text>App content</Text>
+        </ForceUpgradeGate>,
+      );
+    });
+
+    expect(tree!.root.findAllByType(Text).map((node) => node.props.children).flat().join(' ')).toContain('New Version Available');
+
+    const laterButton = tree!.root.findAllByType(TouchableOpacity)[0];
+    await act(async () => {
+      laterButton.props.onPress();
+    });
+
+    const textAfterDismiss = tree!.root.findAllByType(Text).map((node) => node.props.children).flat().join(' ');
+    expect(textAfterDismiss).toContain('App content');
+    expect(textAfterDismiss).not.toContain('New Version Available');
+  });
+});

--- a/app/mobile/__tests__/VersionCheckService.test.ts
+++ b/app/mobile/__tests__/VersionCheckService.test.ts
@@ -1,0 +1,85 @@
+import { Platform } from 'react-native';
+
+import { VersionCheckService } from '../services/VersionCheckService';
+
+jest.mock('../src/config/build', () => ({
+  API_URL: 'https://api.quickex.test',
+  APP_VERSION: '1.2.0',
+}));
+
+function mockRuntimeConfig(policy: {
+  minSupportedVersion: string;
+  recommendedVersion: string;
+  latestVersion: string;
+}) {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      mobileVersionPolicy: {
+        ...policy,
+        iosStoreUrl: 'https://apps.apple.com/app/quickex',
+        androidStoreUrl: 'market://details?id=com.pulsefy.quickex',
+        releaseNotes: ['Security fixes', 'Contract registry compatibility'],
+      },
+    }),
+  });
+}
+
+describe('VersionCheckService', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    Object.defineProperty(Platform, 'OS', {
+      value: 'ios',
+      configurable: true,
+    });
+  });
+
+  it('blocks clients below the server minimum supported version', async () => {
+    mockRuntimeConfig({
+      minSupportedVersion: '1.3.0',
+      recommendedVersion: '1.4.0',
+      latestVersion: '1.4.1',
+    });
+
+    const result = await VersionCheckService.checkVersion();
+
+    expect(result.status).toBe('force_upgrade');
+    expect(result.storeUrl).toBe('https://apps.apple.com/app/quickex');
+    expect(result.message).toContain('no longer supported');
+  });
+
+  it('soft-prompts clients below the recommended version without blocking', async () => {
+    mockRuntimeConfig({
+      minSupportedVersion: '1.0.0',
+      recommendedVersion: '1.3.0',
+      latestVersion: '1.3.1',
+    });
+
+    const result = await VersionCheckService.checkVersion();
+
+    expect(result.status).toBe('optional_upgrade');
+    expect(result.latestVersion).toBe('1.3.1');
+    expect(result.releaseNotes).toContain('Security fixes');
+  });
+
+  it('allows clients at or above the recommended version', async () => {
+    mockRuntimeConfig({
+      minSupportedVersion: '1.0.0',
+      recommendedVersion: '1.2.0',
+      latestVersion: '1.2.0',
+    });
+
+    const result = await VersionCheckService.checkVersion();
+
+    expect(result.status).toBe('ok');
+  });
+
+  it('defaults to allow when the version check fails', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('network unavailable'));
+
+    const result = await VersionCheckService.checkVersion();
+
+    expect(result.status).toBe('ok');
+    expect(result.latestVersion).toBe('1.2.0');
+  });
+});

--- a/app/mobile/components/ForceUpgradeGate.tsx
+++ b/app/mobile/components/ForceUpgradeGate.tsx
@@ -37,7 +37,8 @@ export function ForceUpgradeGate({ children }: ForceUpgradeGateProps) {
         <View style={styles.content}>
           <Text style={styles.title}>Update Required</Text>
           <Text style={styles.description}>
-            You are using an unsupported version of the app. Please update to the latest version to continue using our services securely.
+            {versionInfo.message ??
+              'You are using an unsupported version of the app. Please update to the latest version to continue using our services securely.'}
           </Text>
           <TouchableOpacity style={styles.button} onPress={handleUpdate}>
             <Text style={styles.buttonText}>Update Now</Text>

--- a/app/mobile/services/VersionCheckService.ts
+++ b/app/mobile/services/VersionCheckService.ts
@@ -1,44 +1,103 @@
 import { Platform } from 'react-native';
-import Constants from 'expo-constants';
+import { API_URL, APP_VERSION } from '../src/config/build';
 
 export type VersionCheckResult = {
   status: 'ok' | 'force_upgrade' | 'optional_upgrade';
   latestVersion: string;
   releaseNotes: string[];
   storeUrl: string;
+  message?: string;
 };
 
-// Mock service for minimal implementation
+type RuntimeMobileVersionPolicy = {
+  minSupportedVersion?: string;
+  recommendedVersion?: string;
+  latestVersion?: string;
+  iosStoreUrl?: string;
+  androidStoreUrl?: string;
+  releaseNotes?: string[];
+};
+
+type RuntimeConfigResponse = {
+  minAppVersion?: string;
+  mobileVersionPolicy?: RuntimeMobileVersionPolicy;
+};
+
 export class VersionCheckService {
   static async checkVersion(): Promise<VersionCheckResult> {
-    const currentVersion = Constants.expoConfig?.version || '1.0.0';
-    
-    // In a real app, this would be an API call to your backend
-    const mockApiResponse = {
-      latestVersion: '1.2.0',
-      minRequiredVersion: '1.1.0',
-      releaseNotes: [
-        'Added new security features',
-        'Fixed critical bug causing crashes on startup',
-        'Improved performance in transaction history'
-      ],
-      iosStoreUrl: 'https://apps.apple.com/app/id123456789',
-      androidStoreUrl: 'market://details?id=com.pulsefy.soter'
-    };
+    try {
+      const config = await this.fetchRuntimeConfig();
+      const policy = config.mobileVersionPolicy ?? {};
+      const minSupportedVersion = policy.minSupportedVersion ?? config.minAppVersion ?? '0.0.0';
+      const recommendedVersion = policy.recommendedVersion ?? minSupportedVersion;
+      const latestVersion = policy.latestVersion ?? recommendedVersion;
+      const releaseNotes = policy.releaseNotes ?? [];
+      const storeUrl = Platform.OS === 'ios' ? policy.iosStoreUrl : policy.androidStoreUrl;
+      const resolvedStoreUrl = storeUrl ?? '';
 
-    const isForceUpgrade = this.compareVersions(currentVersion, mockApiResponse.minRequiredVersion) < 0;
-    const isOptionalUpgrade = !isForceUpgrade && this.compareVersions(currentVersion, mockApiResponse.latestVersion) < 0;
+      if (this.compareVersions(APP_VERSION, minSupportedVersion) < 0) {
+        return {
+          status: 'force_upgrade',
+          latestVersion,
+          releaseNotes,
+          storeUrl: resolvedStoreUrl,
+          message: `Version ${APP_VERSION} is no longer supported. Update to ${minSupportedVersion} or later to continue.`,
+        };
+      }
 
+      if (this.compareVersions(APP_VERSION, recommendedVersion) < 0) {
+        return {
+          status: 'optional_upgrade',
+          latestVersion,
+          releaseNotes,
+          storeUrl: resolvedStoreUrl,
+          message: `Version ${recommendedVersion} is recommended for the best QuickEx experience.`,
+        };
+      }
+
+      return {
+        status: 'ok',
+        latestVersion,
+        releaseNotes,
+        storeUrl: resolvedStoreUrl,
+      };
+    } catch {
+      return this.allowOnFailure();
+    }
+  }
+
+  private static async fetchRuntimeConfig(): Promise<RuntimeConfigResponse> {
+    const response = await fetch(`${API_URL.replace(/\/$/, '')}/v1/runtime-config`);
+    if (!response.ok) {
+      throw new Error(`Version policy request failed with ${response.status}`);
+    }
+    return response.json();
+  }
+
+  static getStatusForPolicy(
+    currentVersion: string,
+    policy: Required<RuntimeMobileVersionPolicy>,
+  ): VersionCheckResult['status'] {
+    if (this.compareVersions(currentVersion, policy.minSupportedVersion) < 0) {
+      return 'force_upgrade';
+    }
+    if (this.compareVersions(currentVersion, policy.recommendedVersion) < 0) {
+      return 'optional_upgrade';
+    }
+    return 'ok';
+  }
+
+  static allowOnFailure(): VersionCheckResult {
     return {
-      status: isForceUpgrade ? 'force_upgrade' : (isOptionalUpgrade ? 'optional_upgrade' : 'ok'),
-      latestVersion: mockApiResponse.latestVersion,
-      releaseNotes: mockApiResponse.releaseNotes,
-      storeUrl: Platform.OS === 'ios' ? mockApiResponse.iosStoreUrl : mockApiResponse.androidStoreUrl,
+      status: 'ok',
+      latestVersion: APP_VERSION,
+      releaseNotes: [],
+      storeUrl: '',
     };
   }
 
   // Helper to compare semver versions
-  private static compareVersions(v1: string, v2: string): number {
+  static compareVersions(v1: string, v2: string): number {
     const p1 = v1.split('.').map(Number);
     const p2 = v2.split('.').map(Number);
     for (let i = 0; i < 3; i++) {


### PR DESCRIPTION
## Overview

Implements the MOB-69 force-upgrade policy flow by serving mobile version policy from the backend runtime config and having the mobile app consume that policy instead of hardcoded mock values.

## Related Issue

Closes #859

## Changes

- Added backend runtime config fields for `minSupportedVersion`, `recommendedVersion`, `latestVersion`, platform store URLs, and release notes.
- Exposed the version policy through `/v1/runtime-config` and included policy versions in the runtime config ETag.
- Updated the mobile `VersionCheckService` to fetch the server policy, force-block versions below minimum, soft-prompt versions below recommended, and fail open when the policy check fails.
- Updated `ForceUpgradeGate` to display the server-backed clear block message.
- Added focused backend and mobile tests for blocked, recommended, current, and failed-check flows.

## Verification Results

| Check | Result |
| --- | --- |
| `corepack.cmd pnpm --filter mobile exec jest __tests__/VersionCheckService.test.ts __tests__/ForceUpgradeGate.test.tsx --runInBand` | Passed |
| `corepack.cmd pnpm --filter @quickex/backend test -- runtime-config.service.unit.spec.ts --runInBand` | Passed |
| `corepack.cmd pnpm --filter @quickex/backend test:e2e -- runtime-config.e2e-spec.ts --runInBand` | Passed |
| `corepack.cmd pnpm --filter @quickex/backend type-check` | Passed |
| `git diff --check` | Passed with CRLF conversion warnings |
| `corepack.cmd pnpm --filter mobile type-check` | Failed due existing unrelated mobile TypeScript errors outside this change |

## Acceptance Criteria

| Requirement | Status |
| --- | --- |
| Minimum supported version is served from backend runtime config | Done |
| Clients below minimum are blocked with clear message and store link | Done |
| Soft recommended version prompts without blocking and can be dismissed | Done |
| Failed version check never blocks and defaults to allow | Done |
| Tests cover blocked, recommended, current, and check failure | Done |
