### PR TITLE
feat(backend): real SEP-24 anchor handshake for fiat-ramps deposits/withdrawals

### DIFF
--- a/app/backend/src/fiat-ramps/errors/fiat-ramp-errors.ts
+++ b/app/backend/src/fiat-ramps/errors/fiat-ramp-errors.ts
@@ -1,0 +1,86 @@
+/**
+ * Typed errors for the SEP-24 anchor handshake (SEP-01 discovery,
+ * SEP-10 authentication, SEP-24 interactive initiation).
+ *
+ * Each error carries stable fields (domain, phase, operation, ...) so
+ * controllers and API consumers can map them deterministically to HTTP
+ * responses without string matching.
+ */
+
+export class AnchorNotFoundError extends Error {
+  constructor(
+    public readonly domain: string,
+    message?: string,
+  ) {
+    super(
+      message ??
+        `Anchor "${domain}" could not be discovered. stellar.toml is unreachable, invalid, or missing the required SEP-24/SEP-10 endpoints.`,
+    );
+    this.name = 'AnchorNotFoundError';
+  }
+}
+
+/**
+ * The requested asset is not listed in the anchor's stellar.toml CURRENCIES.
+ *
+ * Note: this is distinct from the `UnsupportedAssetError` in
+ * `src/config/stellar.config.ts`, which validates assets against QuickEx's
+ * own supported-asset list. This error validates against the anchor's
+ * declared capabilities.
+ */
+export class UnsupportedAssetError extends Error {
+  constructor(
+    public readonly assetCode: string,
+    public readonly domain: string,
+    message?: string,
+  ) {
+    super(
+      message ?? `Anchor "${domain}" does not support asset "${assetCode}".`,
+    );
+    this.name = 'UnsupportedAssetError';
+  }
+}
+
+export type Sep10AuthPhase =
+  | 'challenge_request'
+  | 'challenge_parse'
+  | 'token_exchange';
+
+export class Sep10AuthError extends Error {
+  constructor(
+    public readonly domain: string,
+    public readonly phase: Sep10AuthPhase,
+    message?: string,
+  ) {
+    super(
+      message ??
+        `SEP-10 authentication with anchor "${domain}" failed during ${phase}.`,
+    );
+    this.name = 'Sep10AuthError';
+  }
+}
+
+export class Sep24InitiationError extends Error {
+  constructor(
+    public readonly domain: string,
+    public readonly operation: 'deposit' | 'withdraw',
+    message?: string,
+  ) {
+    super(
+      message ??
+        `SEP-24 ${operation} initiation with anchor "${domain}" failed.`,
+    );
+    this.name = 'Sep24InitiationError';
+  }
+}
+
+/**
+ * Backend configuration is insufficient for the handshake (e.g. the Stellar
+ * signing keypair is not configured).
+ */
+export class FiatRampsConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FiatRampsConfigurationError';
+  }
+}

--- a/app/backend/src/fiat-ramps/errors/index.ts
+++ b/app/backend/src/fiat-ramps/errors/index.ts
@@ -1,0 +1,8 @@
+export {
+  AnchorNotFoundError,
+  UnsupportedAssetError,
+  Sep10AuthError,
+  Sep24InitiationError,
+  FiatRampsConfigurationError,
+} from './fiat-ramp-errors';
+export type { Sep10AuthPhase } from './fiat-ramp-errors';

--- a/app/backend/src/fiat-ramps/fiat-ramps.controller.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.controller.ts
@@ -1,10 +1,29 @@
-import { Controller, Get, Post, Body, Query, UseInterceptors } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Query,
+  UseInterceptors,
+  BadRequestException,
+  BadGatewayException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiHeader } from '@nestjs/swagger';
 import { FiatRampsService } from './fiat-ramps.service';
 import {
   IdempotencyInterceptor,
   IDEMPOTENCY_KEY_HEADER,
 } from '../common/idempotency/idempotency.interceptor';
