### PR TITLE
fix(mobile): secure wallet session storage

### DIFF
--- a/app/mobile/__tests__/SecurityService.test.ts
+++ b/app/mobile/__tests__/SecurityService.test.ts
@@ -12,6 +12,8 @@ import {
   setFallbackPin,
   verifyFallbackPin,
 } from "../services/security";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as SecureStore from "expo-secure-store";
 import { DEFAULT_SESSION_TIMEOUT_MINUTES, MAX_SESSION_TIMEOUT_MINUTES, MIN_SESSION_TIMEOUT_MINUTES } from "../types/security";
 
 describe("security service", () => {
@@ -79,11 +81,29 @@ describe("security service", () => {
       expect(await verifyFallbackPin("1234")).toBe(true);
       expect(await verifyFallbackPin("0000")).toBe(false);
     });
+
+    it("stores only a salted hash in SecureStore", async () => {
+      await setFallbackPin("1234");
+
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+        "quickex.security.pinHash",
+        expect.anything(),
+      );
+      const stored = await SecureStore.getItemAsync("quickex.security.pinHash");
+      const parsed = JSON.parse(stored!);
+
+      expect(parsed.salt).toHaveLength(32);
+      expect(parsed.hash).not.toContain("1234");
+    });
   });
 
   describe("sensitive token", () => {
     it("stores sensitive token and can clear it", async () => {
       await saveSensitiveToken("qex_session_abc123xyz");
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+        "quickex.security.sensitiveToken",
+        expect.anything(),
+      );
       expect(await getSensitiveToken()).toBe("qex_session_abc123xyz");
 
       await clearSensitiveToken();

--- a/app/mobile/__tests__/wallet-session.test.ts
+++ b/app/mobile/__tests__/wallet-session.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../services/wallet-session";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { WalletSession } from "../services/wallet-session";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 // AsyncStorage is already mocked in __mocks__/@react-native-async-storage/async-storage.js
 
@@ -42,6 +43,15 @@ describe("wallet-session service", () => {
     expect(session!.network).toBe("testnet");
     expect(session!.walletType).toBe("demo");
     expect(session!.connectedAt).toBe(VALID_SESSION.connectedAt);
+  });
+
+  it("stores wallet session state outside AsyncStorage", async () => {
+    await saveWalletSession(VALID_SESSION);
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+      "quickex.wallet.session.v3",
+      expect.anything(),
+    );
   });
 
   it("returns null when no session exists", async () => {

--- a/app/mobile/docs/storage-inventory.md
+++ b/app/mobile/docs/storage-inventory.md
@@ -1,0 +1,35 @@
+# Mobile Storage Inventory
+
+Storage is classified by the most sensitive value a key can contain. Secrets and wallet session material use `expo-secure-store` with `WHEN_UNLOCKED_THIS_DEVICE_ONLY`. AsyncStorage is reserved for non-sensitive preferences, cached data, and recoverable app state.
+
+| Key or pattern | Classification | Storage mechanism | Cleanup |
+| --- | --- | --- | --- |
+| `quickex.security.pinHash` | Secret: salted PIN hash | SecureStore | `clearSecurityData` and app data wipe |
+| `quickex.security.sensitiveToken` | Secret: session token | SecureStore | `clearSecurityData` and app data wipe |
+| `quickex.security.biometricSession` | Sensitive: short-lived auth session | SecureStore | `clearSecurityData` and app data wipe |
+| `quickex.wallet.session.v3` | Sensitive: wallet session state | SecureStore | `clearWalletSession` and app data wipe |
+| `quickex.secure-storage.install-marker` | Non-sensitive lifecycle marker | AsyncStorage | App data wipe; absence triggers SecureStore purge on next install |
+| `quickex.wallet.lastType` | Non-sensitive wallet preference | AsyncStorage | App data wipe |
+| `quickex.security.settings` | Non-sensitive security preferences | AsyncStorage | `clearSecuritySettings` and app data wipe |
+| `@quickex/environment` | Non-sensitive environment preference | AsyncStorage | `resetEnvironment` and app data wipe |
+| `quickex_onboarding_completed` | Non-sensitive onboarding preference | AsyncStorage | Onboarding reset |
+| `quickex_onboarding_events` | Non-sensitive diagnostics | AsyncStorage | Onboarding reset |
+| `quickex_session_id` | Pseudonymous analytics identifier | AsyncStorage | Onboarding reset |
+| `contacts` | User data, not authentication material | AsyncStorage | App data wipe |
+| `app_notifications` | Non-sensitive notification state | AsyncStorage | App data wipe |
+| `quickex.offline-queue.v1` | Recoverable transaction metadata | AsyncStorage | Queue clear and app data wipe |
+| `@qex_tx_cache_*` | Recoverable transaction cache | AsyncStorage | Cache clear and app data wipe |
+| `@qex_profile_cache_*` | Recoverable profile cache | AsyncStorage | Cache clear and app data wipe |
+| `@contract_registry` | Recoverable contract metadata cache | AsyncStorage | App data wipe |
+| `quickex.background-sync.settings.v1` | Non-sensitive sync preference | AsyncStorage | App data wipe |
+| `quickex.background-sync.snapshot.v1` | Recoverable sync metadata | AsyncStorage | App data wipe |
+| `@quickex_theme_mode` and profile theme keys | Non-sensitive display preference | AsyncStorage | Profile/theme reset |
+| `qex_sound_enabled_v1` | Non-sensitive notification preference | AsyncStorage | App data wipe |
+
+## PIN storage
+
+A PIN is never persisted. `setFallbackPin` generates a cryptographically random per-PIN salt and stores only `{ salt, hash }` in SecureStore. Verification hashes the supplied PIN with the stored salt and compares the result. If no cryptographic random source or hash implementation is available, setting a PIN fails rather than storing recoverable material.
+
+## Sign-out and uninstall
+
+The wallet disconnect flow clears the wallet session and sensitive session token. The Settings "Clear Local Data" flow additionally clears all AsyncStorage state, security settings, PIN hash, biometric session, and SecureStore session material. Native uninstall removes the platform keychain/keystore according to the platform lifecycle; the app does not retain a recoverable secret outside SecureStore.

--- a/app/mobile/hooks/use-security.tsx
+++ b/app/mobile/hooks/use-security.tsx
@@ -13,7 +13,7 @@ import { AppState, Platform } from "react-native";
 import { PinAuthModal } from "@/components/security/pin-auth-modal";
 import {
     clearBiometricSession,
-    clearSensitiveToken,
+  clearSensitiveSecurityData,
     getSecuritySettings,
     getSensitiveToken,
     getSessionExpiryExplanation,
@@ -358,7 +358,7 @@ export function SecurityProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const clearSensitiveSessionToken = useCallback(async () => {
-    await clearSensitiveToken();
+    await clearSensitiveSecurityData();
   }, []);
 
   // ── New session timeout methods ─────────────────────────────────────────────

--- a/app/mobile/services/secure-storage.ts
+++ b/app/mobile/services/secure-storage.ts
@@ -1,0 +1,49 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as SecureStore from "expo-secure-store";
+
+const INSTALL_MARKER_KEY = "quickex.secure-storage.install-marker";
+const SENSITIVE_KEYS = [
+  "quickex.security.pinHash",
+  "quickex.security.sensitiveToken",
+  "quickex.security.biometricSession",
+  "quickex.wallet.session.v3",
+] as const;
+
+let initialization: Promise<void> | undefined;
+
+async function initializeSecureStorage(): Promise<void> {
+  if (!initialization) {
+    initialization = (async () => {
+      const marker = await AsyncStorage.getItem(INSTALL_MARKER_KEY);
+      if (!marker && (await SecureStore.isAvailableAsync())) {
+        await Promise.all(
+          SENSITIVE_KEYS.map((key) => SecureStore.deleteItemAsync(key)),
+        );
+      }
+      await AsyncStorage.setItem(INSTALL_MARKER_KEY, "1");
+    })();
+  }
+  await initialization;
+}
+
+export async function getSecureItem(key: string): Promise<string | null> {
+  await initializeSecureStorage();
+  if (!(await SecureStore.isAvailableAsync())) return null;
+  return SecureStore.getItemAsync(key);
+}
+
+export async function setSecureItem(key: string, value: string): Promise<void> {
+  await initializeSecureStorage();
+  if (!(await SecureStore.isAvailableAsync())) {
+    throw new Error("Secure storage is unavailable on this device");
+  }
+  await SecureStore.setItemAsync(key, value, {
+    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  });
+}
+
+export async function deleteSecureItem(key: string): Promise<void> {
+  await initializeSecureStorage();
+  if (!(await SecureStore.isAvailableAsync())) return;
+  await SecureStore.deleteItemAsync(key);
+}

--- a/app/mobile/services/security.ts
+++ b/app/mobile/services/security.ts
@@ -1,9 +1,15 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import {
+  deleteSecureItem,
+  getSecureItem,
+  setSecureItem,
+} from "./secure-storage";
+
 // Lazily load native modules to avoid runtime errors in environments where
 // native Expo modules (expo-crypto, expo-secure-store) are not available
 // (web, node, or mismatched Expo Go). We provide JS fallbacks where possible.
 let ExpoCrypto: any | undefined;
-let ExpoSecureStore: any | undefined;
-let AsyncStorage: any | undefined;
 
 try {
   // Use require so bundlers won't eagerly fail when native modules are missing
@@ -12,20 +18,6 @@ try {
   ExpoCrypto = require("expo-crypto");
 } catch (e) {
   ExpoCrypto = undefined;
-}
-
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
-  ExpoSecureStore = require("expo-secure-store");
-} catch (e) {
-  ExpoSecureStore = undefined;
-}
-
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
-  AsyncStorage = require("@react-native-async-storage/async-storage");
-} catch (e) {
-  AsyncStorage = undefined;
 }
 
 import type {
@@ -42,7 +34,7 @@ import {
 const SECURITY_SETTINGS_KEY = "quickex.security.settings";
 const FALLBACK_PIN_HASH_KEY = "quickex.security.pinHash";
 const SENSITIVE_TOKEN_KEY = "quickex.security.sensitiveToken";
-const PIN_HASH_SALT = "quickex.v2.pin.salt";
+const PIN_HASH_LENGTH = 16;
 
 const BIOMETRIC_SESSION_KEY = "quickex.security.biometricSession";
 
@@ -51,71 +43,8 @@ export const DEFAULT_SETTINGS: SecuritySettings = {
   sessionTimeoutMinutes: DEFAULT_SESSION_TIMEOUT_MINUTES,
 };
 
-async function isSecureStoreAvailable() {
-  try {
-    if (
-      ExpoSecureStore &&
-      typeof ExpoSecureStore.isAvailableAsync === "function"
-    ) {
-      return await ExpoSecureStore.isAvailableAsync();
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
-
-async function getItem(key: string) {
-  if (await isSecureStoreAvailable()) {
-    return ExpoSecureStore.getItemAsync(key);
-  }
-
-  // Fallback to AsyncStorage if available (less secure, used for web/testing)
-  if (AsyncStorage && typeof AsyncStorage.getItem === "function") {
-    try {
-      return await AsyncStorage.getItem(key);
-    } catch {
-      return null;
-    }
-  }
-
-  return null;
-}
-
-async function setItem(key: string, value: string) {
-  if (await isSecureStoreAvailable()) {
-    await ExpoSecureStore.setItemAsync(key, value, {
-      keychainAccessible: ExpoSecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
-    });
-    return;
-  }
-
-  if (AsyncStorage && typeof AsyncStorage.setItem === "function") {
-    try {
-      await AsyncStorage.setItem(key, value);
-    } catch {
-      // ignore
-    }
-  }
-}
-
-async function deleteItem(key: string) {
-  if (await isSecureStoreAvailable()) {
-    await ExpoSecureStore.deleteItemAsync(key);
-    return;
-  }
-
-  if (AsyncStorage && typeof AsyncStorage.removeItem === "function") {
-    try {
-      await AsyncStorage.removeItem(key);
-    } catch {
-      // ignore
-    }
-  }
-}
-
 export async function getSecuritySettings(): Promise<SecuritySettings> {
-  const raw = await getItem(SECURITY_SETTINGS_KEY);
+  const raw = await AsyncStorage.getItem(SECURITY_SETTINGS_KEY);
   if (!raw) return DEFAULT_SETTINGS;
 
   try {
@@ -135,14 +64,14 @@ export async function getSecuritySettings(): Promise<SecuritySettings> {
 }
 
 export async function saveSecuritySettings(settings: SecuritySettings) {
-  await setItem(SECURITY_SETTINGS_KEY, JSON.stringify(settings));
+  await AsyncStorage.setItem(SECURITY_SETTINGS_KEY, JSON.stringify(settings));
 }
 
 /**
  * Removes all stored security settings, returning to the default state.
  */
 export async function clearSecuritySettings() {
-  await deleteItem(SECURITY_SETTINGS_KEY);
+  await AsyncStorage.removeItem(SECURITY_SETTINGS_KEY);
 }
 
 // ── Biometric Session Management ──────────────────────────────────────────────
@@ -156,14 +85,14 @@ export async function recordBiometricAuth(reason: SecurityAuthReason) {
     lastAuthenticatedAt: new Date().toISOString(),
     lastAuthReason: reason,
   };
-  await setItem(BIOMETRIC_SESSION_KEY, JSON.stringify(sessionInfo));
+  await setSecureItem(BIOMETRIC_SESSION_KEY, JSON.stringify(sessionInfo));
 }
 
 /**
  * Retrieves the last biometric session info.
  */
 export async function getBiometricSession(): Promise<BiometricSessionInfo | null> {
-  const raw = await getItem(BIOMETRIC_SESSION_KEY);
+  const raw = await getSecureItem(BIOMETRIC_SESSION_KEY);
   if (!raw) return null;
 
   try {
@@ -179,7 +108,7 @@ export async function getBiometricSession(): Promise<BiometricSessionInfo | null
  * Clears the biometric session, forcing re-authentication on the next action.
  */
 export async function clearBiometricSession() {
-  await deleteItem(BIOMETRIC_SESSION_KEY);
+  await deleteSecureItem(BIOMETRIC_SESSION_KEY);
 }
 
 /**
@@ -240,13 +169,41 @@ export async function getSessionExpiryExplanation(): Promise<string> {
   return `Your session expires in ${remainingSeconds} second${remainingSeconds !== 1 ? "s" : ""}.`;
 }
 
-async function hashPin(pin: string) {
+async function createPinSalt(): Promise<string> {
+  try {
+    if (ExpoCrypto && typeof ExpoCrypto.getRandomBytesAsync === "function") {
+      const bytes = await ExpoCrypto.getRandomBytesAsync(PIN_HASH_LENGTH);
+      return Array.from(bytes, (byte: number) => byte.toString(16).padStart(2, "0")).join("");
+    }
+  } catch {
+    // Try the platform-independent crypto implementations below.
+  }
+
+  try {
+    if (typeof globalThis?.crypto?.getRandomValues === "function") {
+      const bytes = globalThis.crypto.getRandomValues(new Uint8Array(PIN_HASH_LENGTH));
+      return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+    }
+  } catch {
+    // Try Node crypto in test and development environments.
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    const nodeCrypto = require("crypto");
+    return nodeCrypto.randomBytes(PIN_HASH_LENGTH).toString("hex");
+  } catch {
+    throw new Error("A cryptographically secure random source is unavailable");
+  }
+}
+
+async function hashPin(pin: string, salt: string) {
   // Prefer ExpoCrypto if available, otherwise use Web Crypto or Node crypto as fallback
   try {
     if (ExpoCrypto && typeof ExpoCrypto.digestStringAsync === "function") {
       return ExpoCrypto.digestStringAsync(
         ExpoCrypto.CryptoDigestAlgorithm.SHA256,
-        `${PIN_HASH_SALT}:${pin}`,
+        `${salt}:${pin}`,
       );
     }
   } catch (e) {
@@ -256,7 +213,7 @@ async function hashPin(pin: string) {
   // Web Crypto API
   try {
     if (typeof globalThis?.crypto?.subtle?.digest === "function") {
-      const data = new TextEncoder().encode(`${PIN_HASH_SALT}:${pin}`);
+      const data = new TextEncoder().encode(`${salt}:${pin}`);
       const hash = await globalThis.crypto.subtle.digest("SHA-256", data);
       // convert to hex
       const arr = Array.from(new Uint8Array(hash));
@@ -272,49 +229,67 @@ async function hashPin(pin: string) {
     const nodeCrypto = require("crypto");
     return nodeCrypto
       .createHash("sha256")
-      .update(`${PIN_HASH_SALT}:${pin}`)
+      .update(`${salt}:${pin}`)
       .digest("hex");
   } catch (e) {
     // As a last resort, return a non-cryptographic string (shouldn't happen)
-    return `${PIN_HASH_SALT}:${pin}`;
+    throw new Error("No cryptographic hash implementation is available");
   }
 }
 
 export async function setFallbackPin(pin: string) {
-  const pinHash = await hashPin(pin);
-  await setItem(FALLBACK_PIN_HASH_KEY, pinHash);
+  const salt = await createPinSalt();
+  const hash = await hashPin(pin, salt);
+  await setSecureItem(FALLBACK_PIN_HASH_KEY, JSON.stringify({ salt, hash }));
 }
 
 export async function hasFallbackPin() {
-  const pinHash = await getItem(FALLBACK_PIN_HASH_KEY);
-  return Boolean(pinHash);
+  const stored = await getSecureItem(FALLBACK_PIN_HASH_KEY);
+  if (!stored) return false;
+  try {
+    const parsed = JSON.parse(stored) as { salt?: string; hash?: string };
+    return Boolean(parsed.salt && parsed.hash);
+  } catch {
+    return false;
+  }
 }
 
 export async function verifyFallbackPin(pin: string) {
-  const storedHash = await getItem(FALLBACK_PIN_HASH_KEY);
-  if (!storedHash) return false;
+  const stored = await getSecureItem(FALLBACK_PIN_HASH_KEY);
+  if (!stored) return false;
 
-  const incomingHash = await hashPin(pin);
-  return storedHash === incomingHash;
+  try {
+    const parsed = JSON.parse(stored) as { salt?: string; hash?: string };
+    if (!parsed.salt || !parsed.hash) return false;
+    return parsed.hash === (await hashPin(pin, parsed.salt));
+  } catch {
+    return false;
+  }
 }
 
 export async function saveSensitiveToken(token: string) {
-  await setItem(SENSITIVE_TOKEN_KEY, token);
+  await setSecureItem(SENSITIVE_TOKEN_KEY, token);
 }
 
 export async function getSensitiveToken() {
-  return getItem(SENSITIVE_TOKEN_KEY);
+  return getSecureItem(SENSITIVE_TOKEN_KEY);
 }
 
 export async function clearSensitiveToken() {
-  await deleteItem(SENSITIVE_TOKEN_KEY);
+  await deleteSecureItem(SENSITIVE_TOKEN_KEY);
+}
+
+export async function clearSensitiveSecurityData(): Promise<void> {
+  await Promise.all([
+    deleteSecureItem(FALLBACK_PIN_HASH_KEY),
+    deleteSecureItem(SENSITIVE_TOKEN_KEY),
+    deleteSecureItem(BIOMETRIC_SESSION_KEY),
+  ]);
 }
 
 export async function clearSecurityData(): Promise<void> {
   await Promise.all([
-    deleteItem(SECURITY_SETTINGS_KEY),
-    deleteItem(FALLBACK_PIN_HASH_KEY),
-    deleteItem(SENSITIVE_TOKEN_KEY),
-    deleteItem(BIOMETRIC_SESSION_KEY),
+    clearSecuritySettings(),
+    clearSensitiveSecurityData(),
   ]);
 }

--- a/app/mobile/services/wallet-session.ts
+++ b/app/mobile/services/wallet-session.ts
@@ -1,5 +1,10 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { StellarNetwork, WalletType } from "../types/wallet";
+import {
+  deleteSecureItem,
+  getSecureItem,
+  setSecureItem,
+} from "./secure-storage";
 
 export type WalletNetwork = StellarNetwork;
 
@@ -51,7 +56,8 @@ function isValidNetwork(value: unknown): value is WalletNetwork {
 
 export async function getWalletSession(): Promise<WalletSession | null> {
   try {
-    const raw = await AsyncStorage.getItem(WALLET_SESSION_KEY);
+    await AsyncStorage.removeItem(WALLET_SESSION_KEY);
+    const raw = await getSecureItem(WALLET_SESSION_KEY);
     if (!raw) return null;
 
     const parsed = JSON.parse(raw) as Partial<WalletSession>;
@@ -91,11 +97,13 @@ export async function saveWalletSession(
     environmentId: environmentId ?? session.environmentId,
     buildTag: buildTag ?? session.buildTag,
   };
-  await AsyncStorage.setItem(WALLET_SESSION_KEY, JSON.stringify(enriched));
+  await AsyncStorage.removeItem(WALLET_SESSION_KEY);
+  await setSecureItem(WALLET_SESSION_KEY, JSON.stringify(enriched));
   await AsyncStorage.setItem(LAST_WALLET_TYPE_KEY, session.walletType);
 }
 
 export async function clearWalletSession(): Promise<void> {
+  await deleteSecureItem(WALLET_SESSION_KEY);
   await AsyncStorage.removeItem(WALLET_SESSION_KEY);
 }
 


### PR DESCRIPTION
Closes #855 
it’s implemented.
Completed:

- SecureStore is used for wallet sessions, PIN hashes, tokens, and biometric sessions.
- PINs are stored only as salted hashes.
- AsyncStorage fallback for secrets was removed.
- Sign-out clears all sensitive security data.
- Legacy insecure wallet-session entries are purged.
- Reinstall cleanup handles SecureStore entries that may survive iOS uninstall.
- Storage inventory documentation was added.
- Regression tests were added.
- Static checks and VS Code error checks passed.