### PR TITLE
Fix partial payment accounting invariants

### DIFF
--- a/app/contract/contracts/quickex/src/escrow.rs
+++ b/app/contract/contracts/quickex/src/escrow.rs
@@ -126,6 +126,43 @@ fn compute_expires_at(env: &Env, timeout_secs: u64) -> Result<u64, QuickexError>
     Ok(expires_at)
 }
 
+/// Enforces partial-payment value conservation for every transition that moves
+/// escrowed principal or final fees:
+///
+/// settled + refunded + outstanding + fees == deposit
+fn assert_accounting_invariant(
+    deposit: i128,
+    settled: i128,
+    refunded: i128,
+    outstanding: i128,
+    fees: i128,
+) -> Result<(), QuickexError> {
+    if deposit < 0 || settled < 0 || refunded < 0 || outstanding < 0 || fees < 0 {
+        return Err(QuickexError::InternalError);
+    }
+
+    let total = settled
+        .checked_add(refunded)
+        .and_then(|v| v.checked_add(outstanding))
+        .and_then(|v| v.checked_add(fees))
+        .ok_or(QuickexError::InternalError)?;
+
+    if total != deposit {
+        return Err(QuickexError::InternalError);
+    }
+
+    Ok(())
+}
+
+/// Pending escrows hold every paid unit in the contract until they settle or
+/// refund. The target amount_due may be higher, but amount_paid cannot exceed it.
+fn assert_pending_partial_accounting(entry: &EscrowEntry) -> Result<(), QuickexError> {
+    if entry.amount_paid > entry.amount_due {
+        return Err(QuickexError::InternalError);
+    }
+    assert_accounting_invariant(entry.amount_paid, 0, 0, entry.amount_paid, 0)
+}
+
 // ---------------------------------------------------------------------------
 // deposit
 // ---------------------------------------------------------------------------
