### PR TITLE
feat: add analytics dashboard summary

### DIFF
--- a/app/backend/src/analytics/analytics.controller.ts
+++ b/app/backend/src/analytics/analytics.controller.ts
@@ -9,6 +9,7 @@ import {
   TimeSeriesQueryDto,
   ReportFormat,
 } from './dto/analytics-query.dto';
+import { DashboardSummaryQueryDto } from './dto/dashboard-summary.dto';
 
 @ApiTags('analytics')
 @UseGuards(ApiKeyGuard)
@@ -111,5 +112,20 @@ export class AnalyticsController {
     res.header('Content-Type', 'text/csv');
     res.attachment(filename);
     return res.send(csv);
+  }
+
+  @Get('dashboard-summary')
+  @ApiOperation({
+    summary: 'Fetch compact dashboard summary metrics for header cards',
+  })
+  @ApiResponse({ status: 200, description: 'Dashboard summary generated' })
+  async getDashboardSummary(@Req() req: Request, @Query() query: DashboardSummaryQueryDto) {
+    return this.analyticsService.getDashboardSummary(
+      query.publicKey,
+      query.timeRange,
+      query.startDate,
+      query.endDate,
+      req.organizationContext?.organizationId,
+    );
   }
 }

--- a/app/backend/src/analytics/analytics.service.ts
+++ b/app/backend/src/analytics/analytics.service.ts
@@ -1,9 +1,10 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { SupabaseService } from '../supabase/supabase.service';
 import {
   AnalyticsInterval,
   ReportType,
 } from './dto/analytics-query.dto';
+import { TimeRange } from './dto/dashboard-summary.dto';
 
 type PaymentRow = Record<string, unknown>;
 type RpcSummaryRow = {
@@ -73,9 +74,82 @@ export type AnalyticsReport = {
   };
 };
 
