### PR TITLE
Add privacy retention and erasure workflow

### DIFF
--- a/app/backend/src/privacy/data-retention.policy.ts
+++ b/app/backend/src/privacy/data-retention.policy.ts
@@ -1,0 +1,186 @@
+export type PrivacySubjectKey = 'publicKey' | 'username' | 'userId';
+
+export type RetentionAction = 'delete' | 'anonymize';
+
+export type RetentionCutoffMode = 'age' | 'absolute';
+
+export interface SubjectIdentifier {
+  key: PrivacySubjectKey;
+  column: string;
+}
+
+export interface RetentionPolicy {
+  storeKey: string;
+  tableName: string;
+  description: string;
+  retentionDays: number;
+  retentionColumn: string;
+  cutoffMode: RetentionCutoffMode;
+  action: RetentionAction;
+  subjectIdentifiers: SubjectIdentifier[];
+  anonymizeColumns?: string[];
+  nullColumns?: string[];
+  setColumns?: Record<string, unknown>;
+  financialIntegrityNote?: string;
+}
+
+const SEVEN_YEARS_DAYS = 2555;
+
+/**
+ * Central declaration for personal-data stores handled by retention and
+ * right-to-erasure workflows.
+ */
+export const DATA_RETENTION_POLICIES: readonly RetentionPolicy[] = [
+  {
+    storeKey: 'public_profiles',
+    tableName: 'usernames',
+    description: 'Public username/profile ownership records.',
+    retentionDays: 3650,
+    retentionColumn: 'created_at',
+    cutoffMode: 'age',
+    action: 'delete',
+    subjectIdentifiers: [
+      { key: 'publicKey', column: 'public_key' },
+      { key: 'username', column: 'username' },
+    ],
+  },
+  {
+    storeKey: 'crash_reports',
+    tableName: 'crash_reports',
+    description: 'Opt-in crash reports, issue reports, and redacted logs.',
+    retentionDays: 30,
+    retentionColumn: 'timestamp',
+    cutoffMode: 'age',
+    action: 'delete',
+    subjectIdentifiers: [{ key: 'userId', column: 'user_id' }],
+  },
+  {
+    storeKey: 'crash_reporting_settings',
+    tableName: 'crash_reporting_settings',
+    description: 'Per-user crash-reporting opt-in settings.',
+    retentionDays: 365,
+    retentionColumn: 'updated_at',
+    cutoffMode: 'age',
+    action: 'delete',
+    subjectIdentifiers: [{ key: 'userId', column: 'user_id' }],
+  },
+  {
+    storeKey: 'notification_preferences',
+    tableName: 'notification_preferences',
+    description: 'Notification destinations and user channel preferences.',
+    retentionDays: 365,
+    retentionColumn: 'updated_at',
+    cutoffMode: 'age',
+    action: 'delete',
+    subjectIdentifiers: [{ key: 'publicKey', column: 'public_key' }],
+  },
+  {
+    storeKey: 'notification_log',
+    tableName: 'notification_log',
+    description: 'Notification delivery attempts and retry diagnostics.',
+    retentionDays: 180,
+    retentionColumn: 'created_at',
+    cutoffMode: 'age',
+    action: 'delete',
+    subjectIdentifiers: [{ key: 'publicKey', column: 'public_key' }],
+  },
+  {
+    storeKey: 'abuse_signals',
+    tableName: 'abuse_signals',
+    description: 'Privacy-safe abuse signals for public payment endpoints.',
+    retentionDays: 90,
+    retentionColumn: 'retention_until',
+    cutoffMode: 'absolute',
+    action: 'delete',
+    subjectIdentifiers: [{ key: 'username', column: 'target_username' }],
+  },
+  {
+    storeKey: 'support_bundle_references',
+    tableName: 'support_bundle_references',
+    description: 'Support bundle pointers and ticket/receipt links.',
+    retentionDays: 30,
+    retentionColumn: 'expires_at',
+    cutoffMode: 'absolute',
+    action: 'anonymize',
+    subjectIdentifiers: [
+      { key: 'userId', column: 'created_by' },
+      { key: 'publicKey', column: 'created_by' },
+    ],
+    anonymizeColumns: ['bundle_id', 'created_by'],
+    setColumns: { redacted: true },
+    financialIntegrityNote:
+      'Support bundle references are redacted instead of deleted so support audit history can explain why a ticket lost its bundle pointer.',
+  },
+  {
+    storeKey: 'payment_links',
+    tableName: 'payment_links',
+    description: 'Payment link records that may be referenced by reconciliation and receipts.',
+    retentionDays: SEVEN_YEARS_DAYS,
+    retentionColumn: 'created_at',
+    cutoffMode: 'age',
+    action: 'anonymize',
+    subjectIdentifiers: [
+      { key: 'publicKey', column: 'owner_public_key' },
+      { key: 'publicKey', column: 'destination_public_key' },
+    ],
+    anonymizeColumns: ['owner_public_key', 'destination_public_key'],
+    nullColumns: ['memo', 'reference_id'],
+    financialIntegrityNote:
+      'Payment links are anonymized rather than deleted because matched links can be needed to reconcile on-chain financial activity.',
+  },
+  {
+    storeKey: 'recurring_payment_links',
+    tableName: 'recurring_payment_links',
+    description: 'Recurring payment schedules and execution source metadata.',
+    retentionDays: SEVEN_YEARS_DAYS,
+    retentionColumn: 'created_at',
+    cutoffMode: 'age',
+    action: 'anonymize',
+    subjectIdentifiers: [
+      { key: 'publicKey', column: 'destination' },
+      { key: 'username', column: 'username' },
+    ],
+    anonymizeColumns: ['destination', 'username'],
+    nullColumns: ['memo', 'reference_id'],
+    financialIntegrityNote:
+      'Recurring payment links keep schedule and amount history for financial integrity, but user identifiers are anonymized.',
+  },
+  {
+    storeKey: 'unmatched_transactions',
+    tableName: 'unmatched_transactions',
+    description: 'Unmatched transaction review queue for financial reconciliation.',
+    retentionDays: SEVEN_YEARS_DAYS,
+    retentionColumn: 'ingested_at',
+    cutoffMode: 'age',
+    action: 'anonymize',
+    subjectIdentifiers: [
+      { key: 'publicKey', column: 'source_account' },
+      { key: 'publicKey', column: 'destination_account' },
+      { key: 'userId', column: 'resolved_by' },
+    ],
+    anonymizeColumns: ['source_account', 'destination_account', 'resolved_by'],
+    nullColumns: ['memo', 'resolution_note'],
+    financialIntegrityNote:
+      'Unmatched transaction rows preserve transaction hashes and amounts for reconciliation, while account identifiers are anonymized.',
+  },
+  {
+    storeKey: 'admin_audit_logs',
+    tableName: 'admin_audit_logs',
+    description: 'Administrative audit trail.',
+    retentionDays: SEVEN_YEARS_DAYS,
+    retentionColumn: 'created_at',
+    cutoffMode: 'age',
+    action: 'anonymize',
+    subjectIdentifiers: [
+      { key: 'userId', column: 'actor' },
+      { key: 'publicKey', column: 'actor' },
+      { key: 'userId', column: 'target' },
+      { key: 'publicKey', column: 'target' },
+    ],
+    anonymizeColumns: ['actor', 'target'],
+    setColumns: { metadata: {} },
+    financialIntegrityNote:
+      'Audit rows are anonymized rather than deleted so administrative and security investigations retain a durable event trail.',
+  },
+];
+

