### PR TITLE
BE-118: configurable key rotation overlap, audit trail, scope tests

### DIFF
--- a/app/backend/src/api-keys/api-keys.controller.ts
+++ b/app/backend/src/api-keys/api-keys.controller.ts
@@ -28,10 +28,14 @@ export class ApiKeysController {
   @Post()
   @RequireOrgRole('admin')
   create(@Body() dto: CreateApiKeyDto, @Req() req: Request) {
-    return this.service.create({
-      ...dto,
-      organization_id: dto.organization_id ?? req.organizationContext?.organizationId,
-    });
+    const actor = req.organizationContext?.organizationId ?? req.apiKey?.id ?? 'admin';
+    return this.service.create(
+      {
+        ...dto,
+        organization_id: dto.organization_id ?? req.organizationContext?.organizationId,
+      },
+      actor,
+    );
   }
 
   /**
@@ -72,8 +76,9 @@ export class ApiKeysController {
    */
   @Delete(':id')
   @RequireOrgRole('admin')
-  revoke(@Param('id', ParseUUIDPipe) id: string) {
-    return this.service.revoke(id);
+  revoke(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+    const actor = req.organizationContext?.organizationId ?? req.apiKey?.id ?? 'admin';
+    return this.service.revoke(id, actor);
   }
 
   /**
@@ -82,7 +87,8 @@ export class ApiKeysController {
    */
   @Post(':id/rotate')
   @RequireOrgRole('admin')
-  rotate(@Param('id', ParseUUIDPipe) id: string) {
-    return this.service.rotate(id);
+  rotate(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+    const actor = req.organizationContext?.organizationId ?? req.apiKey?.id ?? 'admin';
+    return this.service.rotate(id, actor);
   }
 }

--- a/app/backend/src/api-keys/api-keys.module.ts
+++ b/app/backend/src/api-keys/api-keys.module.ts
@@ -3,9 +3,10 @@ import { ApiKeysController } from './api-keys.controller';
 import { ApiKeysService } from './api-keys.service';
 import { ApiKeysRepository } from './api-keys.repository';
 import { SupabaseModule } from '../supabase/supabase.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
-  imports: [SupabaseModule],
+  imports: [SupabaseModule, AuditModule],
   controllers: [ApiKeysController],
   providers: [ApiKeysService, ApiKeysRepository],
   exports: [ApiKeysService],

--- a/app/backend/src/api-keys/api-keys.service.ts
+++ b/app/backend/src/api-keys/api-keys.service.ts
@@ -15,6 +15,8 @@ import {
 } from './api-keys.types';
 import { decodeCursor, clampLimit } from '../common/pagination/cursor.util';
 import { PaginationMetaDto } from '../dto/pagination/pagination.dto';
+import { AppConfigService } from '../config/app-config.service';
+import { AuditService } from '../audit/audit.service';
 
 const BCRYPT_ROUNDS = 10;
 const DEFAULT_QUOTA = 10_000;
@@ -24,13 +26,17 @@ const KEY_PREFIX_LENGTH = 8; // chars used for prefix display / lookup
 export class ApiKeysService {
   private readonly logger = new Logger(ApiKeysService.name);
 
-  constructor(private readonly repo: ApiKeysRepository) {}
+  constructor(
+    private readonly repo: ApiKeysRepository,
+    private readonly configService: AppConfigService,
+    private readonly auditService: AuditService,
+  ) {}
 
   // ---------------------------------------------------------------------------
   // Public API
   // ---------------------------------------------------------------------------
 
-  async create(dto: CreateApiKeyDto): Promise<ApiKeyCreated> {
+  async create(dto: CreateApiKeyDto, actor = 'system'): Promise<ApiKeyCreated> {
     const rawKey = this.generateRawKey();
     const prefix = rawKey.slice(0, KEY_PREFIX_LENGTH + 3); // "qx_" + 8 chars
     const hash = await bcrypt.hash(rawKey, BCRYPT_ROUNDS);
@@ -46,6 +52,18 @@ export class ApiKeysService {
     });
 
     this.logger.log(`API key created: id=${record.id} name="${record.name}"`);
+
+    await this.auditService.log(
+      actor,
+      'api_key.created',
+      record.id,
+      {
+        name: record.name,
+        scopes: record.scopes,
+        owner_id: record.owner_id,
+        organization_id: record.organization_id,
+      },
+    );
 
     return { ...this.toPublic(record), key: rawKey };
   }
@@ -79,15 +97,27 @@ export class ApiKeysService {
     };
   }
 
-  async revoke(id: string): Promise<void> {
+  async revoke(id: string, actor = 'system'): Promise<void> {
     const record = await this.repo.findById(id);
     if (!record) throw new NotFoundException('API key not found');
 
     await this.repo.revoke(id);
     this.logger.log(`API key revoked: id=${id}`);
+
+    await this.auditService.log(
+      actor,
+      'api_key.revoked',
+      id,
+      {
+        name: record.name,
+        scopes: record.scopes,
+        owner_id: record.owner_id,
+        organization_id: record.organization_id,
+      },
+    );
   }
 
-  async rotate(id: string): Promise<ApiKeyCreated> {
+  async rotate(id: string, actor = 'system'): Promise<ApiKeyCreated> {
     const record = await this.repo.findById(id);
     if (!record) throw new NotFoundException('API key not found');
 
@@ -102,10 +132,22 @@ export class ApiKeysService {
 
     this.logger.log(`API key rotated: id=${id}`);
 
+    await this.auditService.log(
+      actor,
+      'api_key.rotated',
+      id,
+      {
+        name: updated.name,
+        scopes: updated.scopes,
+        owner_id: updated.owner_id,
+        organization_id: updated.organization_id,
+      },
+    );
+
     return { ...this.toPublic(updated), key: rawKey };
   }
 
-  async emergencyRotate(id: string): Promise<ApiKeyCreated> {
+  async emergencyRotate(id: string, actor = 'system'): Promise<ApiKeyCreated> {
     const record = await this.repo.findById(id);
     if (!record) throw new NotFoundException('API key not found');
 
@@ -119,6 +161,18 @@ export class ApiKeysService {
     });
 
     this.logger.log(`API key emergency-rotated: id=${id}`);
+
+    await this.auditService.log(
+      actor,
+      'api_key.emergency_rotated',
+      id,
+      {
+        name: updated.name,
+        scopes: updated.scopes,
+        owner_id: updated.owner_id,
+        organization_id: updated.organization_id,
+      },
+    );
 
     return { ...this.toPublic(updated), key: rawKey };
   }
@@ -136,6 +190,8 @@ export class ApiKeysService {
   ): Promise<{ record: ApiKeyRecord; hasScope: (s: ApiKeyScope) => boolean } | null> {
     const prefix = rawKey.slice(0, KEY_PREFIX_LENGTH + 3);
     const candidates = await this.repo.findByPrefix(prefix);
+    const overlapHours = this.configService?.apiKeyRotationOverlapHours ?? 24;
+    const overlapMs = overlapHours * 60 * 60 * 1000;
 
     for (const record of candidates) {
       const isCurrentMatch = await bcrypt.compare(rawKey, record.key_hash);
@@ -144,7 +200,6 @@ export class ApiKeysService {
       if (!isCurrentMatch && record.key_hash_old && record.rotated_at) {
         const rotatedAt = new Date(record.rotated_at).getTime();
         const now = Date.now();
-        const overlapMs = 24 * 60 * 60 * 1000; // 24 hours
 
         if (now - rotatedAt < overlapMs) {
           isOldMatch = await bcrypt.compare(rawKey, record.key_hash_old);

--- a/app/backend/src/api-keys/api-keys.service.unit.spec.ts
+++ b/app/backend/src/api-keys/api-keys.service.unit.spec.ts
@@ -4,6 +4,8 @@ import * as bcrypt from "bcrypt";
 import { ApiKeysService } from "./api-keys.service";
 import { ApiKeysRepository } from "./api-keys.repository";
 import { ApiKeyRecord } from "./api-keys.types";
+import { AppConfigService } from "../config/app-config.service";
+import { AuditService } from "../audit/audit.service";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -36,28 +38,43 @@ const makeRecord = (overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord => ({
 describe("ApiKeysService", () => {
   let service: ApiKeysService;
   let repo: jest.Mocked<ApiKeysRepository>;
+  let auditService: jest.Mocked<AuditService>;
+  let configService: { apiKeyRotationOverlapHours: number };
 
   beforeEach(async () => {
     const mockRepo: jest.Mocked<Partial<ApiKeysRepository>> = {
       insert: jest.fn(),
       findAll: jest.fn(),
+      findAllPaginated: jest.fn(),
       findById: jest.fn(),
       findByPrefix: jest.fn(),
       revoke: jest.fn(),
       updateKey: jest.fn(),
+      emergencyUpdateKey: jest.fn(),
       incrementUsage: jest.fn(),
       getUsageSummary: jest.fn(),
+    };
+
+    const mockAuditService: jest.Mocked<Partial<AuditService>> = {
+      log: jest.fn().mockResolvedValue(undefined),
+    };
+
+    configService = {
+      apiKeyRotationOverlapHours: 24,
     };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ApiKeysService,
         { provide: ApiKeysRepository, useValue: mockRepo },
+        { provide: AuditService, useValue: mockAuditService },
+        { provide: AppConfigService, useValue: configService },
       ],
     }).compile();
 
     service = module.get<ApiKeysService>(ApiKeysService);
     repo = module.get(ApiKeysRepository);
+    auditService = module.get(AuditService);
   });
 
   it("should be defined", () => {
@@ -105,6 +122,47 @@ describe("ApiKeysService", () => {
       const insertedPrefix = repo.insert.mock.calls[0][0].key_prefix;
       expect(insertedPrefix).toMatch(/^qx_live_/);
     });
+
+    it("logs audit entry on create with non-sensitive metadata", async () => {
+      const record = makeRecord({
+        id: "key-123",
+        name: "Test Key",
+        scopes: ["links:read", "links:write"],
+        owner_id: "owner-1",
+        organization_id: "org-1",
+      });
+      repo.insert.mockResolvedValue(record);
+
+      const result = await service.create(
+        {
+          name: "Test Key",
+          scopes: ["links:read", "links:write"],
+          owner_id: "owner-1",
+          organization_id: "org-1",
+        },
+        "admin-user-1",
+      );
+
+      expect(auditService.log).toHaveBeenCalledTimes(1);
+      expect(auditService.log).toHaveBeenCalledWith(
+        "admin-user-1",
+        "api_key.created",
+        "key-123",
+        {
+          name: "Test Key",
+          scopes: ["links:read", "links:write"],
+          owner_id: "owner-1",
+          organization_id: "org-1",
+        },
+      );
+
+      // Verify raw key or hash is NEVER passed in metadata
+      const metadata = (auditService.log as jest.Mock).mock.calls[0][3];
+      expect(metadata).not.toHaveProperty("key");
+      expect(metadata).not.toHaveProperty("key_hash");
+      expect(JSON.stringify(metadata)).not.toContain(result.key);
+      expect(JSON.stringify(metadata)).not.toContain(record.key_hash);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -136,13 +194,28 @@ describe("ApiKeysService", () => {
   // -------------------------------------------------------------------------
 
   describe("revoke", () => {
-    it("calls repo.revoke when key exists", async () => {
-      repo.findById.mockResolvedValue(makeRecord());
+    it("calls repo.revoke and logs audit entry when key exists", async () => {
+      const record = makeRecord({ id: "test-uuid-1234", name: "My Key", scopes: ["links:read"] });
+      repo.findById.mockResolvedValue(record);
       repo.revoke.mockResolvedValue(undefined);
 
-      await service.revoke("test-uuid-1234");
+      await service.revoke("test-uuid-1234", "admin-actor");
 
       expect(repo.revoke).toHaveBeenCalledWith("test-uuid-1234");
+      expect(auditService.log).toHaveBeenCalledWith(
+        "admin-actor",
+        "api_key.revoked",
+        "test-uuid-1234",
+        {
+          name: "My Key",
+          scopes: ["links:read"],
+          owner_id: null,
+          organization_id: null,
+        },
+      );
+
+      const metadata = (auditService.log as jest.Mock).mock.calls[0][3];
+      expect(metadata).not.toHaveProperty("key_hash");
     });
 
     it("throws NotFoundException when key does not exist", async () => {
@@ -152,6 +225,7 @@ describe("ApiKeysService", () => {
         NotFoundException,
       );
       expect(repo.revoke).not.toHaveBeenCalled();
+      expect(auditService.log).not.toHaveBeenCalled();
     });
   });
 
@@ -160,19 +234,38 @@ describe("ApiKeysService", () => {
   // -------------------------------------------------------------------------
 
   describe("rotate", () => {
-    it("returns a new raw key and updated record", async () => {
+    it("returns a new raw key and updated record, and writes audit log", async () => {
       const original = makeRecord({ key_prefix: "qx_live_old" });
-      const updated = makeRecord({ key_prefix: "qx_live_new" });
+      const updated = makeRecord({
+        key_prefix: "qx_live_new",
+        key_hash: "$2b$10$newhashvalue",
+      });
       repo.findById.mockResolvedValue(original);
       repo.updateKey.mockResolvedValue(updated);
 
-      const result = await service.rotate("test-uuid-1234");
+      const result = await service.rotate("test-uuid-1234", "admin-rotator");
 
       expect(result.key).toMatch(/^qx_live_[a-f0-9]+$/);
       expect(repo.updateKey).toHaveBeenCalledWith(
         "test-uuid-1234",
         expect.objectContaining({ key_hash: expect.stringMatching(/^\$2b\$/) }),
       );
+
+      expect(auditService.log).toHaveBeenCalledWith(
+        "admin-rotator",
+        "api_key.rotated",
+        "test-uuid-1234",
+        {
+          name: updated.name,
+          scopes: updated.scopes,
+          owner_id: updated.owner_id,
+          organization_id: updated.organization_id,
+        },
+      );
+
+      const metadata = (auditService.log as jest.Mock).mock.calls[0][3];
+      expect(metadata).not.toHaveProperty("key_hash");
+      expect(JSON.stringify(metadata)).not.toContain(result.key);
     });
 
     it("throws NotFoundException when key does not exist", async () => {
@@ -181,11 +274,44 @@ describe("ApiKeysService", () => {
       await expect(service.rotate("missing-id")).rejects.toThrow(
         NotFoundException,
       );
+      expect(auditService.log).not.toHaveBeenCalled();
     });
   });
 
   // -------------------------------------------------------------------------
-  // validateKey
+  // emergencyRotate
+  // -------------------------------------------------------------------------
+
+  describe("emergencyRotate", () => {
+    it("immediately rotates key and logs emergency_rotated audit entry", async () => {
+      const original = makeRecord({ id: "emergency-id" });
+      const updated = makeRecord({ id: "emergency-id", key_prefix: "qx_live_newp" });
+      repo.findById.mockResolvedValue(original);
+      repo.emergencyUpdateKey.mockResolvedValue(updated);
+
+      const result = await service.emergencyRotate("emergency-id", "security-admin");
+
+      expect(result.key).toMatch(/^qx_live_[a-f0-9]+$/);
+      expect(repo.emergencyUpdateKey).toHaveBeenCalledWith(
+        "emergency-id",
+        expect.objectContaining({ key_hash: expect.stringMatching(/^\$2b\$/) }),
+      );
+      expect(auditService.log).toHaveBeenCalledWith(
+        "security-admin",
+        "api_key.emergency_rotated",
+        "emergency-id",
+        {
+          name: updated.name,
+          scopes: updated.scopes,
+          owner_id: updated.owner_id,
+          organization_id: updated.organization_id,
+        },
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // validateKey & Configurable Overlap Window
   // -------------------------------------------------------------------------
 
   describe("validateKey", () => {
@@ -198,7 +324,6 @@ describe("ApiKeysService", () => {
     });
 
     it("returns null when prefix matches but bcrypt compare fails", async () => {
-      // Store a hash for a different key so compare will fail
       const record = makeRecord({
         key_hash:
           "$2b$10$invalidhashvalue000000000000000000000000000000000000000",
@@ -213,8 +338,7 @@ describe("ApiKeysService", () => {
       expect(result).toBeNull();
     });
 
-    it("returns record when key matches key_hash_old within 24h", async () => {
-      // We'll use a known bcrypt hash for 'qx_live_oldkey12345678901234567890'
+    it("returns record when key matches key_hash_old within default 24h overlap window", async () => {
       const oldHash = await bcrypt.hash(
         "qx_live_oldkey12345678901234567890",
         10,
@@ -222,7 +346,7 @@ describe("ApiKeysService", () => {
       const record = makeRecord({
         key_hash: "$2b$10$newhashvalue...",
         key_hash_old: oldHash,
-        rotated_at: new Date().toISOString(),
+        rotated_at: new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString(), // 23h ago
       });
       repo.findByPrefix.mockResolvedValue([record]);
       repo.incrementUsage.mockResolvedValue(undefined);
@@ -235,7 +359,7 @@ describe("ApiKeysService", () => {
       expect(result?.record.id).toBe(record.id);
     });
 
-    it("returns null when key matches key_hash_old but after 24h", async () => {
+    it("returns null when key matches key_hash_old but after default 24h overlap window", async () => {
       const oldHash = await bcrypt.hash(
         "qx_live_oldkey12345678901234567890",
         10,
@@ -252,6 +376,45 @@ describe("ApiKeysService", () => {
       );
 
       expect(result).toBeNull();
+    });
+
+    it("respects custom configured overlap window (e.g. 2 hours)", async () => {
+      configService.apiKeyRotationOverlapHours = 2;
+
+      const oldHash = await bcrypt.hash(
+        "qx_live_customoverlap1234567890123",
+        10,
+      );
+
+      // Case 1: rotated 1 hour ago (within 2h window) -> match
+      const recordWithin = makeRecord({
+        id: "key-within-2h",
+        key_hash: "$2b$10$newhashvalue...",
+        key_hash_old: oldHash,
+        rotated_at: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
+      });
+      repo.findByPrefix.mockResolvedValue([recordWithin]);
+      repo.incrementUsage.mockResolvedValue(undefined);
+
+      const resultWithin = await service.validateKey(
+        "qx_live_customoverlap1234567890123",
+      );
+      expect(resultWithin).not.toBeNull();
+      expect(resultWithin?.record.id).toBe("key-within-2h");
+
+      // Case 2: rotated 3 hours ago (past 2h window) -> rejected
+      const recordPast = makeRecord({
+        id: "key-past-2h",
+        key_hash: "$2b$10$newhashvalue...",
+        key_hash_old: oldHash,
+        rotated_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+      });
+      repo.findByPrefix.mockResolvedValue([recordPast]);
+
+      const resultPast = await service.validateKey(
+        "qx_live_customoverlap1234567890123",
+      );
+      expect(resultPast).toBeNull();
     });
   });
 

--- a/app/backend/src/auth/guards/api-key.guard.unit.spec.ts
+++ b/app/backend/src/auth/guards/api-key.guard.unit.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, UnauthorizedException } from "@nestjs/common";
+import { ExecutionContext, ForbiddenException, UnauthorizedException } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { ApiKeyGuard } from "./api-key.guard";
 import { ApiKeysService } from "../../api-keys/api-keys.service";
@@ -92,5 +92,86 @@ describe("ApiKeyGuard", () => {
     });
 
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+  });
+
+  it("should deny access with INSUFFICIENT_SCOPE when API key is missing required scope", async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(["links:write"]);
+    mockApiKeysService.validateKey.mockResolvedValue({
+      record: {
+        id: "api-key-id",
+        name: "test key",
+        scopes: ["links:read"],
+        request_count: 0,
+        monthly_quota: 1000,
+      },
+      hasScope: (s: string) => ["links:read"].includes(s),
+    });
+
+    const { ctx } = makeContext({
+      "x-api-key": "valid-key",
+    });
+
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+
+    try {
+      await guard.canActivate(ctx);
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(ForbiddenException);
+      const res = (err as ForbiddenException).getResponse();
+      expect(res).toEqual(
+        expect.objectContaining({
+          error: "INSUFFICIENT_SCOPE",
+          message: expect.stringContaining("links:write"),
+        }),
+      );
+    }
+  });
+
+  it("should allow access when API key has the required scope", async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(["links:write"]);
+    mockApiKeysService.validateKey.mockResolvedValue({
+      record: {
+        id: "api-key-id",
+        name: "test key",
+        scopes: ["links:write", "links:read"],
+        request_count: 0,
+        monthly_quota: 1000,
+      },
+      hasScope: (s: string) => ["links:write", "links:read"].includes(s),
+    });
+
+    const { ctx, req } = makeContext({
+      "x-api-key": "valid-key",
+    });
+
+    const result = await guard.canActivate(ctx);
+
+    expect(result).toBe(true);
+    expect(req.apiKey).toBeDefined();
+  });
+
+  it("should skip scope check when route has no @RequireScopes metadata", async () => {
+    mockReflector.getAllAndOverride.mockReturnValue([]);
+    const hasScopeMock = jest.fn().mockReturnValue(false);
+
+    mockApiKeysService.validateKey.mockResolvedValue({
+      record: {
+        id: "api-key-id",
+        name: "test key",
+        scopes: [],
+        request_count: 0,
+        monthly_quota: 1000,
+      },
+      hasScope: hasScopeMock,
+    });
+
+    const { ctx } = makeContext({
+      "x-api-key": "valid-key",
+    });
+
+    const result = await guard.canActivate(ctx);
+
+    expect(result).toBe(true);
+    expect(hasScopeMock).not.toHaveBeenCalled();
   });
 });

--- a/app/backend/src/config/app-config.service.ts
+++ b/app/backend/src/config/app-config.service.ts
@@ -368,6 +368,15 @@ export class AppConfigService {
     });
   }
 
+  /**
+   * Overlap window (hours) for key rotation grace period (BE-118)
+   */
+  get apiKeyRotationOverlapHours(): number {
+    return this.configService.get("API_KEY_ROTATION_OVERLAP_HOURS", {
+      infer: true,
+    });
+  }
+
   // ====================================================================
   // NEW ACCESSORS FOR BOOTSTRAP PAYLOAD
   // ====================================================================

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -488,6 +488,16 @@ export const envSchema = Joi.object({
       "How long completed Idempotency-Key records are retained before expiry",
     ),
 
+  // ── API Key Rotation Overlap (BE-118) ───────────────────────────────────
+  API_KEY_ROTATION_OVERLAP_HOURS: Joi.number()
+    .integer()
+    .min(1)
+    .max(720)
+    .default(24)
+    .description(
+      "Overlap window in hours during which a rotated API key's previous hash remains valid",
+    ),
+
   PREVIEW_INACTIVITY_THRESHOLD_MS: Joi.number()
     .integer()
     .min(0)
@@ -581,6 +591,7 @@ export interface EnvConfig {
   ABUSE_SIGNAL_GEO_ENABLED: boolean;
   ABUSE_SIGNAL_HASH_SALT: string;
   IDEMPOTENCY_RETENTION_HOURS: number;
+  API_KEY_ROTATION_OVERLAP_HOURS: number;
   PREVIEW_INACTIVITY_THRESHOLD_MS: number;
   PREVIEW_MAX_AGE_MS: number;
 }


### PR DESCRIPTION
closes #817 


This PR completes the remaining gaps for the API key scopes and rotation workflow in the backend:

1. Configurable Rotation Overlap Window:
- Added API_KEY_ROTATION_OVERLAP_HOURS environment variable (validated via Joi: integer 1–720, defaulting to 24 hours).
- Exposed apiKeyRotationOverlapHours accessor on AppConfigService.
- Injected AppConfigService into ApiKeysService to compute the rotation grace period dynamically in validateKey().

2. Audit Logging for Key Lifecycle Events:
- Imported AuditModule into ApiKeysModule.
- Injected AuditService into ApiKeysService and added audit trail logging for create() (api_key.created), rotate() (api_key.rotated), revoke() (api_key.revoked), and emergencyRotate() (api_key.emergency_rotated).
- Ensured sensitive data (raw keys and password/key hashes) is never logged in the audit metadata.
- Threaded actor identity (organizationContext?.organizationId ?? apiKey?.id ?? 'admin') from ApiKeysController down to ApiKeysService.

3. Expanded Test Coverage:
- api-keys.service.unit.spec.ts: Added unit tests for custom overlap windows (e.g. 2h window validation & post-window rejection) and assertions verifying auditService.log calls and metadata sanitization.
- api-key.guard.unit.spec.ts: Added unit tests verifying @RequireScopes enforcement (INSUFFICIENT_SCOPE rejection), valid scope acceptance, and unscoped route skip behavior.

Changes:
- app/backend/src/config/env.schema.ts: Added API_KEY_ROTATION_OVERLAP_HOURS schema validation and typed EnvConfig definition.
- app/backend/src/config/app-config.service.ts: Added apiKeyRotationOverlapHours getter.
- app/backend/src/api-keys/api-keys.module.ts: Imported AuditModule.
- app/backend/src/api-keys/api-keys.service.ts: Injected AppConfigService and AuditService, added audit log calls, and dynamic overlap window calculation.
- app/backend/src/api-keys/api-keys.controller.ts: Threaded caller actor identity to ApiKeysService methods.
- app/backend/src/api-keys/api-keys.service.unit.spec.ts: Added unit tests for configurable overlap window and audit trail assertions.
- app/backend/src/auth/guards/api-key.guard.unit.spec.ts: Added unit tests for @RequireScopes guard enforcement.

Verification:
- pnpm --filter @quickex/backend test:unit passed (114/114 test suites, 1389/1389 tests passed).
- pnpm --filter @quickex/backend type-check passed (0 TypeScript errors).
- pnpm --filter @quickex/backend lint passed (0 lint errors/warnings).