### PR TITLE
fix: explicit emergency classification for all entrypoints

### DIFF
--- a/app/contract/contracts/quickex/src/pause_policy.rs
+++ b/app/contract/contracts/quickex/src/pause_policy.rs
@@ -73,6 +73,7 @@ impl EntryPoint {
     ///   mutate privacy settings (`SetPrivacy`), or interact with the dispute resolution 
     ///   process (`Dispute`, `ResolveDispute`, `VoteForDispute`, `ResolveDisputeMultiSig`) 
     ///   are blocked to contain potential exploits and freeze contract state.
+    #[allow(clippy::match_like_matches_macro)]
     pub fn is_emergency_safe(self) -> bool {
         match self {
             // Fund-recovery and maintenance operations are allowed.

--- a/app/contract/contracts/quickex/src/pause_policy.rs
+++ b/app/contract/contracts/quickex/src/pause_policy.rs
@@ -63,15 +63,37 @@ impl EntryPoint {
     }
 
     /// Whether this entry point is on the emergency-mode allowlist.
+    /// 
+    /// Rationale for classification:
+    /// - **Allowed (true)**: Fund-recovery paths (`Withdraw`, `Refund`, `StealthWithdraw`) 
+    ///   must remain accessible so users can retrieve assets even if the protocol is compromised.
+    ///   Maintenance paths (`CleanupEscrow`, `ExtendEscrowTtl`) are neutral and safe to keep running.
+    /// - **Disallowed (false)**: State-changing paths that create new liabilities (`Deposit`, 
+    ///   `DepositWithCommitment`, `DepositPartial`, `PartialPayment`, `StealthDeposit`), 
+    ///   mutate privacy settings (`SetPrivacy`), or interact with the dispute resolution 
+    ///   process (`Dispute`, `ResolveDispute`, `VoteForDispute`, `ResolveDisputeMultiSig`) 
+    ///   are blocked to contain potential exploits and freeze contract state.
     pub fn is_emergency_safe(self) -> bool {
-        matches!(
-            self,
+        match self {
+            // Fund-recovery and maintenance operations are allowed.
             EntryPoint::Withdraw
-                | EntryPoint::Refund
-                | EntryPoint::StealthWithdraw
-                | EntryPoint::CleanupEscrow
-                | EntryPoint::ExtendEscrowTtl
-        )
+            | EntryPoint::Refund
+            | EntryPoint::StealthWithdraw
+            | EntryPoint::CleanupEscrow
+            | EntryPoint::ExtendEscrowTtl => true,
+
+            // All other state-changing operations are blocked.
+            EntryPoint::Deposit
+            | EntryPoint::DepositWithCommitment
+            | EntryPoint::DepositPartial
+            | EntryPoint::PartialPayment
+            | EntryPoint::StealthDeposit
+            | EntryPoint::Dispute
+            | EntryPoint::ResolveDispute
+            | EntryPoint::VoteForDispute
+            | EntryPoint::ResolveDisputeMultiSig
+            | EntryPoint::SetPrivacy => false,
+        }
     }
 }
 

--- a/app/contract/contracts/quickex/src/pause_policy_test.rs
+++ b/app/contract/contracts/quickex/src/pause_policy_test.rs
@@ -96,15 +96,56 @@ fn setup_withdrawable_escrow(
 }
 
 #[test]
-fn test_emergency_allowlist_includes_fund_recovery_paths() {
+fn test_all_entrypoints_classified() {
     let (_env, client) = setup();
 
-    assert!(client.is_entry_allowed_in_emergency(&EntryPoint::Withdraw));
-    assert!(client.is_entry_allowed_in_emergency(&EntryPoint::Refund));
-    assert!(client.is_entry_allowed_in_emergency(&EntryPoint::StealthWithdraw));
-    assert!(client.is_entry_allowed_in_emergency(&EntryPoint::CleanupEscrow));
-    assert!(!client.is_entry_allowed_in_emergency(&EntryPoint::Deposit));
-    assert!(!client.is_entry_allowed_in_emergency(&EntryPoint::DepositWithCommitment));
+    let allowed = [
+        EntryPoint::Withdraw,
+        EntryPoint::Refund,
+        EntryPoint::StealthWithdraw,
+        EntryPoint::CleanupEscrow,
+        EntryPoint::ExtendEscrowTtl,
+    ];
+    let disallowed = [
+        EntryPoint::Deposit,
+        EntryPoint::DepositWithCommitment,
+        EntryPoint::DepositPartial,
+        EntryPoint::PartialPayment,
+        EntryPoint::StealthDeposit,
+        EntryPoint::Dispute,
+        EntryPoint::ResolveDispute,
+        EntryPoint::VoteForDispute,
+        EntryPoint::ResolveDisputeMultiSig,
+        EntryPoint::SetPrivacy,
+    ];
+
+    let check_exhaustive = |e: EntryPoint| match e {
+        EntryPoint::Deposit
+        | EntryPoint::DepositWithCommitment
+        | EntryPoint::DepositPartial
+        | EntryPoint::PartialPayment
+        | EntryPoint::StealthDeposit
+        | EntryPoint::Withdraw
+        | EntryPoint::Refund
+        | EntryPoint::StealthWithdraw
+        | EntryPoint::Dispute
+        | EntryPoint::ResolveDispute
+        | EntryPoint::VoteForDispute
+        | EntryPoint::ResolveDisputeMultiSig
+        | EntryPoint::SetPrivacy
+        | EntryPoint::CleanupEscrow
+        | EntryPoint::ExtendEscrowTtl => {}
+    };
+
+    for a in allowed {
+        check_exhaustive(a);
+        assert!(client.is_entry_allowed_in_emergency(&a));
+    }
+
+    for d in disallowed {
+        check_exhaustive(d);
+        assert!(!client.is_entry_allowed_in_emergency(&d));
+    }
 }
 
 #[test]
@@ -173,6 +214,36 @@ fn test_risky_entry_points_blocked_in_emergency_mode() {
 
     assert_contract_error(
         client.try_dispute(&commitment),
+        QuickexError::ContractPaused,
+    );
+
+    assert_contract_error(
+        client.try_resolve_dispute(&commitment, &true, &100),
+        QuickexError::ContractPaused,
+    );
+
+    assert_contract_error(
+        client.try_vote_for_dispute(&commitment, &user, &true),
+        QuickexError::ContractPaused,
+    );
+
+    assert_contract_error(
+        client.try_resolve_dispute_multi_sig(&commitment, &true),
+        QuickexError::ContractPaused,
+    );
+
+    let stealth_params = StealthDepositParams {
+        sender: user.clone(),
+        token: token.clone(),
+        amount_due: amount,
+        amount_paid: amount,
+        eph_pub: BytesN::from_array(&env, &[1; 32]),
+        spend_pub: BytesN::from_array(&env, &[2; 32]),
+        stealth_address: commitment.clone(),
+        timeout_secs: 0,
+    };
+    assert_contract_error(
+        client.try_register_ephemeral_key(&stealth_params, &0, &u64::MAX),
         QuickexError::ContractPaused,
     );
 


### PR DESCRIPTION
Closes #878 

### Description
This PR resolves the security issue where some entrypoints could default into an unclassified state, risking unexpected behavior and bypassing intended blocks during emergency mode.

### Changes Made
* Refactored `is_emergency_safe` to use an exhaustive `match` on the `EntryPoint` enum. This guarantees at compile-time that any newly added entrypoint must be explicitly classified.
* Added documentation detailing the rationale behind which entrypoints are allowed (fund-recovery/maintenance) and which are disallowed (state-changing operations) during emergency mode.
* Added a new test `test_all_entrypoints_classified` that explicitly lists and verifies all current entrypoints.
* Updated `test_risky_entry_points_blocked_in_emergency_mode` to ensure all disallowed entrypoints (including stealth deposits, resolving, and voting for disputes) properly reject with `QuickexError::ContractPaused` when emergency mode is active.