@@ -360,6 +397,9 @@ pub fn deposit_partial(
     if amount_due <= 0 {
         return Err(QuickexError::InvalidAmount);
     }
+    if initial_payment > amount_due {
+        return Err(QuickexError::Overpayment);
+    }
 
     owner.require_auth();
 
@@ -392,6 +432,7 @@ pub fn deposit_partial(
         arbiter_threshold: 0,
     };
 
+    assert_pending_partial_accounting(&entry)?;
     put_escrow(env, &commitment_bytes, &entry);
     token_client.transfer(&owner, env.current_contract_address(), &initial_payment);
 
@@ -467,8 +508,13 @@ pub fn partial_payment(
         return Err(QuickexError::AlreadySpent);
     }
 
+    assert_pending_partial_accounting(&entry)?;
+
     // Calculate remaining amount due
-    let remaining = entry.amount_due.saturating_sub(entry.amount_paid);
+    let remaining = entry
+        .amount_due
+        .checked_sub(entry.amount_paid)
+        .ok_or(QuickexError::InternalError)?;
 
     // Reject overpayment
     if payment_amount > remaining {
@@ -480,7 +526,11 @@ pub fn partial_payment(
     token_client.transfer(&payer, env.current_contract_address(), &payment_amount);
 
     // Update amount_paid
-    entry.amount_paid = entry.amount_paid.saturating_add(payment_amount);
+    entry.amount_paid = entry
+        .amount_paid
+        .checked_add(payment_amount)
+        .ok_or(QuickexError::InternalError)?;
+    assert_pending_partial_accounting(&entry)?;
 
     // Check if escrow is now fully paid
     let is_fully_paid = entry.amount_paid >= entry.amount_due;
@@ -595,8 +645,9 @@ pub fn withdraw(
     updated.status = EscrowStatus::Spent;
     put_escrow(env, &commitment_bytes, &updated);
 
-    let (_payout_amount, fee_amount) =
+    let (payout_amount, fee_amount) =
         fee_router::route_payout_price_aware(env, &token_ref, &to, amount_paid, None)?;
+    assert_accounting_invariant(amount_paid, payout_amount, 0, 0, fee_amount)?;
 
     events::publish_escrow_withdrawn(
         env,
@@ -677,6 +728,7 @@ pub fn refund(
     let token_ref = entry.token.clone();
     let owner_ref = entry.owner.clone();
     let amount_paid = entry.amount_paid;
+    assert_accounting_invariant(amount_paid, 0, amount_paid, 0, 0)?;
 
     let mut updated = entry;
     updated.status = EscrowStatus::Refunded;
@@ -754,6 +806,7 @@ pub fn finalize_expired_escrow(env: &Env, commitment: BytesN<32>) -> Result<(), 
     let owner_ref = entry.owner.clone();
     let amount_paid = entry.amount_paid;
     let expires_at = entry.expires_at;
+    assert_accounting_invariant(amount_paid, 0, amount_paid, 0, 0)?;
 
     let mut updated = entry;
     updated.status = EscrowStatus::Refunded;

--- a/app/contract/contracts/quickex/src/fuzz_test.rs
+++ b/app/contract/contracts/quickex/src/fuzz_test.rs
@@ -11,6 +11,7 @@
 //! | INV-5 | Terminal states are final — `Spent`/`Refunded` block all further transitions. |
 //! | INV-6 | No overpayment — `partial_payment` rejects amounts exceeding the remainder. |
 //! | INV-7 | Nonce uniqueness — replaying a `(signer, nonce)` pair always fails.      |
+//! | INV-8 | Partial payment accounting conserves paid deposit through settlement/refund. |
 //!
 //! # Adding a new invariant
 //!
@@ -21,7 +22,7 @@
 
 use proptest::prelude::*;
 
-use crate::test_context::TestContext;
+use crate::{fee::fee_from_bps_floor, test_context::TestContext};
 
 // ---------------------------------------------------------------------------
 // Strategies
@@ -630,6 +631,98 @@ proptest! {
     }
 }
 
+// ---------------------------------------------------------------------------
+// INV-8: Partial payment accounting conservation
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// INV-8: settled + refunded + outstanding + fees must equal the paid deposit
+    /// after every partial operation and after either final settlement or timeout finalization.
+    #[test]
+    fn inv8_partial_payment_accounting_conserved(
+        amount_due in 2_i128..=100_000_i128,
+        initial_seed in any::<u64>(),
+        payments in prop::collection::vec(1_i128..=50_000_i128, 0..12),
+        fee_bps in 0_u32..=1_000_u32,
+        settle_when_full in any::<bool>(),
+        salt in salt_strategy(),
+    ) {
+        let ctx = TestContext::with_fees(fee_bps);
+        let initial_payment = 1_i128 + (i128::from(initial_seed) % amount_due);
+        let timeout = 3600_u64;
+
+        ctx.mint(&ctx.alice.clone(), initial_payment);
+        let commitment = ctx.client.deposit_partial(
+            &ctx.token,
+            &amount_due,
+            &initial_payment,
+            &ctx.alice.clone(),
+            &ctx.salt(&salt),
+            &timeout,
+            &None,
+            &0u64,
+            &u64::MAX,
+        );
+
+        let mut paid_deposit = initial_payment;
+        prop_assert!(paid_deposit <= amount_due);
+        prop_assert_eq!(0_i128 + 0_i128 + paid_deposit + 0_i128, paid_deposit);
+
+        for (idx, candidate) in payments.iter().enumerate() {
+            let remaining = amount_due - paid_deposit;
+            if remaining == 0 {
+                break;
+            }
+
+            let payment = (*candidate).min(remaining);
+            ctx.mint(&ctx.bob.clone(), payment);
+            ctx.client.partial_payment(
+                &commitment,
+                &ctx.bob.clone(),
+                &payment,
+                &(idx as u64),
+                &u64::MAX,
+            );
+            paid_deposit += payment;
+
+            prop_assert!(paid_deposit <= amount_due);
+            prop_assert_eq!(0_i128 + 0_i128 + paid_deposit + 0_i128, paid_deposit);
+        }
+
+        if paid_deposit == amount_due && settle_when_full {
+            let recipient_before = ctx.balance(&ctx.alice.clone());
+            let fee_before = ctx.balance(&ctx.platform_wallet.clone());
+
+            ctx.client.withdraw(
+                &ctx.token,
+                &amount_due,
+                &commitment,
+                &ctx.alice.clone(),
+                &ctx.salt(&salt),
+                &0u64,
+                &u64::MAX,
+            );
+
+            let settled = ctx.balance(&ctx.alice.clone()) - recipient_before;
+            let fees = ctx.balance(&ctx.platform_wallet.clone()) - fee_before;
+            let outstanding = ctx.balance(&ctx.client.address);
+            let expected_fee = fee_from_bps_floor(paid_deposit, fee_bps);
+
+            prop_assert_eq!(fees, expected_fee);
+            prop_assert_eq!(settled + 0_i128 + outstanding + fees, paid_deposit);
+        } else {
+            let owner_before = ctx.balance(&ctx.alice.clone());
+
+            ctx.advance_time(timeout);
+            ctx.client.finalize_expired_escrow(&commitment);
+
+            let refunded = ctx.balance(&ctx.alice.clone()) - owner_before;
+            let outstanding = ctx.balance(&ctx.client.address);
+
+            prop_assert_eq!(0_i128 + refunded + outstanding + 0_i128, paid_deposit);
+        }
+    }
+}
 // ---------------------------------------------------------------------------
 // Regression corpus
 //

--- a/app/contract/contracts/quickex/src/test.rs
+++ b/app/contract/contracts/quickex/src/test.rs
@@ -4,10 +4,12 @@ use crate::{
         EVENT_COMPATIBILITY, EVENT_SCHEMAS, EVENT_SCHEMA_VERSION, EVENT_TOPIC_ADMIN,
         EVENT_TOPIC_ESCROW, EVENT_TOPIC_PRIVACY,
     },
+    fee::fee_from_bps_floor,
     storage::{
         put_escrow, DataKey, PauseFlag, CURRENT_CONTRACT_VERSION, LEGACY_CONTRACT_VERSION,
         PRIVACY_ENABLED_KEY,
     },
+    types::FeeConfig,
     EscrowEntry, EscrowStatus, QuickexContract, QuickexContractClient,
 };
 
@@ -330,6 +332,29 @@ fn assert_contract_error<T>(
         Err(Ok(actual)) => assert_eq!(actual, expected),
         _ => panic!("expected contract error"),
     }
+}
+
+fn assert_partial_accounting(
+    client: &QuickexContractClient,
+    commitment: &BytesN<32>,
+    viewer: &Address,
+    expected_due: i128,
+    expected_paid_deposit: i128,
+) {
+    let details = client.get_escrow_details(commitment, viewer).unwrap();
+    let outstanding = details.amount_paid.unwrap();
+
+    assert_eq!(details.amount_due, Some(expected_due));
+    assert_eq!(outstanding, expected_paid_deposit);
+    assert!(
+        outstanding <= expected_due,
+        "outstanding principal cannot exceed amount_due"
+    );
+    assert_eq!(
+        0_i128 + 0_i128 + outstanding + 0_i128,
+        expected_paid_deposit,
+        "settled + refunded + outstanding + fees must equal deposit"
+    );
 }
 
 fn latest_contract_event(env: &Env, contract_id: &Address) -> (soroban_sdk::Vec<Val>, Val) {
@@ -3635,9 +3660,13 @@ fn test_partial_payment_success() {
         &u64::MAX,
     );
 
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, initial_payment);
+
     // Make partial payment
     let payment_amount: i128 = 300;
     client.partial_payment(&commitment, &payer, &payment_amount, &0u64, &u64::MAX);
+
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, 1000);
 
     // Verify escrow state
     let details = client.get_escrow_details(&commitment, &owner).unwrap();
@@ -3646,6 +3675,36 @@ fn test_partial_payment_success() {
     assert_eq!(details.status, EscrowStatus::Pending);
 }
 
+#[test]
+fn test_deposit_partial_initial_overpayment_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let amount_due: i128 = 1000;
+    let initial_payment: i128 = 1001;
+    let salt = Bytes::from_slice(&env, b"initial_overpayment_salt");
+
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &initial_payment);
+
+    let result = client.try_deposit_partial(
+        &token,
+        &amount_due,
+        &initial_payment,
+        &owner,
+        &salt,
+        &0,
+        &None,
+        &0u64,
+        &u64::MAX,
+    );
+    assert_contract_error(result, QuickexError::Overpayment);
+}
 #[test]
 fn test_partial_payment_overpayment_rejected() {
     let env = Env::default();
@@ -3910,24 +3969,140 @@ fn test_multi_payment_sequence() {
         &0u64,
         &u64::MAX,
     );
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, initial_payment);
 
     // First partial payment: 200
     client.partial_payment(&commitment, &payer1, &200, &0u64, &u64::MAX);