+export type DashboardSummary = {
+  volume: {
+    totalVolumeUsd: number;
+    paymentCount: number;
+  };
+  payments: {
+    successfulCount: number;
+    failedCount: number;
+    pendingCount: number;
+  };
+  refunds: {
+    totalCount: number;
+    pendingCount: number;
+    approvedCount: number;
+  };
+  health: {
+    successRate: number;
+    deliveryFailureRate: number;
+  };
+  window: {
+    startDate: string;
+    endDate: string;
+  };
+};
+
 @Injectable()
 export class AnalyticsService {
+  private readonly logger = new Logger(AnalyticsService.name);
+
   constructor(private readonly supabase: SupabaseService) {}
+
+  async getDashboardSummary(
+    publicKey: string,
+    timeRange: TimeRange = TimeRange.WEEK,
+    startDate?: string,
+    endDate?: string,
+    organizationId?: string,
+  ): Promise<DashboardSummary> {
+    const { startIso, endIso } = this.resolveTimeRange(timeRange, startDate, endDate);
+
+    const [analyticsReport, refundCounts, deliveryFailures] = await Promise.all([
+      this.getAnalyticsReport(publicKey, startIso, endIso, AnalyticsInterval.DAILY, organizationId),
+      this.fetchRefundCounts(publicKey, startIso, endIso, organizationId),
+      this.fetchDeliveryFailureCount(publicKey, startIso, endIso, organizationId),
+    ]);
+
+    const pendingPayments = await this.fetchPendingPaymentCount(publicKey, startIso, endIso, organizationId);
+
+    return {
+      volume: {
+        totalVolumeUsd: analyticsReport.summary.totalVolumeUsd,
+        paymentCount: analyticsReport.summary.totalTransactions,
+      },
+      payments: {
+        successfulCount: analyticsReport.summary.successfulTransactions,
+        failedCount: analyticsReport.summary.failedTransactions,
+        pendingCount: pendingPayments,
+      },
+      refunds: {
+        totalCount: refundCounts.total,
+        pendingCount: refundCounts.pending,
+        approvedCount: refundCounts.approved,
+      },
+      health: {
+        successRate: analyticsReport.summary.conversionRate,
+        deliveryFailureRate: this.calculateDeliveryFailureRate(
+          analyticsReport.summary.totalTransactions,
+          deliveryFailures,
+        ),
+      },
+      window: {
+        startDate: startIso,
+        endDate: endIso,
+      },
+    };
+  }
 
   async getAnalyticsReport(
     publicKey: string,
@@ -580,6 +654,42 @@ export class AnalyticsService {
     return 0;
   }
 
+  private resolveTimeRange(
+    timeRange: TimeRange,
+    startDate?: string,
+    endDate?: string,
+  ): { startIso: string; endIso: string } {
+    if (timeRange === TimeRange.CUSTOM) {
+      return this.resolveDateWindow(startDate, endDate);
+    }
+
+    const end = new Date();
+    let start: Date;
+
+    switch (timeRange) {
+      case TimeRange.TODAY:
+        start = new Date(end);
+        start.setUTCHours(0, 0, 0, 0);
+        break;
+      case TimeRange.WEEK:
+        start = new Date(end);
+        start.setUTCDate(start.getUTCDate() - 7);
+        break;
+      case TimeRange.MONTH:
+        start = new Date(end);
+        start.setUTCDate(start.getUTCDate() - 30);
+        break;
+      default:
+        start = new Date(end);
+        start.setUTCDate(start.getUTCDate() - 7);
+    }
+
+    return {
+      startIso: start.toISOString(),
+      endIso: end.toISOString(),
+    };
+  }
+
   private resolveDateWindow(startDate?: string, endDate?: string): { startIso: string; endIso: string } {
     const end = endDate ? new Date(endDate) : new Date();
     const start = startDate
@@ -658,5 +768,105 @@ export class AnalyticsService {
 
   private round2(value: number): number {
     return Math.round(value * 100) / 100;
+  }
+
+  private async fetchRefundCounts(
+    publicKey: string,
+    startIso: string,
+    endIso: string,
+    organizationId?: string,
+  ): Promise<{ total: number; pending: number; approved: number }> {
+    const client = this.supabase.getClient();
+
+    let query = client
+      .from('refund_attempts')
+      .select('status')
+      .gte('created_at', startIso)
+      .lte('created_at', endIso);
+
+    if (organizationId) {
+      query = query.eq('organization_id', organizationId);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      this.logger.warn(`Failed to fetch refund counts: ${error.message}`);
+      return { total: 0, pending: 0, approved: 0 };
+    }
+
+    const refunds = data ?? [];
+    return {
+      total: refunds.length,
+      pending: refunds.filter((r) => r.status === 'pending').length,
+      approved: refunds.filter((r) => r.status === 'approved').length,
+    };
+  }
+
+  private async fetchPendingPaymentCount(
+    publicKey: string,
+    startIso: string,
+    endIso: string,
+    organizationId?: string,
+  ): Promise<number> {
+    const client = this.supabase.getClient();
+
+    let query = client
+      .from('payment_records')
+      .select('id')
+      .or(`sender_public_key.eq.${publicKey},receiver_public_key.eq.${publicKey}`)
+      .gte('created_at', startIso)
+      .lte('created_at', endIso)
+      .in('status', ['pending', 'processing']);
+
+    if (organizationId) {
+      query = query.eq('organization_id', organizationId);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      this.logger.warn(`Failed to fetch pending payment count: ${error.message}`);
+      return 0;
+    }
+
+    return data?.length ?? 0;
+  }
+
+  private async fetchDeliveryFailureCount(
+    publicKey: string,
+    startIso: string,
+    endIso: string,
+    organizationId?: string,
+  ): Promise<number> {
+    const client = this.supabase.getClient();
+
+    let query = client
+      .from('notification_logs')
+      .select('id')
+      .eq('recipient_public_key', publicKey)
+      .eq('status', 'failed')
+      .gte('created_at', startIso)
+      .lte('created_at', endIso);
+
+    if (organizationId) {
+      query = query.eq('organization_id', organizationId);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      this.logger.warn(`Failed to fetch delivery failure count: ${error.message}`);
+      return 0;
+    }
+
+    return data?.length ?? 0;
+  }
+
+  private calculateDeliveryFailureRate(totalTransactions: number, deliveryFailures: number): number {
+    if (totalTransactions === 0) {
+      return 0;
+    }
+    return this.round2((deliveryFailures / totalTransactions) * 100);
   }
 }

--- a/app/backend/src/analytics/analytics.service.unit.spec.ts
+++ b/app/backend/src/analytics/analytics.service.unit.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { SupabaseService } from '../supabase/supabase.service';
 import { AnalyticsInterval, ReportType } from './dto/analytics-query.dto';
+import { TimeRange } from './dto/dashboard-summary.dto';
 import { AnalyticsService } from './analytics.service';
 
 describe('AnalyticsService', () => {
@@ -214,5 +215,325 @@ describe('AnalyticsService', () => {
         '2026-04-01T00:00:00.000Z',
       ),
     ).rejects.toThrow(BadRequestException);
+  });
+
+  describe('getDashboardSummary', () => {
+    it('should return dashboard summary for populated account with week time range', async () => {
+      mockClient.rpc
+        .mockResolvedValueOnce({
+          data: [
+            {
+              total_transactions: 10,
+              successful_transactions: 8,
+              failed_transactions: 2,
+              conversion_rate: 80,
+              total_volume_usd: 500,
+              average_transaction_usd: 50,
+            },
+          ],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [
+            {
+              asset: 'USDC',
+              volume_usd: 300,
+              percentage: 60,
+              transaction_count: 6,
+            },
+            {
+              asset: 'XLM',
+              volume_usd: 200,
+              percentage: 40,
+              transaction_count: 4,
+            },
+          ],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [
+            {
+              period: '2026-04-01',
+              transaction_count: 5,
+              successful_transactions: 4,
+              volume_usd: 250,
+              volume_usdc: 150,
+              volume_xlm: 100,
+              asset_volumes: { USDC: 150, XLM: 100 },
+            },
+          ],
+          error: null,
+        });
+
+      mockClient.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        lte: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        or: jest.fn().mockReturnThis(),
+        in: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
+      });
+
+      const summary = await service.getDashboardSummary(
+        'GB1234567890123456789012345678901234567890123456789012345',
+        TimeRange.WEEK,
+      );
+
+      expect(summary.volume.totalVolumeUsd).toBe(500);
+      expect(summary.volume.paymentCount).toBe(10);
+      expect(summary.payments.successfulCount).toBe(8);
+      expect(summary.payments.failedCount).toBe(2);
+      expect(summary.payments.pendingCount).toBe(0);
+      expect(summary.refunds.totalCount).toBe(0);
+      expect(summary.refunds.pendingCount).toBe(0);
+      expect(summary.refunds.approvedCount).toBe(0);
+      expect(summary.health.successRate).toBe(80);
+      expect(summary.health.deliveryFailureRate).toBe(0);
+      expect(summary.window.startDate).toBeDefined();
+      expect(summary.window.endDate).toBeDefined();
+    });
+
+    it('should return valid zero state for empty account', async () => {
+      mockClient.rpc
+        .mockResolvedValueOnce({
+          data: [
+            {
+              total_transactions: 0,
+              successful_transactions: 0,
+              failed_transactions: 0,
+              conversion_rate: 0,
+              total_volume_usd: 0,
+              average_transaction_usd: 0,
+            },
+          ],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [],
+          error: null,
+        });
+
+      mockClient.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        lte: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        or: jest.fn().mockReturnThis(),
+        in: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
+      });
+
+      const summary = await service.getDashboardSummary(
+        'GB1234567890123456789012345678901234567890123456789012345',
+        TimeRange.TODAY,
+      );
+
+      expect(summary.volume.totalVolumeUsd).toBe(0);
+      expect(summary.volume.paymentCount).toBe(0);
+      expect(summary.payments.successfulCount).toBe(0);
+      expect(summary.payments.failedCount).toBe(0);
+      expect(summary.payments.pendingCount).toBe(0);
+      expect(summary.refunds.totalCount).toBe(0);
+      expect(summary.refunds.pendingCount).toBe(0);
+      expect(summary.refunds.approvedCount).toBe(0);
+      expect(summary.health.successRate).toBe(0);
+      expect(summary.health.deliveryFailureRate).toBe(0);
+    });
+
+    it('should handle custom time range with provided dates', async () => {
+      mockClient.rpc
+        .mockResolvedValueOnce({
+          data: [
+            {
+              total_transactions: 5,
+              successful_transactions: 5,
+              failed_transactions: 0,
+              conversion_rate: 100,
+              total_volume_usd: 250,
+              average_transaction_usd: 50,
+            },
+          ],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [{ asset: 'USDC', volume_usd: 250, percentage: 100, transaction_count: 5 }],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [
+            {
+              period: '2026-04-01',
+              transaction_count: 5,
+              successful_transactions: 5,
+              volume_usd: 250,
+              volume_usdc: 250,
+              volume_xlm: 0,
+              asset_volumes: { USDC: 250 },
+            },
+          ],
+          error: null,
+        });
+
+      mockClient.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        lte: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        or: jest.fn().mockReturnThis(),
+        in: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
+      });
+
+      const summary = await service.getDashboardSummary(
+        'GB1234567890123456789012345678901234567890123456789012345',
+        TimeRange.CUSTOM,
+        '2026-04-01T00:00:00.000Z',
+        '2026-04-30T23:59:59.999Z',
+      );
+
+      expect(summary.volume.totalVolumeUsd).toBe(250);
+      expect(summary.window.startDate).toBe('2026-04-01T00:00:00.000Z');
+      expect(summary.window.endDate).toBe('2026-04-30T23:59:59.999Z');
+    });
+
+    it('should handle refund data correctly', async () => {
+      mockClient.rpc
+        .mockResolvedValueOnce({
+          data: [
+            {
+              total_transactions: 10,
+              successful_transactions: 8,
+              failed_transactions: 2,
+              conversion_rate: 80,
+              total_volume_usd: 500,
+              average_transaction_usd: 50,
+            },
+          ],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [{ asset: 'USDC', volume_usd: 500, percentage: 100, transaction_count: 10 }],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [
+            {
+              period: '2026-04-01',
+              transaction_count: 10,
+              successful_transactions: 8,
+              volume_usd: 500,
+              volume_usdc: 500,
+              volume_xlm: 0,
+              asset_volumes: { USDC: 500 },
+            },
+          ],
+          error: null,
+        });
+
+      const refundData = [
+        { status: 'pending' },
+        { status: 'pending' },
+        { status: 'approved' },
+        { status: 'rejected' },
+      ];
+
+      mockClient.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        lte: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        or: jest.fn().mockReturnThis(),
+        in: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: refundData, error: null }),
+      });
+
+      const summary = await service.getDashboardSummary(
+        'GB1234567890123456789012345678901234567890123456789012345',
+        TimeRange.WEEK,
+      );
+
+      expect(summary.refunds.totalCount).toBe(4);
+      expect(summary.refunds.pendingCount).toBe(2);
+      expect(summary.refunds.approvedCount).toBe(1);
+    });
+
+    it('should handle pending payments correctly', async () => {
+      mockClient.rpc
+        .mockResolvedValueOnce({
+          data: [
+            {
+              total_transactions: 10,
+              successful_transactions: 7,
+              failed_transactions: 1,
+              conversion_rate: 70,
+              total_volume_usd: 500,
+              average_transaction_usd: 50,
+            },
+          ],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [{ asset: 'USDC', volume_usd: 500, percentage: 100, transaction_count: 10 }],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [
+            {
+              period: '2026-04-01',
+              transaction_count: 10,
+              successful_transactions: 7,
+              volume_usd: 500,
+              volume_usdc: 500,
+              volume_xlm: 0,
+              asset_volumes: { USDC: 500 },
+            },
+          ],
+          error: null,
+        });
+
+      mockClient.from
+        .mockReturnValueOnce({
+          select: jest.fn().mockReturnThis(),
+          gte: jest.fn().mockReturnThis(),
+          lte: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          or: jest.fn().mockReturnThis(),
+          in: jest.fn().mockReturnThis(),
+          maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
+        })
+        .mockReturnValueOnce({
+          select: jest.fn().mockReturnThis(),
+          gte: jest.fn().mockReturnThis(),
+          lte: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          or: jest.fn().mockReturnThis(),
+          in: jest.fn().mockReturnThis(),
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: [{ id: '1' }, { id: '2' }],
+            error: null,
+          }),
+        })
+        .mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          gte: jest.fn().mockReturnThis(),
+          lte: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          or: jest.fn().mockReturnThis(),
+          in: jest.fn().mockReturnThis(),
+          maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
+        });
+
+      const summary = await service.getDashboardSummary(
+        'GB1234567890123456789012345678901234567890123456789012345',
+        TimeRange.WEEK,
+      );
+
+      expect(summary.payments.pendingCount).toBe(2);
+    });
   });
 });