+import {
+  AnchorNotFoundError,
+  FiatRampsConfigurationError,
+  Sep10AuthError,
+  Sep24InitiationError,
+  UnsupportedAssetError,
+} from './errors';
 
 @ApiTags('fiat-ramps')
 @ApiHeader({
@@ -28,15 +47,31 @@ export class FiatRampsController {
   @Post('deposit')
   @ApiOperation({ summary: 'Initiate SEP-24 hosted deposit flow' })
   @ApiResponse({ status: 201, description: 'Deposit flow initiated' })
+  @ApiResponse({ status: 400, description: 'Asset not supported by the anchor' })
+  @ApiResponse({ status: 401, description: 'SEP-10 authentication with the anchor failed' })
+  @ApiResponse({ status: 404, description: 'Anchor could not be discovered (stellar.toml unreachable or misconfigured)' })
+  @ApiResponse({ status: 502, description: 'SEP-24 interactive initiation failed' })
   async initiateDeposit(@Body() depositDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
-    return this.fiatRampsService.initiateDeposit(depositDto);
+    try {
+      return await this.fiatRampsService.initiateDeposit(depositDto);
+    } catch (err) {
+      this.mapFiatRampError(err);
+    }
   }
 
   @Post('withdraw')
   @ApiOperation({ summary: 'Initiate SEP-24 hosted withdrawal flow' })
   @ApiResponse({ status: 201, description: 'Withdrawal flow initiated' })
+  @ApiResponse({ status: 400, description: 'Asset not supported by the anchor' })
+  @ApiResponse({ status: 401, description: 'SEP-10 authentication with the anchor failed' })
+  @ApiResponse({ status: 404, description: 'Anchor could not be discovered (stellar.toml unreachable or misconfigured)' })
+  @ApiResponse({ status: 502, description: 'SEP-24 interactive initiation failed' })
   async initiateWithdrawal(@Body() withdrawalDto: { assetCode: string; amount: number; userAccount: string; anchorDomain: string }) {
-    return this.fiatRampsService.initiateWithdrawal(withdrawalDto);
+    try {
+      return await this.fiatRampsService.initiateWithdrawal(withdrawalDto);
+    } catch (err) {
+      this.mapFiatRampError(err);
+    }
   }
 
   @Post('kyc/callback')
@@ -49,5 +84,43 @@ export class FiatRampsController {
   @ApiOperation({ summary: 'Securely handle transaction status updates' })
   async updateTransactionStatus(@Body() statusData: unknown) {
     return this.fiatRampsService.updateTransactionStatus(statusData);
+  }
+
+  /**
+   * Map handshake failures to stable HTTP responses with deterministic
+   * error codes. Re-throws anything that is not a fiat-ramp typed error.
+   */
+  private mapFiatRampError(err: unknown): never {
+    if (err instanceof AnchorNotFoundError) {
+      throw new NotFoundException({
+        code: 'ANCHOR_NOT_FOUND',
+        message: err.message,
+      });
+    }
+    if (err instanceof UnsupportedAssetError) {
+      throw new BadRequestException({
+        code: 'UNSUPPORTED_ASSET',
+        message: err.message,
+      });
+    }
+    if (err instanceof Sep10AuthError) {
+      throw new UnauthorizedException({
+        code: 'SEP10_AUTH_FAILED',
+        message: err.message,
+      });
+    }
+    if (err instanceof Sep24InitiationError) {
+      throw new BadGatewayException({
+        code: 'SEP24_INITIATION_FAILED',
+        message: err.message,
+      });
+    }
+    if (err instanceof FiatRampsConfigurationError) {
+      throw new InternalServerErrorException({
+        code: 'FIAT_RAMPS_CONFIGURATION',
+        message: err.message,
+      });
+    }
+    throw err;
   }
 }

--- a/app/backend/src/fiat-ramps/fiat-ramps.int.spec.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.int.spec.ts
@@ -1,0 +1,340 @@
+import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
+import { AddressInfo } from 'net';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Keypair, Networks, WebAuth } from '@stellar/stellar-sdk';
+
+import { AppConfigService } from '../config/app-config.service';
+import { Sep24TransactionRepository } from './sep24-transaction.repository';
+import {
+  FiatRampsService,
+  FIAT_RAMPS_SERVICE_OPTIONS,
+} from './fiat-ramps.service';
+import { Sep10AuthError, UnsupportedAssetError } from './errors';
+
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+const HOME_DOMAIN_PREFIX = '127.0.0.1';
+
+/** Stub anchor signing keypair (SIGNING_KEY in stellar.toml). */
+const serverKeypair = Keypair.random();
+/** Backend wallet keypair (STELLAR_SECRET_KEY / STELLAR_PUBLIC_KEY). */
+const clientKeypair = Keypair.random();
+const USER_ACCOUNT = Keypair.random().publicKey();
+
+const mockAppConfig = {
+  stellarSecretKey: clientKeypair.secret(),
+  stellarPublicKey: clientKeypair.publicKey(),
+  stellarNetworkPassphrase: NETWORK_PASSPHRASE,
+};
+
+/** Mock SEP-24 transaction repository (records are persisted after handshake). */
+const mockSep24Repository = {
+  create: jest.fn(),
+};
+
+interface StubAnchor {
+  server: Server;
+  port: number;
+  close: () => Promise<void>;
+}
+
+function tomlText(port: number): string {
+  const domain = `${HOME_DOMAIN_PREFIX}:${port}`;
+  return [
+    'NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"',
+    `WEB_AUTH_ENDPOINT = "http://${domain}/auth"`,
+    `TRANSFER_SERVER_SEP0024 = "http://${domain}/transfer"`,
+    `WEB_AUTH_DOMAIN = "${domain}"`,
+    `SIGNING_KEY = "${serverKeypair.publicKey()}"`,
+    '[[CURRENCIES]]',
+    'code = "USDC"',
+    `issuer = "${Keypair.random().publicKey()}"`,
+    '[[CURRENCIES]]',
+    'code = "XLM"',
+    '',
+  ].join('\n');
+}
+
+function send(
+  res: ServerResponse,
+  status: number,
+  contentType: string,
+  data: string,
+): void {
+  res.writeHead(status, { 'Content-Type': contentType });
+  res.end(data);
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk: Buffer) => {
+      data += chunk.toString();
+    });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function startServer(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve(port);
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+/**
+ * Spin up a stubbed anchor on an ephemeral port that speaks SEP-01, SEP-10
+ * and SEP-24 against the real `@stellar/stellar-sdk` crypto.
+ */
+async function createStubAnchor(options: {
+  failTokenExchange?: boolean;
+} = {}): Promise<StubAnchor> {
+  const failTokenExchange = options.failTokenExchange ?? false;
+  const state = { port: 0 };
+  const server = createServer((req, res) => {
+    void handleRequest(req, res, () => state.port, failTokenExchange);
+  });
+  state.port = await startServer(server);
+  return {
+    server,
+    port: state.port,
+    close: () => closeServer(server),
+  };
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  getPort: () => number,
+  failTokenExchange: boolean,
+): Promise<void> {
+  const domain = `${HOME_DOMAIN_PREFIX}:${getPort()}`;
+  const url = new URL(req.url ?? '/', `http://${domain}`);
+  const method = req.method ?? 'GET';
+
+  // SEP-01: serve stellar.toml
+  if (method === 'GET' && url.pathname === '/.well-known/stellar.toml') {
+    send(res, 200, 'application/toml', tomlText(getPort()));
+    return;
+  }
+
+  // SEP-10: challenge request + token exchange
+  if (method === 'POST' && url.pathname === '/auth') {
+    const params = new URLSearchParams(await readBody(req));
+
+    // Challenge request: { account }
+    if (params.has('account') && !params.has('transaction')) {
+      const challenge = WebAuth.buildChallengeTx(
+        serverKeypair,
+        params.get('account') as string,
+        domain,
+        300,
+        NETWORK_PASSPHRASE,
+        domain,
+      );
+      send(res, 200, 'application/json', JSON.stringify({ transaction: challenge }));
+      return;
+    }
+
+    // Token exchange: { transaction }
+    if (params.has('transaction')) {
+      if (failTokenExchange) {
+        send(
+          res,
+          401,
+          'application/json',
+          JSON.stringify({ error: 'invalid challenge signature' }),
+        );
+        return;
+      }
+      try {
+        WebAuth.verifyChallengeTxSigners(
+          params.get('transaction') as string,
+          serverKeypair.publicKey(),
+          NETWORK_PASSPHRASE,
+          [clientKeypair.publicKey()],
+          [domain],
+          domain,
+        );
+      } catch {
+        send(
+          res,
+          401,
+          'application/json',
+          JSON.stringify({ error: 'invalid challenge signature' }),
+        );
+        return;
+      }
+      send(res, 200, 'application/json', JSON.stringify({ token: 'stub-jwt' }));
+      return;
+    }
+
+    send(res, 400, 'application/json', JSON.stringify({ error: 'missing account or transaction' }));
+    return;
+  }
+
+  // SEP-24: interactive initiation (deposit / withdraw)
+  if (method === 'POST' && url.pathname.startsWith('/transfer/')) {
+    if (req.headers.authorization !== 'Bearer stub-jwt') {
+      send(res, 401, 'application/json', JSON.stringify({ error: 'unauthorized' }));
+      return;
+    }
+
+    const params = new URLSearchParams(await readBody(req));
+    const assetCode = params.get('asset_code') ?? '';
+    const operation = url.pathname.endsWith('/withdraw/interactive')
+      ? 'withdraw'
+      : 'deposit';
+    const interactiveUrl = `http://${domain}/interactive/${operation}?token=stub-jwt&asset=${assetCode}`;
+
+    send(
+      res,
+      200,
+      'application/json',
+      JSON.stringify({
+        id: operation === 'deposit' ? 'dep-1' : 'wth-1',
+        type: 'interactive_customer_info_needed',
+        url: interactiveUrl,
+      }),
+    );
+    return;
+  }
+
+  send(res, 404, 'application/json', JSON.stringify({ error: 'not found' }));
+}
+
+describe('FiatRampsService (stub anchor integration)', () => {
+  let service: FiatRampsService;
+  let stub: StubAnchor;
+
+  beforeEach(async () => {
+    stub = await createStubAnchor();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FiatRampsService,
+        { provide: AppConfigService, useValue: mockAppConfig },
+        { provide: Sep24TransactionRepository, useValue: mockSep24Repository },
+        {
+          // Short TOML timeout keeps the SDK's CancelToken timers from
+          // lingering past Jest's exit grace period. Prod default is 5000ms.
+          provide: FIAT_RAMPS_SERVICE_OPTIONS,
+          useValue: { allowHttp: true, tomlTimeoutMs: 250 },
+        },
+      ],
+    }).compile();
+
+    service = module.get<FiatRampsService>(FiatRampsService);
+    mockSep24Repository.create.mockReset().mockResolvedValue({ id: 'record-1' });
+  });
+
+  afterEach(async () => {
+    await stub.close();
+  });
+
+  it('completes the end-to-end deposit handshake against the stub anchor', async () => {
+    const domain = `${HOME_DOMAIN_PREFIX}:${stub.port}`;
+
+    const result = await service.initiateDeposit({
+      assetCode: 'USDC',
+      amount: 100,
+      userAccount: USER_ACCOUNT,
+      anchorDomain: domain,
+    });
+
+    expect(result).toEqual({
+      status: 'success',
+      transaction_id: 'dep-1',
+      internal_id: 'record-1',
+      type: 'interactive_customer_info_needed',
+      url: `http://${domain}/interactive/deposit?token=stub-jwt&asset=USDC`,
+    });
+
+    // The handshake result is persisted so the SEP-24 polling worker can track it.
+    expect(mockSep24Repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        anchor_transaction_id: 'dep-1',
+        type: 'deposit',
+        asset_code: 'USDC',
+        interactive_url: `http://${domain}/interactive/deposit?token=stub-jwt&asset=USDC`,
+      }),
+    );
+  });
+
+  it('completes the end-to-end withdrawal handshake against the stub anchor', async () => {
+    const domain = `${HOME_DOMAIN_PREFIX}:${stub.port}`;
+
+    const result = await service.initiateWithdrawal({
+      assetCode: 'XLM',
+      amount: 50,
+      userAccount: USER_ACCOUNT,
+      anchorDomain: domain,
+    });
+
+    expect(result).toEqual({
+      status: 'success',
+      transaction_id: 'wth-1',
+      internal_id: 'record-1',
+      type: 'interactive_customer_info_needed',
+      url: `http://${domain}/interactive/withdraw?token=stub-jwt&asset=XLM`,
+    });
+  });
+
+  it('rejects assets the anchor does not list in stellar.toml', async () => {
+    const domain = `${HOME_DOMAIN_PREFIX}:${stub.port}`;
+
+    const err = await service
+      .initiateDeposit({
+        assetCode: 'EURC',
+        amount: 10,
+        userAccount: USER_ACCOUNT,
+        anchorDomain: domain,
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(UnsupportedAssetError);
+    expect((err as UnsupportedAssetError).assetCode).toBe('EURC');
+  });
+
+  it('throws Sep10AuthError when the anchor rejects the signed challenge', async () => {
+    const failingStub = await createStubAnchor({ failTokenExchange: true });
+    try {
+      const err = await service
+        .initiateDeposit({
+          assetCode: 'USDC',
+          amount: 10,
+          userAccount: USER_ACCOUNT,
+          anchorDomain: `${HOME_DOMAIN_PREFIX}:${failingStub.port}`,
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(Sep10AuthError);
+      expect((err as Sep10AuthError).phase).toBe('token_exchange');
+    } finally {
+      await failingStub.close();
+    }
+  });
+
+  it('throws AnchorNotFoundError when the anchor is unreachable', async () => {
+    const err = await service
+      .initiateDeposit({
+        assetCode: 'USDC',
+        amount: 10,
+        userAccount: USER_ACCOUNT,
+        anchorDomain: '127.0.0.1:1', // nothing listening on port 1
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe('AnchorNotFoundError');
+  });
+});

--- a/app/backend/src/fiat-ramps/fiat-ramps.service.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.service.ts
@@ -1,6 +1,68 @@
-import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
+import { Injectable, Logger, Optional, Inject } from '@nestjs/common';
+import {
+  Keypair,
+  StellarToml,
+  TransactionBuilder,
+  WebAuth,
+} from '@stellar/stellar-sdk';
+
+import { AppConfigService } from '../config/app-config.service';
 import { Sep24TransactionRepository } from './sep24-transaction.repository';
 import { Sep24InternalStatus } from './types/sep24.types';
+import {
+  AnchorNotFoundError,
+  FiatRampsConfigurationError,
+  Sep10AuthError,
+  Sep24InitiationError,
+  UnsupportedAssetError,
+} from './errors';
+
+/**
+ * Injection token for overriding handshake options (used by tests to allow
+ * plain-HTTP resolution of a local stub anchor). When omitted, production
+ * defaults apply.
+ */
+export const FIAT_RAMPS_SERVICE_OPTIONS = Symbol('FIAT_RAMPS_SERVICE_OPTIONS');
+
+export interface FiatRampsServiceOptions {
+  /**
+   * Allow resolving stellar.toml over plain HTTP. Must remain false in
+   * production; enabled only for local stub-anchor tests.
+   */
+  allowHttp?: boolean;
+  /** Timeout (ms) for stellar.toml resolution. */
+  tomlTimeoutMs?: number;
+}
+
+export type Sep24Operation = 'deposit' | 'withdraw';
+
+export interface InitiateFiatRampDto {
+  assetCode: string;
+  amount: number;
+  userAccount: string;
+  anchorDomain: string;
+}
+
+export interface Sep24InteractiveResult {
+  status: string;
+  transaction_id: string;
+  internal_id: string | null;
+  type: string;
+  url: string;
+}
+
+/**
+ * Anchor capabilities discovered from stellar.toml (SEP-01).
+ */
+interface DiscoveredAnchor {
+  toml: StellarToml.Api.StellarToml;
+  webAuthUrl: string;
+  transferServerUrl: string;
+  /** WEB_AUTH_DOMAIN from stellar.toml, falling back to the home domain. */
+  webAuthDomain: string;
+}
+
+const DEFAULT_TOML_TIMEOUT_MS = 5000;
 
 @Injectable()
 export class FiatRampsService {
@@ -8,6 +70,9 @@ export class FiatRampsService {
 
   constructor(
     private readonly sep24Repository: Sep24TransactionRepository,
+    private readonly config: AppConfigService,
+    @Optional() @Inject(FIAT_RAMPS_SERVICE_OPTIONS)
+    private readonly options?: FiatRampsServiceOptions,
   ) {}
 
   async getAvailableAnchors(assetCode: string, country: string) {
@@ -33,99 +98,22 @@ export class FiatRampsService {
     };
   }
 
-  async initiateDeposit(depositDto: {
-    assetCode: string;
-    amount: number;
-    userAccount: string;
-    anchorDomain: string;
-  }) {
-    this.logger.log(`Initiating SEP-24 deposit flow with ${depositDto.anchorDomain}`);
-
-    try {
-      // Build mock interactive URL (real integration would use stellar-sdk toml resolver
-      // + SEP-10 auth to obtain a JWT then POST /sep24/transactions/deposit/interactive)
-      const anchorTransactionId = `dep_${Date.now()}`;
-      const interactiveUrl =
-        `https://${depositDto.anchorDomain}/sep24/interactive` +
-        `?type=deposit&asset_code=${depositDto.assetCode}&account=${depositDto.userAccount}`;
-
-      // Persist the in-flight transaction so the poller can track it
-      const record = await this.sep24Repository.create({
-        anchor_transaction_id: anchorTransactionId,
-        anchor_domain: depositDto.anchorDomain,
-        type: 'deposit',
-        status: Sep24InternalStatus.Initiated,
-        anchor_status: null,
-        stellar_tx_hash: null,
-        amount: String(depositDto.amount),
-        asset_code: depositDto.assetCode,
-        asset_issuer: null,
-        user_account: depositDto.userAccount,
-        interactive_url: interactiveUrl,
-      });
-
-      this.logger.log(
-        `SEP-24 deposit initiated: anchor_tx=${anchorTransactionId} ` +
-        `record_id=${record?.id ?? 'unknown'}`,
-      );
-
-      return {
-        status: 'success',
-        transaction_id: anchorTransactionId,
-        internal_id: record?.id ?? null,
-        type: 'interactive_customer_info_needed',
-        url: interactiveUrl,
-      };
-    } catch (error) {
-      this.logger.error(`Error initiating deposit: ${(error as Error).message}`);
-      throw new HttpException('Failed to initiate deposit', HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+  /**
+   * Initiate a SEP-24 hosted deposit: discover the anchor via stellar.toml
+   * (SEP-01), authenticate with SEP-10, then start the interactive flow and
+   * return the anchor-provided interactive URL.
+   */
+  async initiateDeposit(depositDto: InitiateFiatRampDto): Promise<Sep24InteractiveResult> {
+    return this.initiateInteractiveFlow('deposit', depositDto);
   }
 
-  async initiateWithdrawal(withdrawalDto: {
-    assetCode: string;
-    amount: number;
-    userAccount: string;
-    anchorDomain: string;
-  }) {
-    this.logger.log(`Initiating SEP-24 withdrawal flow with ${withdrawalDto.anchorDomain}`);
-
-    try {
-      const anchorTransactionId = `wth_${Date.now()}`;
-      const interactiveUrl =
-        `https://${withdrawalDto.anchorDomain}/sep24/interactive` +
-        `?type=withdraw&asset_code=${withdrawalDto.assetCode}&account=${withdrawalDto.userAccount}`;
-
-      const record = await this.sep24Repository.create({
-        anchor_transaction_id: anchorTransactionId,
-        anchor_domain: withdrawalDto.anchorDomain,
-        type: 'withdrawal',
-        status: Sep24InternalStatus.Initiated,
-        anchor_status: null,
-        stellar_tx_hash: null,
-        amount: String(withdrawalDto.amount),
-        asset_code: withdrawalDto.assetCode,
-        asset_issuer: null,
-        user_account: withdrawalDto.userAccount,
-        interactive_url: interactiveUrl,
-      });
-
-      this.logger.log(
-        `SEP-24 withdrawal initiated: anchor_tx=${anchorTransactionId} ` +
-        `record_id=${record?.id ?? 'unknown'}`,
-      );
-
-      return {
-        status: 'success',
-        transaction_id: anchorTransactionId,
-        internal_id: record?.id ?? null,
-        type: 'interactive_customer_info_needed',
-        url: interactiveUrl,
-      };
-    } catch (error) {
-      this.logger.error(`Error initiating withdrawal: ${(error as Error).message}`);
-      throw new HttpException('Failed to initiate withdrawal', HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+  /**
+   * Initiate a SEP-24 hosted withdrawal: discover the anchor via stellar.toml
+   * (SEP-01), authenticate with SEP-10, then start the interactive flow and
+   * return the anchor-provided interactive URL.
+   */
+  async initiateWithdrawal(withdrawalDto: InitiateFiatRampDto): Promise<Sep24InteractiveResult> {
+    return this.initiateInteractiveFlow('withdraw', withdrawalDto);
   }
 
   async handleKycCallback(callbackData: unknown) {
@@ -157,12 +145,337 @@ export class FiatRampsService {
 
           this.logger.log(
             `Webhook status update applied for anchor_tx=${anchorTransactionId}: ` +
-            `internal=${internalStatus}`,
+              `internal=${internalStatus}`,
           );
         }
       }
     }
 
     return { status: 'acknowledged' };
+  }
+
+  // ─── SEP-24 handshake ──────────────────────────────────────────────────────
+
+  /**
+   * Full SEP-24 handshake shared by deposits and withdrawals:
+   *
+   * 1. SEP-01  — resolve the anchor's stellar.toml, extract SEP-10/SEP-24
+   *              endpoints, and verify the requested asset is supported.
+   * 2. SEP-10  — obtain a challenge from the anchor, sign it with the backend
+   *              keypair, and exchange it for a JWT.
+   * 3. SEP-24  — POST to /deposit/interactive (or /withdraw/interactive) with
+   *              the JWT and return the interactive URL from the response.
+   *
+   * The initiated transaction is persisted via {@link Sep24TransactionRepository}
+   * so the SEP-24 polling worker can track it through to completion.
+   */
+  private async initiateInteractiveFlow(
+    operation: Sep24Operation,
+    dto: InitiateFiatRampDto,
+  ): Promise<Sep24InteractiveResult> {
+    const { assetCode, amount, userAccount, anchorDomain } = dto;
+
+    this.logger.log(
+      `Initiating SEP-24 ${operation} flow with ${anchorDomain} (asset=${assetCode})`,
+    );
+
+    const anchor = await this.discoverAnchor(anchorDomain);
+    this.assertAssetSupported(anchorDomain, assetCode, anchor);
+
+    const jwt = await this.authenticateSep10(anchorDomain, anchor);
+
+    const interactive = await this.initiateSep24(
+      operation,
+      anchorDomain,
+      anchor,
+      assetCode,
+      amount,
+      userAccount,
+      jwt,
+    );
+
+    // The anchor-assigned transaction id (falling back to a local id when the
+    // anchor response does not include one) is what the polling worker uses to
+    // query SEP-24 GET /transaction.
+    const anchorTransactionId =
+      interactive.id ?? `${operation === 'deposit' ? 'dep' : 'wth'}_${Date.now()}`;
+    const interactiveUrl = interactive.url;
+
+    const record = await this.sep24Repository.create({
+      anchor_transaction_id: anchorTransactionId,
+      anchor_domain: anchorDomain,
+      type: operation === 'deposit' ? 'deposit' : 'withdrawal',
+      status: Sep24InternalStatus.Initiated,
+      anchor_status: null,
+      stellar_tx_hash: null,
+      amount: String(amount),
+      asset_code: assetCode,
+      asset_issuer: null,
+      user_account: userAccount,
+      interactive_url: interactiveUrl,
+    });
+
+    this.logger.log(
+      `SEP-24 ${operation} initiated: anchor_tx=${anchorTransactionId} ` +
+        `record_id=${record?.id ?? 'unknown'}`,
+    );
+
+    return {
+      status: 'success',
+      transaction_id: anchorTransactionId,
+      internal_id: record?.id ?? null,
+      type: interactive.type ?? 'interactive_customer_info_needed',
+      url: interactiveUrl,
+    };
+  }
+
+  // ─── SEP-01: anchor discovery ─────────────────────────────────────────────
+
+  /**
+   * Resolve and validate the anchor's stellar.toml for the given domain.
+   * Throws {@link AnchorNotFoundError} when the TOML cannot be fetched/parsed
+   * or when required SEP-10/SEP-24 endpoints are missing.
+   */
+  private async discoverAnchor(domain: string): Promise<DiscoveredAnchor> {
+    let toml: StellarToml.Api.StellarToml;
+    try {
+      toml = await StellarToml.Resolver.resolve(domain, {
+        allowHttp: this.options?.allowHttp ?? false,
+        timeout: this.options?.tomlTimeoutMs ?? DEFAULT_TOML_TIMEOUT_MS,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `stellar.toml resolution failed for ${domain}: ${(err as Error).message}`,
+      );
+      throw new AnchorNotFoundError(domain);
+    }
+
+    const webAuthUrl = toml.WEB_AUTH_ENDPOINT;
+    const transferServerUrl = toml.TRANSFER_SERVER_SEP0024;
+
+    if (!webAuthUrl || !transferServerUrl) {
+      throw new AnchorNotFoundError(
+        domain,
+        `Anchor "${domain}" is misconfigured: stellar.toml must declare WEB_AUTH_ENDPOINT and TRANSFER_SERVER_SEP0024.`,
+      );
+    }
+
+    return {
+      toml,
+      webAuthUrl,
+      transferServerUrl,
+      // Per SEP-10, WEB_AUTH_DOMAIN falls back to the home domain when absent.
+      // The SDK type omits WEB_AUTH_DOMAIN, so it surfaces via the index
+      // signature as `unknown`.
+      webAuthDomain: (toml.WEB_AUTH_DOMAIN as string | undefined) || domain,
+    };
+  }
+
+  /**
+   * Verify the requested asset is listed in the anchor's stellar.toml
+   * CURRENCIES. Throws {@link UnsupportedAssetError} otherwise.
+   */
+  private assertAssetSupported(
+    domain: string,
+    assetCode: string,
+    anchor: DiscoveredAnchor,
+  ): void {
+    const normalizedCode = assetCode.trim().toUpperCase();
+    const supported = (anchor.toml.CURRENCIES ?? []).some(
+      (currency) => currency.code?.toUpperCase() === normalizedCode,
+    );
+
+    if (!supported) {
+      throw new UnsupportedAssetError(normalizedCode, domain);
+    }
+  }
+
+  // ─── SEP-10: authentication ───────────────────────────────────────────────
+
+  /**
+   * Complete the SEP-10 web-authentication flow against the anchor:
+   *
+   * 1. POST { account } to WEB_AUTH_ENDPOINT to request a challenge.
+   * 2. Verify the challenge (signed by the anchor's SIGNING_KEY) and sign it
+   *    with the backend keypair.
+   * 3. POST { transaction } back to obtain the JWT token.
+   */
+  private async authenticateSep10(
+    domain: string,
+    anchor: DiscoveredAnchor,
+  ): Promise<string> {
+    const secretKey = this.config.stellarSecretKey;
+    const publicKey = this.config.stellarPublicKey;
+
+    if (!secretKey || !publicKey) {
+      throw new FiatRampsConfigurationError(
+        'STELLAR_SECRET_KEY and STELLAR_PUBLIC_KEY must be configured to authenticate with anchors via SEP-10.',
+      );
+    }
+
+    const signingKey = anchor.toml.SIGNING_KEY;
+    if (!signingKey) {
+      throw new Sep10AuthError(
+        domain,
+        'challenge_parse',
+        `Anchor "${domain}" stellar.toml does not declare a SIGNING_KEY, so the SEP-10 challenge cannot be verified.`,
+      );
+    }
+
+    // 1. Request the challenge transaction.
+    let challengeXdr: string;
+    try {
+      const challengeRes = await fetch(anchor.webAuthUrl, {
+        method: 'POST',
+        headers: this.sep10Headers(),
+        body: new URLSearchParams({ account: publicKey }).toString(),
+      });
+      if (!challengeRes.ok) {
+        throw new Error(`anchor returned HTTP ${challengeRes.status}`);
+      }
+      const challengePayload = (await challengeRes.json()) as {
+        transaction?: string;
+      };
+      if (!challengePayload.transaction) {
+        throw new Error('response did not include a challenge transaction');
+      }
+      challengeXdr = challengePayload.transaction;
+    } catch (err) {
+      this.logger.warn(
+        `SEP-10 challenge request failed for ${domain}: ${(err as Error).message}`,
+      );
+      throw new Sep10AuthError(
+        domain,
+        'challenge_request',
+        `Unable to obtain a SEP-10 challenge from anchor "${domain}": ${(err as Error).message}`,
+      );
+    }
+
+    // 2. Validate the challenge (server signature + structure) and sign it.
+    let signedXdr: string;
+    try {
+      WebAuth.readChallengeTx(
+        challengeXdr,
+        signingKey,
+        this.config.stellarNetworkPassphrase,
+        [domain],
+        anchor.webAuthDomain,
+      );
+
+      const transaction = TransactionBuilder.fromXDR(
+        challengeXdr,
+        this.config.stellarNetworkPassphrase,
+      );
+      transaction.sign(Keypair.fromSecret(secretKey));
+      signedXdr = transaction.toEnvelope().toXDR('base64').toString();
+    } catch (err) {
+      this.logger.warn(
+        `SEP-10 challenge validation/signing failed for ${domain}: ${(err as Error).message}`,
+      );
+      throw new Sep10AuthError(
+        domain,
+        'challenge_parse',
+        `Unable to validate or sign the SEP-10 challenge from anchor "${domain}": ${(err as Error).message}`,
+      );
+    }
+
+    // 3. Exchange the signed challenge for a JWT.
+    try {
+      const tokenRes = await fetch(anchor.webAuthUrl, {
+        method: 'POST',
+        headers: this.sep10Headers(),
+        body: new URLSearchParams({ transaction: signedXdr }).toString(),
+      });
+      if (!tokenRes.ok) {
+        throw new Error(`anchor returned HTTP ${tokenRes.status}`);
+      }
+      const tokenPayload = (await tokenRes.json()) as { token?: string };
+      if (!tokenPayload.token) {
+        throw new Error('response did not include a token');
+      }
+      return tokenPayload.token;
+    } catch (err) {
+      this.logger.warn(
+        `SEP-10 token exchange failed for ${domain}: ${(err as Error).message}`,
+      );
+      throw new Sep10AuthError(
+        domain,
+        'token_exchange',
+        `Unable to exchange the signed SEP-10 challenge for a token with anchor "${domain}": ${(err as Error).message}`,
+      );
+    }
+  }
+
+  // ─── SEP-24: interactive initiation ───────────────────────────────────────
+
+  /**
+   * POST to the anchor's SEP-24 transfer server to start the interactive
+   * flow. Returns the anchor-provided payload; the interactive URL comes
+   * exclusively from the anchor's response.
+   */
+  private async initiateSep24(
+    operation: Sep24Operation,
+    domain: string,
+    anchor: DiscoveredAnchor,
+    assetCode: string,
+    amount: number,
+    userAccount: string,
+    jwt: string,
+  ): Promise<{ id?: string; type?: string; url: string }> {
+    const endpoint = `${anchor.transferServerUrl.replace(/\/+$/, '')}/${operation}/interactive`;
+
+    let payload: { id?: string; type?: string; url?: string };
+    try {
+      const body = new URLSearchParams({
+        asset_code: assetCode,
+        account: userAccount,
+        lang: 'en',
+      });
+      if (amount > 0) {
+        body.append('amount', String(amount));
+      }
+
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: body.toString(),
+      });
+      if (!res.ok) {
+        throw new Error(`anchor returned HTTP ${res.status}`);
+      }
+      payload = (await res.json()) as { id?: string; type?: string; url?: string };
+    } catch (err) {
+      this.logger.warn(
+        `SEP-24 ${operation} initiation failed for ${domain}: ${(err as Error).message}`,
+      );
+      throw new Sep24InitiationError(
+        domain,
+        operation,
+        `Unable to initiate a SEP-24 ${operation} with anchor "${domain}": ${(err as Error).message}`,
+      );
+    }
+
+    if (!payload.url) {
+      throw new Sep24InitiationError(
+        domain,
+        operation,
+        `Anchor "${domain}" responded without an interactive url for ${operation}.`,
+      );
+    }
+
+    return payload as { id?: string; type?: string; url: string };
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  private sep10Headers(): Record<string, string> {
+    return {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    };
   }
 }

--- a/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
@@ -1,0 +1,389 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  Keypair,
+  Networks,
+  StellarToml,
+  WebAuth,
+} from '@stellar/stellar-sdk';
+
+import { AppConfigService } from '../config/app-config.service';
+import { Sep24TransactionRepository } from './sep24-transaction.repository';
+import { Sep24InternalStatus } from './types/sep24.types';
+import { FiatRampsService } from './fiat-ramps.service';
+import {
+  AnchorNotFoundError,
+  FiatRampsConfigurationError,
+  Sep10AuthError,
+  Sep24InitiationError,
+  UnsupportedAssetError,
+} from './errors';
+
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+const ANCHOR_DOMAIN = 'anchor.example';
+const AUTH_URL = `https://${ANCHOR_DOMAIN}/auth`;
+const TRANSFER_URL = `https://${ANCHOR_DOMAIN}/sep24`;
+
+/** Stub anchor signing keypair (SIGNING_KEY in stellar.toml). */
+const serverKeypair = Keypair.random();
+/** Backend wallet keypair (STELLAR_SECRET_KEY / STELLAR_PUBLIC_KEY). */
+const clientKeypair = Keypair.random();
+
+const mockAppConfig = {
+  stellarSecretKey: clientKeypair.secret(),
+  stellarPublicKey: clientKeypair.publicKey(),
+  stellarNetworkPassphrase: NETWORK_PASSPHRASE,
+};
+
+const minimalAppConfig = {
+  stellarSecretKey: undefined,
+  stellarPublicKey: undefined,
+  stellarNetworkPassphrase: NETWORK_PASSPHRASE,
+};
+
+/** Mock SEP-24 transaction repository (records are persisted after handshake). */
+const mockSep24Repository = {
+  create: jest.fn(),
+};
+
+function buildChallenge(account: string): string {
+  return WebAuth.buildChallengeTx(
+    serverKeypair,
+    account,
+    ANCHOR_DOMAIN,
+    300,
+    NETWORK_PASSPHRASE,
+    ANCHOR_DOMAIN,
+  );
+}
+
+function anchorToml(
+  overrides: Partial<StellarToml.Api.StellarToml> = {},
+): StellarToml.Api.StellarToml {
+  return {
+    WEB_AUTH_ENDPOINT: AUTH_URL,
+    TRANSFER_SERVER_SEP0024: TRANSFER_URL,
+    WEB_AUTH_DOMAIN: ANCHOR_DOMAIN,
+    SIGNING_KEY: serverKeypair.publicKey(),
+    CURRENCIES: [
+      { code: 'USDC', issuer: serverKeypair.publicKey() },
+      { code: 'XLM' },
+    ],
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+describe('FiatRampsService', () => {
+  let service: FiatRampsService;
+  let resolveSpy: jest.SpyInstance;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FiatRampsService,
+        { provide: AppConfigService, useValue: mockAppConfig },
+        { provide: Sep24TransactionRepository, useValue: mockSep24Repository },
+      ],
+    }).compile();
+
+    service = module.get<FiatRampsService>(FiatRampsService);
+    mockSep24Repository.create.mockReset().mockResolvedValue({ id: 'record-1' });
+    resolveSpy = jest.spyOn(StellarToml.Resolver, 'resolve');
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('initiateDeposit', () => {
+    it('completes the full SEP-01/SEP-10/SEP-24 handshake and returns the anchor-provided URL', async () => {
+      const challenge = buildChallenge(clientKeypair.publicKey());
+      const interactiveUrl = `${TRANSFER_URL}/deposit?token=abc123`;
+
+      resolveSpy.mockResolvedValue(anchorToml());
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({ transaction: challenge }))
+        .mockResolvedValueOnce(jsonResponse({ token: 'jwt-token-123' }))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            id: 'dep-123',
+            type: 'interactive_customer_info_needed',
+            url: interactiveUrl,
+          }),
+        );
+
+      const result = await service.initiateDeposit({
+        assetCode: 'USDC',
+        amount: 100,
+        userAccount: 'GUSER123',
+        anchorDomain: ANCHOR_DOMAIN,
+      });
+
+      expect(result).toEqual({
+        status: 'success',
+        transaction_id: 'dep-123',
+        internal_id: 'record-1',
+        type: 'interactive_customer_info_needed',
+        url: interactiveUrl,
+      });
+
+      // SEP-01: resolved the anchor's stellar.toml for the requested domain.
+      expect(resolveSpy).toHaveBeenCalledWith(
+        ANCHOR_DOMAIN,
+        expect.objectContaining({ allowHttp: false }),
+      );
+
+      // SEP-10 step 1: challenge requested for the backend public key.
+      const challengeCall = fetchSpy.mock.calls[0];
+      expect(challengeCall[0]).toBe(AUTH_URL);
+      const challengeBody = new URLSearchParams(
+        (challengeCall[1] as RequestInit).body as string,
+      );
+      expect(challengeBody.get('account')).toBe(clientKeypair.publicKey());
+
+      // SEP-10 step 2: the submitted transaction is the challenge signed by
+      // the backend keypair (real signature verification).
+      const tokenCall = fetchSpy.mock.calls[1];
+      const tokenBody = new URLSearchParams(
+        (tokenCall[1] as RequestInit).body as string,
+      );
+      const signedXdr = tokenBody.get('transaction') as string;
+      const signers = WebAuth.verifyChallengeTxSigners(
+        signedXdr,
+        serverKeypair.publicKey(),
+        NETWORK_PASSPHRASE,
+        [clientKeypair.publicKey()],
+        [ANCHOR_DOMAIN],
+        ANCHOR_DOMAIN,
+      );
+      expect(signers).toContain(clientKeypair.publicKey());
+
+      // SEP-24: authenticated POST to /deposit/interactive with the JWT.
+      const sep24Call = fetchSpy.mock.calls[2];
+      expect(sep24Call[0]).toBe(`${TRANSFER_URL}/deposit/interactive`);
+      const sep24Init = sep24Call[1] as RequestInit;
+      expect((sep24Init.headers as Record<string, string>).Authorization).toBe(
+        'Bearer jwt-token-123',
+      );
+      const sep24Body = new URLSearchParams(sep24Init.body as string);
+      expect(sep24Body.get('asset_code')).toBe('USDC');
+      expect(sep24Body.get('account')).toBe('GUSER123');
+
+      // The initiated transaction is persisted for the SEP-24 polling worker,
+      // using the anchor-assigned id and the anchor-provided interactive URL.
+      expect(mockSep24Repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          anchor_transaction_id: 'dep-123',
+          anchor_domain: ANCHOR_DOMAIN,
+          type: 'deposit',
+          status: Sep24InternalStatus.Initiated,
+          amount: '100',
+          asset_code: 'USDC',
+          user_account: 'GUSER123',
+          interactive_url: interactiveUrl,
+        }),
+      );
+    });
+
+    it('throws AnchorNotFoundError when stellar.toml cannot be resolved', async () => {
+      resolveSpy.mockRejectedValue(new Error('connection refused'));
+
+      await expect(
+        service.initiateDeposit({
+          assetCode: 'USDC',
+          amount: 10,
+          userAccount: 'GUSER123',
+          anchorDomain: ANCHOR_DOMAIN,
+        }),
+      ).rejects.toThrow(AnchorNotFoundError);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws AnchorNotFoundError when required endpoints are missing from stellar.toml', async () => {
+      resolveSpy.mockResolvedValue(
+        anchorToml({ TRANSFER_SERVER_SEP0024: undefined }),
+      );
+
+      await expect(
+        service.initiateDeposit({
+          assetCode: 'USDC',
+          amount: 10,
+          userAccount: 'GUSER123',
+          anchorDomain: ANCHOR_DOMAIN,
+        }),
+      ).rejects.toThrow(AnchorNotFoundError);
+    });
+
+    it('throws UnsupportedAssetError when the asset is not listed by the anchor', async () => {
+      resolveSpy.mockResolvedValue(anchorToml());
+
+      const err = await service
+        .initiateDeposit({
+          assetCode: 'EURC',
+          amount: 10,
+          userAccount: 'GUSER123',
+          anchorDomain: ANCHOR_DOMAIN,
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(UnsupportedAssetError);
+      expect((err as UnsupportedAssetError).assetCode).toBe('EURC');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws Sep10AuthError with phase token_exchange when the anchor rejects the token exchange', async () => {
+      const challenge = buildChallenge(clientKeypair.publicKey());
+      resolveSpy.mockResolvedValue(anchorToml());
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({ transaction: challenge }))
+        .mockResolvedValueOnce(
+          jsonResponse({ error: 'invalid challenge signature' }, false, 401),
+        );
+
+      const err = await service
+        .initiateDeposit({
+          assetCode: 'USDC',
+          amount: 10,
+          userAccount: 'GUSER123',
+          anchorDomain: ANCHOR_DOMAIN,
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(Sep10AuthError);
+      expect((err as Sep10AuthError).phase).toBe('token_exchange');
+    });
+
+    it('throws Sep10AuthError when the challenge response has no transaction', async () => {
+      resolveSpy.mockResolvedValue(anchorToml());
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+
+      const err = await service
+        .initiateDeposit({
+          assetCode: 'USDC',
+          amount: 10,
+          userAccount: 'GUSER123',
+          anchorDomain: ANCHOR_DOMAIN,
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(Sep10AuthError);
+      expect((err as Sep10AuthError).phase).toBe('challenge_request');
+    });
+
+    it('throws Sep24InitiationError when the interactive endpoint fails', async () => {
+      const challenge = buildChallenge(clientKeypair.publicKey());
+      resolveSpy.mockResolvedValue(anchorToml());
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({ transaction: challenge }))
+        .mockResolvedValueOnce(jsonResponse({ token: 'jwt-token-123' }))
+        .mockResolvedValueOnce(
+          jsonResponse({ error: 'anchor error' }, false, 500),
+        );
+
+      const err = await service
+        .initiateDeposit({
+          assetCode: 'USDC',
+          amount: 10,
+          userAccount: 'GUSER123',
+          anchorDomain: ANCHOR_DOMAIN,
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(Sep24InitiationError);
+      expect((err as Sep24InitiationError).operation).toBe('deposit');
+    });
+
+    it('throws Sep24InitiationError when the anchor omits the interactive url', async () => {
+      const challenge = buildChallenge(clientKeypair.publicKey());
+      resolveSpy.mockResolvedValue(anchorToml());
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({ transaction: challenge }))
+        .mockResolvedValueOnce(jsonResponse({ token: 'jwt-token-123' }))
+        .mockResolvedValueOnce(jsonResponse({ id: 'dep-999' }));
+
+      const err = await service
+        .initiateDeposit({
+          assetCode: 'USDC',
+          amount: 10,
+          userAccount: 'GUSER123',
+          anchorDomain: ANCHOR_DOMAIN,
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(Sep24InitiationError);
+    });
+
+    it('throws FiatRampsConfigurationError when the signing keypair is not configured', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FiatRampsService,
+          { provide: AppConfigService, useValue: minimalAppConfig },
+          { provide: Sep24TransactionRepository, useValue: mockSep24Repository },
+        ],
+      }).compile();
+      const unconfiguredService = module.get<FiatRampsService>(FiatRampsService);
+      resolveSpy.mockResolvedValue(anchorToml());
+
+      const err = await unconfiguredService
+        .initiateDeposit({
+          assetCode: 'USDC',
+          amount: 10,
+          userAccount: 'GUSER123',
+          anchorDomain: ANCHOR_DOMAIN,
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(FiatRampsConfigurationError);
+    });
+  });
+
+  describe('initiateWithdrawal', () => {
+    it('runs the handshake and returns the anchor-provided withdrawal URL', async () => {
+      const challenge = buildChallenge(clientKeypair.publicKey());
+      const interactiveUrl = `${TRANSFER_URL}/withdraw?token=xyz789`;
+
+      resolveSpy.mockResolvedValue(anchorToml());
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({ transaction: challenge }))
+        .mockResolvedValueOnce(jsonResponse({ token: 'jwt-token-456' }))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            id: 'wth-456',
+            type: 'interactive_customer_info_needed',
+            url: interactiveUrl,
+          }),
+        );
+
+      const result = await service.initiateWithdrawal({
+        assetCode: 'XLM',
+        amount: 50,
+        userAccount: 'GUSER123',
+        anchorDomain: ANCHOR_DOMAIN,
+      });
+
+      expect(result).toEqual({
+        status: 'success',
+        transaction_id: 'wth-456',
+        internal_id: 'record-1',
+        type: 'interactive_customer_info_needed',
+        url: interactiveUrl,
+      });
+
+      const sep24Call = fetchSpy.mock.calls[2];
+      expect(sep24Call[0]).toBe(`${TRANSFER_URL}/withdraw/interactive`);
+      const sep24Init = sep24Call[1] as RequestInit;
+      expect((sep24Init.headers as Record<string, string>).Authorization).toBe(
+        'Bearer jwt-token-456',
+      );
+      const sep24Body = new URLSearchParams(sep24Init.body as string);
+      expect(sep24Body.get('asset_code')).toBe('XLM');
+      expect(sep24Body.get('amount')).toBe('50');
+    });
+  });
+});


### PR DESCRIPTION
Closes #805

---

Closes #866

---

## Summary

Implements genuine anchor discovery and SEP-24 initiation for fiat-ramps deposits
and withdrawals. Previously `fiat-ramps.service.ts` constructed mock interactive
URLs by hand (never negotiated with the anchor). Now the backend performs the full
SEP-01 → SEP-10 → SEP-24 handshake against the anchor and returns the
anchor-provided interactive URL.

## Acceptance Criteria

- [x] Anchor capabilities are discovered from the anchor `stellar.toml` (SEP-01)
      rather than assumed — endpoints, `SIGNING_KEY`, `WEB_AUTH_DOMAIN`, and
      supported `CURRENCIES` are read from the resolved TOML.
- [x] SEP-10 authentication is performed (challenge request → sign with backend
      keypair → JWT exchange) and the resulting token is used for SEP-24 initiation
      (`Authorization: Bearer <jwt>`).
- [x] Interactive URLs come from the anchor's SEP-24 response, never string
      construction; a response without `url` is a typed error.
- [x] Unsupported assets / unreachable anchors return stable typed errors:
      `AnchorNotFoundError`, `UnsupportedAssetError`, `Sep10AuthError`,
      `Sep24InitiationError`, `FiatRampsConfigurationError` — mapped to fixed
      HTTP codes (404/400/401/502/500) with stable `code` fields.
- [x] Tests cover the handshake against a stubbed anchor (real HTTP stub serving
      SEP-01/SEP-10/SEP-24), including auth failure.

## Changes

- `app/backend/src/fiat-ramps/fiat-ramps.service.ts` — SEP-01 discovery,
  SEP-10 auth, SEP-24 interactive initiation; `FIAT_RAMPS_SERVICE_OPTIONS`
  injection token for test-only plain-HTTP resolution.
- `app/backend/src/fiat-ramps/fiat-ramps.controller.ts` — maps typed errors to
  stable HTTP responses with deterministic error codes.
- `app/backend/src/fiat-ramps/errors/fiat-ramp-errors.ts` (+ `errors/index.ts`) —
  typed handshake errors carrying stable fields (domain, phase, operation, asset).
- `app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts` — 10 unit tests
  (real SDK crypto, mocked fetch).
- `app/backend/src/fiat-ramps/fiat-ramps.int.spec.ts` — 5 integration tests
  against a stubbed anchor (deposit, withdrawal, unsupported asset, auth failure,
  unreachable anchor).

## Test Results

- Unit (fiat-ramps): 10 passed
- Integration (fiat-ramps): 5 passed
- Full backend suite: 118 suites / 1404 tests passed
- `tsc --noEmit`: clean · ESLint (backend): clean
- `test:unit:coverage` (CI gate): 105 suites / 1283 tests, thresholds met
- `test:int:coverage` (CI gate): 6 suites / 50 tests passed

## Testing Steps

1. `pnpm exec jest --config jest.unit.config.ts src/fiat-ramps`
2. `pnpm exec jest --config jest.int.config.ts src/fiat-ramps`
3. `pnpm test` (full backend suite)
4. `pnpm type-check` && `pnpm lint`
5. Optional live check: `POST /fiat-ramps/deposit` with `assetCode`, `amount`,
   `userAccount`, `anchorDomain` — expect an anchor-provided interactive URL or a
   typed error (`ANCHOR_NOT_FOUND`/`UNSUPPORTED_ASSET`/`SEP10_AUTH_FAILED`/
   `SEP24_INITIATION_FAILED`).

## Notes

- `STELLAR_SECRET_KEY` / `STELLAR_PUBLIC_KEY` / network passphrase must be
  configured for SEP-10 auth (typed `FiatRampsConfigurationError` otherwise).
- Plain-HTTP `stellar.toml` resolution is allowed only via
  `FIAT_RAMPS_SERVICE_OPTIONS.allowHttp` (used by local stub-anchor tests);
  production defaults to HTTPS.
