### PR TITLE
feta: Frontend Feature Flag Provider Backed by the Snapshot Endpoint

### DIFF
--- a/app/frontend/src/app/generator/page.tsx
+++ b/app/frontend/src/app/generator/page.tsx
@@ -6,6 +6,7 @@ import { QRPreview } from "@/components/QRPreview";
 import { NetworkBadge } from "@/components/NetworkBadge";
 import { useApi } from "@/hooks/useApi";
 import { getQuickexApiBase } from "@/lib/api";
+import { useFeatureFlag } from "@/contexts/FeatureFlagContext";
 import {
   buildGeneratedLinksCsv,
   BulkCsvDraftRow,
@@ -117,6 +118,7 @@ type BulkLinkRequestItem = {
 
 export default function Generator() {
   const { t } = useTranslation();
+  const bulkInvoicingEnabled = useFeatureFlag("bulk_invoicing_v2");
   const apiBase = useMemo(() => getQuickexApiBase(), []);
   const { error, loading, callApi, data } = useApi<LinkMetadataSuccess>();
   const csvInputRef = useRef<HTMLInputElement | null>(null);
@@ -1340,7 +1342,8 @@ export default function Generator() {
           </div>
         </div>
 
-        <section className="mt-20 max-w-7xl space-y-8">
+        {bulkInvoicingEnabled && (
+          <section className="mt-20 max-w-7xl space-y-8">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div>
               <p className="text-xs font-black uppercase tracking-widest text-brand">
@@ -1973,7 +1976,8 @@ export default function Generator() {
               </div>
             </div>
           </div>
-        </section>
+          </section>
+        )}
       </main>
     </div>
   );

--- a/app/frontend/src/app/layout.tsx
+++ b/app/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { NotificationCenterProvider } from "@/components/NotificationCenterProvi
 import { ErrorReportingShell } from "@/components/ErrorReportingShell";
 import { ThemeProvider, themeInitScript } from "@/components/ThemeProvider";
 import { BootstrapProvider } from "@/contexts/BootstrapContext";
+import { FeatureFlagProvider } from "@/contexts/FeatureFlagContext";
 import "./globals.css";
 
 const siteUrl =
@@ -64,37 +65,39 @@ export default function RootLayout({
         <StagingBanner />
         <ThemeProvider>
           <BootstrapProvider>
-            <NotificationCenterProvider>
-              <EnvGuard>
-                <Header />
-                <ErrorReportingShell>
-                  <main
-                    id="main-content"
-                    tabIndex={-1}
-                    className="min-h-screen container mx-auto px-6 py-10 focus:outline-none"
-                  >
-                    {children}
-                  </main>
-                </ErrorReportingShell>
+            <FeatureFlagProvider>
+              <NotificationCenterProvider>
+                <EnvGuard>
+                  <Header />
+                  <ErrorReportingShell>
+                    <main
+                      id="main-content"
+                      tabIndex={-1}
+                      className="min-h-screen container mx-auto px-6 py-10 focus:outline-none"
+                    >
+                      {children}
+                    </main>
+                  </ErrorReportingShell>
 
-                <footer className="container mx-auto border-t border-border px-6 py-12 text-sm text-subtle">
-                  <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
-                    <p>Copyright 2026 QuickEx Platform. Built by Pulsefy.</p>
-                    <div className="flex gap-8 underline decoration-border underline-offset-4 hover:decoration-border-strong">
-                      <a
-                        href="https://github.com/pulsefy/QuickEx"
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        GitHub
-                      </a>
-                      <a href="#">Terms</a>
-                      <a href="#">Privacy</a>
+                  <footer className="container mx-auto border-t border-border px-6 py-12 text-sm text-subtle">
+                    <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
+                      <p>Copyright 2026 QuickEx Platform. Built by Pulsefy.</p>
+                      <div className="flex gap-8 underline decoration-border underline-offset-4 hover:decoration-border-strong">
+                        <a
+                          href="https://github.com/pulsefy/QuickEx"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          GitHub
+                        </a>
+                        <a href="#">Terms</a>
+                        <a href="#">Privacy</a>
+                      </div>
                     </div>
-                  </div>
-                </footer>
-              </EnvGuard>
-            </NotificationCenterProvider>
+                  </footer>
+                </EnvGuard>
+              </NotificationCenterProvider>
+            </FeatureFlagProvider>
           </BootstrapProvider>
         </ThemeProvider>
       </body>

--- a/app/frontend/src/config/feature-flags.config.ts
+++ b/app/frontend/src/config/feature-flags.config.ts
@@ -1,0 +1,13 @@
+/**
+ * Client-safe flags returned by GET /feature-flags/snapshot.
+ * Unknown flags are intentionally disabled so a missing rollout cannot expose a gated surface.
+ */
+export type FeatureFlagKey = 'bulk_invoicing_v2' | (string & {});
+
+export type FeatureFlagValues = Record<string, boolean>;
+
+export const DEFAULT_FEATURE_FLAGS: FeatureFlagValues = {
+  bulk_invoicing_v2: false,
+};
+
+export const FEATURE_FLAGS_SESSION_STORAGE_KEY = 'quickex.feature-flags.v1';

--- a/app/frontend/src/contexts/FeatureFlagContext.tsx
+++ b/app/frontend/src/contexts/FeatureFlagContext.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from 'react';
+import {
+  DEFAULT_FEATURE_FLAGS,
+  FeatureFlagKey,
+  FeatureFlagValues,
+} from '@/config/feature-flags.config';
+import { fetchFeatureFlags } from '@/services/feature-flags.service';
+
+type FeatureFlagContextValue = {
+  flags: FeatureFlagValues;
+  isLoading: boolean;
+  error: Error | null;
+  isEnabled: (key: FeatureFlagKey) => boolean;
+  refresh: () => Promise<void>;
+};
+
+const FeatureFlagContext = createContext<FeatureFlagContextValue | null>(null);
+
+/**
+ * Loads flags after mount without blocking children. Values remain cached in
+ * sessionStorage for this browser tab; refresh() is the explicit refresh path.
+ */
+export function FeatureFlagProvider({ children }: { children: React.ReactNode }) {
+  const [flags, setFlags] = useState<FeatureFlagValues>(DEFAULT_FEATURE_FLAGS);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setFlags(await fetchFeatureFlags(true));
+    } catch (refreshError) {
+      setError(refreshError instanceof Error ? refreshError : new Error('Feature flag refresh failed'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    let mounted = true;
+
+    void fetchFeatureFlags().then((loadedFlags) => {
+      if (mounted) {
+        setFlags(loadedFlags);
+        setIsLoading(false);
+      }
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return (
+    <FeatureFlagContext.Provider
+      value={{
+        flags,
+        isLoading,
+        error,
+        isEnabled: (key) => flags[key] ?? false,
+        refresh,
+      }}
+    >
+      {children}
+    </FeatureFlagContext.Provider>
+  );
+}
+
+export function useFeatureFlags(): FeatureFlagContextValue {
+  const context = useContext(FeatureFlagContext);
+  if (!context) throw new Error('useFeatureFlags must be used inside FeatureFlagProvider');
+  return context;
+}
+
+export function useFeatureFlag(key: FeatureFlagKey): boolean {
+  return useFeatureFlags().isEnabled(key);
+}

--- a/app/frontend/src/services/feature-flags.service.test.ts
+++ b/app/frontend/src/services/feature-flags.service.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  FEATURE_FLAGS_SESSION_STORAGE_KEY,
+} from '@/config/feature-flags.config';
+import { fetchFeatureFlags } from './feature-flags.service';
+
+describe('fetchFeatureFlags', () => {
+  const originalFetch = global.fetch;
+  const originalWindow = global.window;
+
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_QUICKEX_API_URL', 'http://localhost:mock');
+    global.fetch = vi.fn();
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: {
+        sessionStorage: {
+          getItem: vi.fn(),
+          setItem: vi.fn(),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: originalWindow,
+    });
+    vi.unstubAllEnvs();
+  });
+
+  it('maps an enabled snapshot and disables unsafe rollout states', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        flags: [
+          { key: 'bulk_invoicing_v2', enabled: true, killSwitch: false, rolloutPercentage: 100 },
+          { key: 'partial_rollout', enabled: true, killSwitch: false, rolloutPercentage: 50 },
+          { key: 'killed_flag', enabled: true, killSwitch: true, rolloutPercentage: 100 },
+        ],
+      }),
+    });
+
+    await expect(fetchFeatureFlags()).resolves.toEqual({
+      bulk_invoicing_v2: true,
+      partial_rollout: false,
+      killed_flag: false,
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:mock/feature-flags/snapshot',
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+
+  it('returns safe defaults when the snapshot fails', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('offline'));
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(fetchFeatureFlags()).resolves.toEqual({ bulk_invoicing_v2: false });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load feature flags. Using safe defaults.',
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('uses the session cache unless explicitly refreshed', async () => {
+    const getItem = window.sessionStorage.getItem as ReturnType<typeof vi.fn>;
+    getItem.mockReturnValue(JSON.stringify({ bulk_invoicing_v2: true }));
+
+    await expect(fetchFeatureFlags()).resolves.toEqual({ bulk_invoicing_v2: true });
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ flags: [] }),
+    });
+    await expect(fetchFeatureFlags(true)).resolves.toEqual({ bulk_invoicing_v2: false });
+    expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
+      FEATURE_FLAGS_SESSION_STORAGE_KEY,
+      JSON.stringify({ bulk_invoicing_v2: false }),
+    );
+  });
+});

--- a/app/frontend/src/services/feature-flags.service.ts
+++ b/app/frontend/src/services/feature-flags.service.ts
@@ -1,0 +1,79 @@
+import {
+  DEFAULT_FEATURE_FLAGS,
+  FEATURE_FLAGS_SESSION_STORAGE_KEY,
+  FeatureFlagValues,
+} from '@/config/feature-flags.config';
+import { getQuickexApiBase } from '@/lib/api';
+
+type FeatureFlagSnapshotEntry = {
+  key: string;
+  enabled: boolean;
+  killSwitch: boolean;
+  rolloutPercentage: number;
+};
+
+type FeatureFlagSnapshotResponse = {
+  flags?: FeatureFlagSnapshotEntry[];
+};
+
+const normalizeFlags = (entries: FeatureFlagSnapshotEntry[]): FeatureFlagValues =>
+  entries.reduce<FeatureFlagValues>((flags, entry) => {
+    // Partial rollouts need user context, so the client stays disabled unless the
+    // snapshot explicitly enables the flag for everyone.
+    flags[entry.key] =
+      entry.enabled && !entry.killSwitch && entry.rolloutPercentage >= 100;
+    return flags;
+  }, { ...DEFAULT_FEATURE_FLAGS });
+
+const readSessionFlags = (): FeatureFlagValues | null => {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const cached = window.sessionStorage.getItem(FEATURE_FLAGS_SESSION_STORAGE_KEY);
+    if (!cached) return null;
+    const parsed = JSON.parse(cached) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return { ...DEFAULT_FEATURE_FLAGS, ...(parsed as FeatureFlagValues) };
+  } catch {
+    return null;
+  }
+};
+
+const writeSessionFlags = (flags: FeatureFlagValues): void => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.sessionStorage.setItem(
+      FEATURE_FLAGS_SESSION_STORAGE_KEY,
+      JSON.stringify(flags),
+    );
+  } catch {
+    // Storage can be unavailable in private browsing; the in-memory value still works.
+  }
+};
+
+/** Loads a client-safe snapshot. Failure returns safe defaults and never blocks rendering. */
+export const fetchFeatureFlags = async (
+  forceRefresh = false,
+): Promise<FeatureFlagValues> => {
+  if (!forceRefresh) {
+    const cached = readSessionFlags();
+    if (cached) return cached;
+  }
+
+  try {
+    const response = await fetch(`${getQuickexApiBase()}/feature-flags/snapshot`, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+    if (!response.ok) throw new Error(`Feature flag fetch failed (${response.status})`);
+
+    const payload = (await response.json()) as FeatureFlagSnapshotResponse;
+    const flags = normalizeFlags(payload.flags ?? []);
+    writeSessionFlags(flags);
+    return flags;
+  } catch (error) {
+    console.warn('Failed to load feature flags. Using safe defaults.', error);
+    return { ...DEFAULT_FEATURE_FLAGS };
+  }
+};


### PR DESCRIPTION
Close #835 

## PR: FE-60 Add Frontend Feature Flag Provider

### Summary

Adds a frontend feature flag provider backed by the backend snapshot endpoint.

### Changes

- Added typed `FeatureFlagProvider`, `useFeatureFlags`, and `useFeatureFlag` hooks.
- Fetches flags from `/feature-flags/snapshot` during app bootstrap.
- Uses safe `false` defaults for unknown, disabled, killed, failed, or partial-rollout flags.
- Caches flag values in `sessionStorage` for the browser tab session.
- Added explicit refresh support.
- Gated the Bulk Invoicing v2 surface behind `bulk_invoicing_v2`.
- Added tests for snapshot mapping, fallback behavior, session caching, and refresh behavior.

### Validation

- Editor diagnostics pass.
- `git diff --check` passes.
- Full typecheck/tests could not run because Node and pnpm are unavailable in the container.