-    let details = client.get_escrow_details(&commitment, &owner).unwrap();
-    assert_eq!(details.amount_paid, Some(500));
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, 500);
 
     // Second partial payment: 300
     client.partial_payment(&commitment, &payer2, &300, &0u64, &u64::MAX);
-    let details = client.get_escrow_details(&commitment, &owner).unwrap();
-    assert_eq!(details.amount_paid, Some(800));
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, 800);
 
     // Final payment: 200 (completes the escrow)
     client.partial_payment(&commitment, &payer3, &200, &0u64, &u64::MAX);
-    let details = client.get_escrow_details(&commitment, &owner).unwrap();
-    assert_eq!(details.amount_paid, Some(1000));
-    assert_eq!(details.amount_due, Some(1000));
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, 1000);
 }
 
+#[test]
+fn test_partial_payment_withdraw_fee_accounting_uses_floor_rounding() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let amount_due: i128 = 1001;
+    let initial_payment: i128 = 400;
+    let final_payment: i128 = 601;
+    let fee_bps = 333_u32;
+    let salt = Bytes::from_slice(&env, b"partial_fee_accounting_salt");
+
+    client.initialize(&admin);
+    client.set_fee_config(&admin, &FeeConfig { fee_bps });
+    client.set_platform_wallet(&admin, &platform_wallet);
+
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &initial_payment);
+    token_client.mint(&payer, &final_payment);
+
+    let commitment = client.deposit_partial(
+        &token,
+        &amount_due,
+        &initial_payment,
+        &owner,
+        &salt,
+        &0,
+        &None,
+        &0u64,
+        &u64::MAX,
+    );
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, initial_payment);
+
+    client.partial_payment(&commitment, &payer, &final_payment, &0u64, &u64::MAX);
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, amount_due);
+
+    let token_client = token::Client::new(&env, &token);
+    let owner_before = token_client.balance(&owner);
+    let platform_before = token_client.balance(&platform_wallet);
+    client.withdraw(
+        &token,
+        &amount_due,
+        &commitment,
+        &owner,
+        &salt,
+        &0u64,
+        &u64::MAX,
+    );
+
+    let expected_fee = fee_from_bps_floor(amount_due, fee_bps);
+    let owner_delta = token_client.balance(&owner) - owner_before;
+    let platform_delta = token_client.balance(&platform_wallet) - platform_before;
+    let contract_balance = token_client.balance(&contract_id);
+
+    assert_eq!(expected_fee, 33);
+    assert_eq!(platform_delta, expected_fee);
+    assert_eq!(owner_delta + platform_delta + contract_balance, amount_due);
+}
+
+#[test]
+fn test_finalize_expired_partial_escrow_refunds_paid_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuickexContract, ());
+    let client = QuickexContractClient::new(&env, &contract_id);
+
+    let token = create_test_token(&env);
+    let owner = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let amount_due: i128 = 1000;
+    let initial_payment: i128 = 250;
+    let second_payment: i128 = 125;
+    let paid_deposit = initial_payment + second_payment;
+    let timeout_secs = 30_u64;
+    let salt = Bytes::from_slice(&env, b"partial_expiry_finalization_salt");
+
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&owner, &initial_payment);
+    token_client.mint(&payer, &second_payment);
+
+    let commitment = client.deposit_partial(
+        &token,
+        &amount_due,
+        &initial_payment,
+        &owner,
+        &salt,
+        &timeout_secs,
+        &None,
+        &0u64,
+        &u64::MAX,
+    );
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, initial_payment);
+
+    client.partial_payment(&commitment, &payer, &second_payment, &0u64, &u64::MAX);
+    assert_partial_accounting(&client, &commitment, &owner, amount_due, paid_deposit);
+
+    let token_client = token::Client::new(&env, &token);
+    let owner_before = token_client.balance(&owner);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + timeout_secs);
+    client.finalize_expired_escrow(&commitment);
+
+    let owner_delta = token_client.balance(&owner) - owner_before;
+    let contract_balance = token_client.balance(&contract_id);
+    let details = client.get_escrow_details(&commitment, &owner).unwrap();
+
+    assert_eq!(owner_delta, paid_deposit);
+    assert_eq!(contract_balance, 0);
+    assert_eq!(details.status, EscrowStatus::Refunded);
+    assert_eq!(0_i128 + paid_deposit + 0_i128 + 0_i128, paid_deposit);
+}
 // ============================================================================
 // Multi-Sig Arbiter Tests
 // ============================================================================

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -39,3 +39,12 @@ Zero-amount payments follow the same state machine but MUST NOT resultin any tok
 INV-10: Fee Ceiling
 
 Protocol fees collected per payment MUST NOT exceed the configuredmaximum fee percentage of the payment amount.