--- a/app/backend/src/privacy/privacy-admin.controller.ts
+++ b/app/backend/src/privacy/privacy-admin.controller.ts
@@ -1,0 +1,44 @@
+import { Body, Controller, Post, Req, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { Request } from "express";
+
+import { RequireScopes } from "../auth/decorators/require-scopes.decorator";
+import { ApiKeyGuard } from "../auth/guards/api-key.guard";
+import {
+  ErasureSubject,
+  PrivacyRetentionService,
+} from "./privacy-retention.service";
+
+class ErasureRequestDto implements ErasureSubject {
+  publicKey?: string;
+  username?: string;
+  userId?: string;
+}
+
+@ApiTags("Admin - Privacy")
+@Controller("admin/privacy")
+@UseGuards(ApiKeyGuard)
+@RequireScopes("admin")
+@ApiBearerAuth()
+export class PrivacyAdminController {
+  constructor(private readonly retentionService: PrivacyRetentionService) {}
+
+  @Post("retention/run")
+  @ApiOperation({
+    summary: "Run the privacy retention sweeper immediately",
+  })
+  enforceRetentionNow() {
+    return this.retentionService.enforceRetention();
+  }
+
+  @Post("erasure")
+  @ApiOperation({
+    summary: "Service a right-to-erasure request across declared data stores",
+  })
+  eraseSubject(@Body() body: ErasureRequestDto, @Req() req: Request) {
+    const actor =
+      req.organizationContext?.organizationId ?? req.apiKey?.id ?? "admin";
+    return this.retentionService.eraseSubject(body, actor);
+  }
+}
+

--- a/app/backend/src/privacy/privacy-retention.scheduler.ts
+++ b/app/backend/src/privacy/privacy-retention.scheduler.ts
@@ -1,0 +1,24 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import { PrivacyRetentionService } from './privacy-retention.service';
+
+@Injectable()
+export class PrivacyRetentionScheduler {
+  private readonly logger = new Logger(PrivacyRetentionScheduler.name);
+
+  constructor(private readonly retentionService: PrivacyRetentionService) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_1AM)
+  async enforceRetention(): Promise<void> {
+    const result = await this.retentionService.enforceRetention();
+    const affectedRows = result.results.reduce(
+      (total, item) => total + item.affectedRows,
+      0,
+    );
+    this.logger.log(
+      `Privacy retention run completed at ${result.runAt}; affected ${affectedRows} rows`,
+    );
+  }
+}
+