--- a/app/backend/src/analytics/analytics.service.unit.spec.ts
+++ b/app/backend/src/analytics/analytics.service.unit.spec.ts
@@ -52,7 +52,10 @@ describe('AnalyticsService', () => {
     order: jest.fn(),
   };
 
-  const mockClient = {
+  const mockClient: {
+    from: jest.Mock;
+    rpc: jest.Mock;
+  } = {
     from: jest.fn(() => queryBuilder),
     rpc: jest.fn(),
   };
@@ -60,6 +63,30 @@ describe('AnalyticsService', () => {
   const mockSupabaseService = {
     getClient: jest.fn(() => mockClient),
   };
+
+  /**
+   * The real service code never calls `.maybeSingle()` on these query
+   * chains — it just `await`s the chain directly after the last filter
+   * method (`.lte()`, `.eq()`, or `.in()`). A plain `mockReturnThis()`
+   * chain is NOT awaitable to `{ data, error }` — it resolves immediately
+   * to the mock object itself. So we make the returned mock a genuine
+   * thenable: every chain method still returns `this` for chaining, but
+   * the object itself resolves to `result` when awaited, regardless of
+   * which method was called last.
+   */
+  function createSupabaseQueryMock(result: { data: unknown; error: unknown }) {
+    const mock: Record<string, unknown> = {};
+    const chainMethods = ['select', 'gte', 'lte', 'eq', 'or', 'in', 'order'];
+    chainMethods.forEach((method) => {
+      mock[method] = jest.fn(() => mock);
+    });
+    mock.maybeSingle = jest.fn().mockResolvedValue(result);
+    mock.then = (
+      resolve: (value: typeof result) => void,
+      reject: (reason?: unknown) => void,
+    ) => Promise.resolve(result).then(resolve, reject);
+    return mock;
+  }
 
   beforeEach(async () => {
     queryBuilder.select.mockReturnValue(queryBuilder);
@@ -265,15 +292,9 @@ describe('AnalyticsService', () => {
           error: null,
         });
 
-      mockClient.from.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        gte: jest.fn().mockReturnThis(),
-        lte: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        or: jest.fn().mockReturnThis(),
-        in: jest.fn().mockReturnThis(),
-        maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
-      });
+      mockClient.from.mockReturnValue(
+        createSupabaseQueryMock({ data: [], error: null }),
+      );
 
       const summary = await service.getDashboardSummary(
         'GB1234567890123456789012345678901234567890123456789012345',
@@ -318,15 +339,9 @@ describe('AnalyticsService', () => {
           error: null,
         });
 
-      mockClient.from.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        gte: jest.fn().mockReturnThis(),
-        lte: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        or: jest.fn().mockReturnThis(),
-        in: jest.fn().mockReturnThis(),
-        maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
-      });
+      mockClient.from.mockReturnValue(
+        createSupabaseQueryMock({ data: [], error: null }),
+      );
 
       const summary = await service.getDashboardSummary(
         'GB1234567890123456789012345678901234567890123456789012345',
@@ -379,15 +394,9 @@ describe('AnalyticsService', () => {
           error: null,
         });
 
-      mockClient.from.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        gte: jest.fn().mockReturnThis(),
-        lte: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        or: jest.fn().mockReturnThis(),
-        in: jest.fn().mockReturnThis(),
-        maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
-      });
+      mockClient.from.mockReturnValue(
+        createSupabaseQueryMock({ data: [], error: null }),
+      );
 
       const summary = await service.getDashboardSummary(
         'GB1234567890123456789012345678901234567890123456789012345',
@@ -442,15 +451,11 @@ describe('AnalyticsService', () => {
         { status: 'rejected' },
       ];
 
-      mockClient.from.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        gte: jest.fn().mockReturnThis(),
-        lte: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        or: jest.fn().mockReturnThis(),
-        in: jest.fn().mockReturnThis(),
-        maybeSingle: jest.fn().mockResolvedValue({ data: refundData, error: null }),
-      });
+      // First `from()` call inside getDashboardSummary is fetchRefundCounts
+      // ('refund_attempts'), so this is the payload that matters here.
+      mockClient.from.mockReturnValue(
+        createSupabaseQueryMock({ data: refundData, error: null }),
+      );
 
       const summary = await service.getDashboardSummary(
         'GB1234567890123456789012345678901234567890123456789012345',
@@ -496,37 +501,22 @@ describe('AnalyticsService', () => {
           error: null,
         });
 
+      // Inside getDashboardSummary, client.from() is called in this order:
+      //   1) fetchRefundCounts        -> 'refund_attempts'
+      //   2) fetchDeliveryFailureCount -> 'notification_logs'
+      //      (both started inside the same Promise.all, in that order)
+      //   3) fetchPendingPaymentCount -> 'payment_records'
+      //      (called separately, after the Promise.all above resolves)
+      // The 2-item payload needs to be on the THIRD call.
       mockClient.from
-        .mockReturnValueOnce({
-          select: jest.fn().mockReturnThis(),
-          gte: jest.fn().mockReturnThis(),
-          lte: jest.fn().mockReturnThis(),
-          eq: jest.fn().mockReturnThis(),
-          or: jest.fn().mockReturnThis(),
-          in: jest.fn().mockReturnThis(),
-          maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
-        })
-        .mockReturnValueOnce({
-          select: jest.fn().mockReturnThis(),
-          gte: jest.fn().mockReturnThis(),
-          lte: jest.fn().mockReturnThis(),
-          eq: jest.fn().mockReturnThis(),
-          or: jest.fn().mockReturnThis(),
-          in: jest.fn().mockReturnThis(),
-          maybeSingle: jest.fn().mockResolvedValue({
+        .mockReturnValueOnce(createSupabaseQueryMock({ data: [], error: null })) // refund_attempts
+        .mockReturnValueOnce(createSupabaseQueryMock({ data: [], error: null })) // notification_logs
+        .mockReturnValue(
+          createSupabaseQueryMock({
             data: [{ id: '1' }, { id: '2' }],
             error: null,
           }),
-        })
-        .mockReturnValue({
-          select: jest.fn().mockReturnThis(),
-          gte: jest.fn().mockReturnThis(),
-          lte: jest.fn().mockReturnThis(),
-          eq: jest.fn().mockReturnThis(),
-          or: jest.fn().mockReturnThis(),
-          in: jest.fn().mockReturnThis(),
-          maybeSingle: jest.fn().mockResolvedValue({ data: [], error: null }),
-        });
+        ); // payment_records (pending)
 
       const summary = await service.getDashboardSummary(
         'GB1234567890123456789012345678901234567890123456789012345',

--- a/app/backend/src/analytics/dto/dashboard-summary.dto.ts
+++ b/app/backend/src/analytics/dto/dashboard-summary.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsISO8601, IsNotEmpty, IsOptional, IsString, Matches } from 'class-validator';
+
+export enum TimeRange {
+  TODAY = 'today',
+  WEEK = 'week',
+  MONTH = 'month',
+  CUSTOM = 'custom',
+}
+
+export class DashboardSummaryQueryDto {
+  @ApiProperty({
+    description: 'Stellar public key for the user whose dashboard summary should be returned',
+    example: 'GBXGQ55JMQ4L2B6E7S8Y9Z0A1B2C3D4E5F6G7H8I7YWR',
+  })
+  @IsNotEmpty()
+  @IsString()
+  @Matches(/^G[A-Z2-7]{55}$/, { message: 'Invalid Stellar public key format' })
+  publicKey: string;
+
+  @ApiPropertyOptional({
+    description: 'Time range preset',
+    enum: TimeRange,
+    default: TimeRange.WEEK,
+  })
+  @IsOptional()
+  @IsEnum(TimeRange)
+  timeRange: TimeRange = TimeRange.WEEK;
+
+  @ApiPropertyOptional({
+    description: 'Start date (inclusive) in ISO-8601 format (required when timeRange is custom)',
+    example: '2026-01-01T00:00:00.000Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  startDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'End date (inclusive) in ISO-8601 format (required when timeRange is custom)',
+    example: '2026-04-29T23:59:59.999Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  endDate?: string;
+}


### PR DESCRIPTION
## summary

Adds an authenticated analytics dashboard summary endpoint with configurable time ranges. close #646

## Changes

* Added dashboard metrics for volume, payments, refunds, pending actions, and delivery failures.
* Added `GET /analytics/dashboard-summary` with API key authentication.
* Added configurable time ranges: today, week, month, and custom.
* Reused existing analytics services to avoid duplicate queries.
* Added tests for empty and populated accounts.
* Ensured a stable response shape for frontend clients.

## Testing

* Added 5 test cases covering empty and populated account scenarios.
* Verified zero-state metrics for empty accounts.
 