+INV-11: Partial Payment Accounting
+
+For every escrow, the accounting equation is:
+
+    settled + refunded + outstanding + fees == paid_deposit
+
+paid_deposit is the cumulative principal transferred into the escrow contract. While a partial escrow is pending, all paid principal is outstanding in the contract and mount_paid must never exceed mount_due. On settlement, the paid principal is split into recipient payout plus protocol fees. On refund or timeout finalization, the paid principal returns to the owner and no fee is charged.
+
+Fee rounding is floor-based at final settlement (ee_from_bps_floor) and is applied once to the settled escrow amount, not incrementally on every partial payment. This keeps repeated partial operations from leaking value in either direction.


### PR DESCRIPTION
## Overview

Add partial-payment escrow accounting invariants and randomized coverage.

## Related Issue

Closes #877

## Changes

- [FIX] Enforced checked escrow accounting across partial payment lifecycle transitions.
- [TEST] Added deterministic, fee-rounding, timeout-refund, and randomized invariant coverage.
- [DOCS] Documented the accounting equation and floor-rounding policy.

## Verification Results

- `cargo fmt --manifest-path app\contract\Cargo.toml --all -- --check` passed.
- `git diff --check` passed.
- `cargo check -p quickex --tests -j 1` and targeted `cargo test` were blocked by insufficient system disk space (`os error 112`) before contract compilation completed.

## Acceptance Criteria

| Criterion | Status |
| --- | --- |
| Accounting invariant reconciles settled, refunded, outstanding, and fees to deposit | Done |
| Invariant is asserted after each partial operation in tests | Done |
| Property/fuzz test drives random operation sequences | Done |
| Rounding behavior prevents repeated partial-operation value leakage | Done |
| Timeout finalization on partially settled escrow is covered | Done |