--- a/app/backend/src/privacy/privacy-retention.service.ts
+++ b/app/backend/src/privacy/privacy-retention.service.ts
@@ -1,0 +1,329 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { createHash } from 'crypto';
+
+import { AuditService } from '../audit/audit.service';
+import { SupabaseService } from '../supabase/supabase.service';
+import {
+  DATA_RETENTION_POLICIES,
+  PrivacySubjectKey,
+  RetentionPolicy,
+  SubjectIdentifier,
+} from './data-retention.policy';
+
+export interface ErasureSubject {
+  publicKey?: string;
+  username?: string;
+  userId?: string;
+}
+
+export interface StoreRetentionResult {
+  storeKey: string;
+  tableName: string;
+  action: 'delete' | 'anonymize';
+  affectedRows: number;
+  error?: string;
+}
+
+export interface PrivacyWorkflowResult {
+  runAt: string;
+  results: StoreRetentionResult[];
+}
+
+type QueryBuilder = {
+  delete?: () => QueryBuilder;
+  update?: (values: Record<string, unknown>) => QueryBuilder;
+  eq?: (column: string, value: unknown) => QueryBuilder;
+  lt?: (column: string, value: unknown) => QueryBuilder;
+  select?: (columns?: string) => Promise<{ data?: unknown[] | null; error?: { message?: string } | null }>;
+};
+
+@Injectable()
+export class PrivacyRetentionService {
+  private readonly logger = new Logger(PrivacyRetentionService.name);
+
+  constructor(
+    private readonly supabaseService: SupabaseService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  getPolicies(): readonly RetentionPolicy[] {
+    return DATA_RETENTION_POLICIES;
+  }
+
+  async enforceRetention(now = new Date()): Promise<PrivacyWorkflowResult> {
+    const runAt = now.toISOString();
+    const results: StoreRetentionResult[] = [];
+
+    for (const policy of DATA_RETENTION_POLICIES) {
+      results.push(await this.enforcePolicyRetention(policy, now));
+    }
+
+    await this.auditService.log('system', 'privacy.retention.enforced', undefined, {
+      runAt,
+      results,
+    });
+
+    return { runAt, results };
+  }
+
+  async eraseSubject(
+    subject: ErasureSubject,
+    requestedBy = 'system',
+  ): Promise<PrivacyWorkflowResult> {
+    if (!subject.publicKey && !subject.username && !subject.userId) {
+      throw new BadRequestException(
+        'At least one erasure subject identifier is required',
+      );
+    }
+
+    const runAt = new Date().toISOString();
+    const results: StoreRetentionResult[] = [];
+
+    for (const policy of DATA_RETENTION_POLICIES) {
+      const matches = this.getSubjectMatches(policy, subject);
+      if (matches.length === 0) {
+        results.push({
+          storeKey: policy.storeKey,
+          tableName: policy.tableName,
+          action: policy.action,
+          affectedRows: 0,
+        });
+        continue;
+      }
+
+      let affectedRows = 0;
+      const errors: string[] = [];
+
+      for (const match of matches) {
+        const result = await this.applySubjectErasure(policy, match, subject);
+        affectedRows += result.affectedRows;
+        if (result.error) errors.push(result.error);
+      }
+
+      results.push({
+        storeKey: policy.storeKey,
+        tableName: policy.tableName,
+        action: policy.action,
+        affectedRows,
+        ...(errors.length > 0 && { error: errors.join('; ') }),
+      });
+    }
+
+    await this.auditService.log(requestedBy, 'privacy.erasure.completed', undefined, {
+      runAt,
+      subject: this.maskSubject(subject),
+      results,
+    });
+
+    return { runAt, results };
+  }
+
+  private async enforcePolicyRetention(
+    policy: RetentionPolicy,
+    now: Date,
+  ): Promise<StoreRetentionResult> {
+    try {
+      const client = this.supabaseService.getClient();
+      const cutoff = this.getRetentionCutoff(policy, now);
+      const table = client.from(policy.tableName) as unknown as QueryBuilder;
+      const query = policy.action === 'delete'
+        ? this.requireMethod(table, 'delete')()
+        : this.requireMethod(table, 'update')(
+            this.buildAnonymizedValues(policy, { retentionRunAt: now.toISOString() }),
+          );
+
+      this.requireMethod(query, 'lt')(policy.retentionColumn, cutoff);
+      const { data, error } = await this.requireMethod(query, 'select')('id');
+
+      if (error) {
+        throw new Error(error.message ?? 'Supabase retention query failed');
+      }
+
+      const affectedRows = data?.length ?? 0;
+      if (affectedRows > 0) {
+        this.logger.log(
+          `${policy.action}d ${affectedRows} rows from ${policy.tableName} during retention enforcement`,
+        );
+      }
+
+      return {
+        storeKey: policy.storeKey,
+        tableName: policy.tableName,
+        action: policy.action,
+        affectedRows,
+      };
+    } catch (error) {
+      const message = (error as Error).message;
+      this.logger.warn(
+        `Retention enforcement failed for ${policy.tableName}: ${message}`,
+      );
+      return {
+        storeKey: policy.storeKey,
+        tableName: policy.tableName,
+        action: policy.action,
+        affectedRows: 0,
+        error: message,
+      };
+    }
+  }
+
+  private async applySubjectErasure(
+    policy: RetentionPolicy,
+    match: { column: string; value: string },
+    subject: ErasureSubject,
+  ): Promise<StoreRetentionResult> {
+    try {
+      const client = this.supabaseService.getClient();
+      const table = client.from(policy.tableName) as unknown as QueryBuilder;
+      const query = policy.action === 'delete'
+        ? this.requireMethod(table, 'delete')()
+        : this.requireMethod(table, 'update')(
+            this.buildAnonymizedValues(policy, {
+              subject,
+              matchedColumn: match.column,
+            }),
+          );
+
+      this.requireMethod(query, 'eq')(match.column, match.value);
+      const { data, error } = await this.requireMethod(query, 'select')('id');
+
+      if (error) {
+        throw new Error(error.message ?? 'Supabase erasure query failed');
+      }
+
+      return {
+        storeKey: policy.storeKey,
+        tableName: policy.tableName,
+        action: policy.action,
+        affectedRows: data?.length ?? 0,
+      };
+    } catch (error) {
+      const message = (error as Error).message;
+      this.logger.warn(
+        `Erasure failed for ${policy.tableName}.${match.column}: ${message}`,
+      );
+      return {
+        storeKey: policy.storeKey,
+        tableName: policy.tableName,
+        action: policy.action,
+        affectedRows: 0,
+        error: message,
+      };
+    }
+  }
+
+  private getRetentionCutoff(policy: RetentionPolicy, now: Date): string {
+    if (policy.cutoffMode === 'absolute') {
+      return now.toISOString();
+    }
+
+    return new Date(
+      now.getTime() - policy.retentionDays * 24 * 60 * 60 * 1000,
+    ).toISOString();
+  }
+
+  private getSubjectMatches(
+    policy: RetentionPolicy,
+    subject: ErasureSubject,
+  ): Array<{ column: string; value: string }> {
+    const seen = new Set<string>();
+    const matches: Array<{ column: string; value: string }> = [];
+
+    for (const identifier of policy.subjectIdentifiers) {
+      const value = this.getSubjectValue(identifier, subject);
+      if (!value) continue;
+
+      const dedupeKey = `${identifier.column}:${value}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      matches.push({ column: identifier.column, value });
+    }
+
+    return matches;
+  }
+
+  private getSubjectValue(
+    identifier: SubjectIdentifier,
+    subject: ErasureSubject,
+  ): string | undefined {
+    const value = subject[identifier.key as PrivacySubjectKey];
+    return value?.trim() || undefined;
+  }
+
+  private buildAnonymizedValues(
+    policy: RetentionPolicy,
+    context: {
+      subject?: ErasureSubject;
+      matchedColumn?: string;
+      retentionRunAt?: string;
+    },
+  ): Record<string, unknown> {
+    const anonymized = this.anonymizedSubjectValue(policy, context);
+    const values: Record<string, unknown> = { ...(policy.setColumns ?? {}) };
+
+    for (const column of policy.anonymizeColumns ?? []) {
+      values[column] = anonymized;
+    }
+    for (const column of policy.nullColumns ?? []) {
+      values[column] = null;
+    }
+    if (policy.tableName === 'support_bundle_references') {
+      values.redacted_at = context.retentionRunAt ?? new Date().toISOString();
+    }
+
+    return values;
+  }
+
+  private anonymizedSubjectValue(
+    policy: RetentionPolicy,
+    context: {
+      subject?: ErasureSubject;
+      matchedColumn?: string;
+      retentionRunAt?: string;
+    },
+  ): string {
+    const source = JSON.stringify({
+      storeKey: policy.storeKey,
+      subject: context.subject ?? null,
+      matchedColumn: context.matchedColumn ?? null,
+      retentionRunAt: context.retentionRunAt ?? null,
+    });
+
+    const digest = createHash('sha256').update(source).digest('hex').slice(0, 24);
+    return `erased:${digest}`;
+  }
+
+  private maskSubject(subject: ErasureSubject): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(subject)
+        .filter(([, value]) => value)
+        .map(([key, value]) => [
+          key,
+          this.anonymizedSubjectValue(
+            {
+              storeKey: `audit-${key}`,
+              tableName: 'audit',
+              description: 'audit subject mask',
+              retentionDays: 0,
+              retentionColumn: 'created_at',
+              cutoffMode: 'age',
+              action: 'anonymize',
+              subjectIdentifiers: [],
+            },
+            { subject: { [key]: value } as ErasureSubject },
+          ),
+        ]),
+    );
+  }
+
+  private requireMethod<TName extends keyof QueryBuilder>(
+    query: QueryBuilder,
+    method: TName,
+  ): NonNullable<QueryBuilder[TName]> {
+    const fn = query[method];
+    if (!fn) {
+      throw new Error(`Supabase query missing ${String(method)} method`);
+    }
+    return fn.bind(query) as NonNullable<QueryBuilder[TName]>;
+  }
+}

--- a/app/backend/src/privacy/privacy-retention.service.unit.spec.ts
+++ b/app/backend/src/privacy/privacy-retention.service.unit.spec.ts
@@ -1,0 +1,174 @@
+import { BadRequestException } from '@nestjs/common';
+
+import { AuditService } from '../audit/audit.service';
+import { SupabaseService } from '../supabase/supabase.service';
+import { DATA_RETENTION_POLICIES } from './data-retention.policy';
+import { PrivacyRetentionService } from './privacy-retention.service';
+
+class FakeQuery {
+  operation: 'delete' | 'update' | null = null;
+  updatePayload: Record<string, unknown> | null = null;
+  filters: Array<{ method: 'eq' | 'lt'; column: string; value: unknown }> = [];
+
+  constructor(
+    readonly tableName: string,
+    private readonly rows: unknown[] = [{ id: 'row-1' }],
+  ) {}
+
+  delete() {
+    this.operation = 'delete';
+    return this;
+  }
+
+  update(values: Record<string, unknown>) {
+    this.operation = 'update';
+    this.updatePayload = values;
+    return this;
+  }
+
+  eq(column: string, value: unknown) {
+    this.filters.push({ method: 'eq', column, value });
+    return this;
+  }
+
+  lt(column: string, value: unknown) {
+    this.filters.push({ method: 'lt', column, value });
+    return this;
+  }
+
+  async select() {
+    return { data: this.rows, error: null };
+  }
+}
+
+describe('PrivacyRetentionService', () => {
+  let service: PrivacyRetentionService;
+  let queries: FakeQuery[];
+  let auditService: jest.Mocked<Partial<AuditService>>;
+
+  beforeEach(() => {
+    queries = [];
+    const supabaseService: Partial<SupabaseService> = {
+      getClient: jest.fn(() => ({
+        from: (tableName: string) => {
+          const query = new FakeQuery(tableName);
+          queries.push(query);
+          return query;
+        },
+      })) as never,
+    };
+
+    auditService = {
+      log: jest.fn().mockResolvedValue(undefined),
+    };
+
+    service = new PrivacyRetentionService(
+      supabaseService as SupabaseService,
+      auditService as unknown as AuditService,
+    );
+  });
+
+  it('declares retention for each personal-data store centrally', () => {
+    const tableNames = DATA_RETENTION_POLICIES.map((policy) => policy.tableName);
+
+    expect(new Set(tableNames).size).toBe(tableNames.length);
+    expect(tableNames).toEqual(
+      expect.arrayContaining([
+        'usernames',
+        'crash_reports',
+        'crash_reporting_settings',
+        'notification_preferences',
+        'notification_log',
+        'abuse_signals',
+        'support_bundle_references',
+        'payment_links',
+        'recurring_payment_links',
+        'unmatched_transactions',
+        'admin_audit_logs',
+      ]),
+    );
+    expect(
+      DATA_RETENTION_POLICIES.every(
+        (policy) => policy.retentionDays > 0 && policy.retentionColumn,
+      ),
+    ).toBe(true);
+  });
+
+  it('documents stores that are anonymized for financial or audit integrity', () => {
+    const anonymizedStores = DATA_RETENTION_POLICIES.filter(
+      (policy) => policy.action === 'anonymize',
+    );
+
+    expect(anonymizedStores.length).toBeGreaterThan(0);
+    expect(
+      anonymizedStores.every((policy) => policy.financialIntegrityNote),
+    ).toBe(true);
+  });
+
+  it('enforces retention across every declared store and records the run', async () => {
+    const result = await service.enforceRetention(new Date('2026-08-25T00:00:00.000Z'));
+
+    expect(result.results).toHaveLength(DATA_RETENTION_POLICIES.length);
+    expect(queries.map((query) => query.tableName)).toEqual(
+      DATA_RETENTION_POLICIES.map((policy) => policy.tableName),
+    );
+    expect(queries.every((query) => query.filters[0]?.method === 'lt')).toBe(true);
+    expect(auditService.log).toHaveBeenCalledWith(
+      'system',
+      'privacy.retention.enforced',
+      undefined,
+      expect.objectContaining({ results: expect.any(Array) }),
+    );
+  });
+
+  it('services erasure across every declared store', async () => {
+    const result = await service.eraseSubject(
+      {
+        publicKey: 'GABC123',
+        username: 'alice',
+        userId: 'user-123',
+      },
+      'admin-key',
+    );
+
+    expect(result.results).toHaveLength(DATA_RETENTION_POLICIES.length);
+    expect(new Set(result.results.map((item) => item.tableName))).toEqual(
+      new Set(DATA_RETENTION_POLICIES.map((policy) => policy.tableName)),
+    );
+
+    const paymentLinkQuery = queries.find(
+      (query) => query.tableName === 'payment_links' && query.operation === 'update',
+    );
+    expect(paymentLinkQuery?.updatePayload).toEqual(
+      expect.objectContaining({
+        owner_public_key: expect.stringMatching(/^erased:/),
+        destination_public_key: expect.stringMatching(/^erased:/),
+        memo: null,
+        reference_id: null,
+      }),
+    );
+
+    const usernameQuery = queries.find((query) => query.tableName === 'usernames');
+    expect(usernameQuery?.operation).toBe('delete');
+
+    expect(auditService.log).toHaveBeenCalledWith(
+      'admin-key',
+      'privacy.erasure.completed',
+      undefined,
+      expect.objectContaining({
+        subject: expect.objectContaining({
+          publicKey: expect.stringMatching(/^erased:/),
+          username: expect.stringMatching(/^erased:/),
+          userId: expect.stringMatching(/^erased:/),
+        }),
+      }),
+    );
+  });
+
+  it('requires at least one subject identifier for erasure', async () => {
+    await expect(service.eraseSubject({})).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+});
+

--- a/app/backend/src/privacy/privacy.module.ts
+++ b/app/backend/src/privacy/privacy.module.ts
@@ -1,10 +1,17 @@
 import { Module } from "@nestjs/common";
+import { AuthModule } from "../auth";
+import { AuditModule } from "../audit/audit.module";
+import { SupabaseModule } from "../supabase/supabase.module";
+import { PrivacyAdminController } from "./privacy-admin.controller";
 import { PrivacyController } from "./privacy.controller";
+import { PrivacyRetentionScheduler } from "./privacy-retention.scheduler";
+import { PrivacyRetentionService } from "./privacy-retention.service";
 import { PrivacyService } from "./privacy.service";
 
 @Module({
-  controllers: [PrivacyController],
-  providers: [PrivacyService],
-  exports: [PrivacyService],
+  imports: [AuditModule, AuthModule, SupabaseModule],
+  controllers: [PrivacyController, PrivacyAdminController],
+  providers: [PrivacyService, PrivacyRetentionService, PrivacyRetentionScheduler],
+  exports: [PrivacyService, PrivacyRetentionService],
 })
 export class PrivacyModule {}


### PR DESCRIPTION
## Overview
- Adds a central privacy retention policy covering the backend personal-data stores.
- Adds a scheduled retention worker plus guarded admin endpoints for manual retention runs and right-to-erasure requests.
- Deletes eligible personal data and anonymizes stores that must preserve financial/audit integrity.

## Related Issue
Closes #821

## Changes
- Added DATA_RETENTION_POLICIES as the single declaration of retention windows, subject identifiers, and delete/anonymize behavior.
- Added PrivacyRetentionService to enforce retention, service erasure requests, anonymize retained financial/audit rows, and audit workflow results.
- Added PrivacyRetentionScheduler for daily enforcement and admin API routes under /admin/privacy.
- Added unit coverage proving all declared stores are included in retention and erasure workflows.

## Verification Results
- npm.cmd run test:unit -- privacy --runInBand: passed (2 suites, 20 tests).
- npm.cmd run type-check: passed.
- npm.cmd run lint: passed.
- npm.cmd run build: passed.
- npm.cmd run test:unit -- --runInBand: passed (119 suites, 1452 tests).

## Acceptance Criteria
| Criteria | Status | Notes |
| --- | --- | --- |
| Each personal-data store declares a retention period in one central policy definition. | Done | DATA_RETENTION_POLICIES is the single declaration. |
| A scheduled job enforces retention and records what it deleted. | Done | Daily scheduler runs PrivacyRetentionService and audit logs per-store results. |
| An erasure request removes or irreversibly anonymises the data of a subject across declared stores. | Done | Admin erasure workflow deletes or anonymizes every declared store matching subject identifiers. |
| Records that must be retained for financial integrity are anonymised rather than deleted, and this is documented. | Done | Financial/audit policies use anonymize action and include integrity notes. |
| Tests prove erasure coverage across every declared store. | Done | PrivacyRetentionService tests compare erasure results with the central policy table set. |