### PR TITLE
fix(marketplace): remove mock listing fallbacks and handle failure states

### DIFF
--- a/app/frontend/__tests__/marketplaceApi.fetch.test.ts
+++ b/app/frontend/__tests__/marketplaceApi.fetch.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+import {
+  fetchListings,
+  fetchUserBids,
+  fetchUserListings,
+  clearMarketplaceCache,
+  type BackendMarketplaceListing,
+} from "@/hooks/marketplaceApi";
+
+describe("marketplaceApi fetch functions without mock fallbacks (FE-58)", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    clearMarketplaceCache();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    clearMarketplaceCache();
+  });
+
+  describe("fetchListings", () => {
+    it("returns mapped listings on successful API response", async () => {
+      const mockBackendListings: BackendMarketplaceListing[] = [
+        {
+          id: "listing-abc",
+          username: "crypto",
+          seller_public_key: "GA123456789012345678901234567890123456789012345678901234",
+          asking_price: 5000,
+          status: "active",
+          created_at: "2026-08-01T10:00:00.000Z",
+          updated_at: "2026-08-01T10:00:00.000Z",
+          sold_at: null,
+          buyer_public_key: null,
+          final_price: null,
+        },
+      ];
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          listings: mockBackendListings,
+          total: 1,
+          next_cursor: null,
+          has_more: false,
+        }),
+      });
+
+      const listings = await fetchListings({ bypassCache: true });
+
+      expect(listings).toHaveLength(1);
+      expect(listings[0].id).toBe("listing-abc");
+      expect(listings[0].username).toBe("crypto");
+      expect(listings[0].currentBid).toBe(5000);
+      expect(listings[0].status).toBe("auction");
+    });
+
+    it("returns empty array on empty API response (not mock listings)", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          listings: [],
+          total: 0,
+          next_cursor: null,
+          has_more: false,
+        }),
+      });
+
+      const listings = await fetchListings({ bypassCache: true });
+
+      expect(listings).toEqual([]);
+      expect(listings).toHaveLength(0);
+    });
+
+    it("throws an error on API error response (500) and does not fall back to mock data", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+
+      await expect(fetchListings({ bypassCache: true })).rejects.toThrow(
+        /Failed to load marketplace listings \(500\)/,
+      );
+    });
+
+    it("throws an error on API error response (404) and does not fall back to mock data", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      });
+
+      await expect(fetchListings({ bypassCache: true })).rejects.toThrow(
+        /Failed to load marketplace listings \(404\)/,
+      );
+    });
+
+    it("throws on network failure (fetch rejection) and does not fall back to mock data", async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network connection lost"));
+
+      await expect(fetchListings({ bypassCache: true })).rejects.toThrow(
+        "Network connection lost",
+      );
+    });
+  });
+
+  describe("fetchUserBids", () => {
+    it("returns empty array instead of mock bids when no cached user bids exist", async () => {
+      const bids = await fetchUserBids();
+      expect(bids).toEqual([]);
+      expect(bids).toHaveLength(0);
+    });
+  });
+
+  describe("fetchUserListings", () => {
+    it("returns empty array instead of mock listings when no cached user listings exist", async () => {
+      const userListings = await fetchUserListings();
+      expect(userListings).toEqual([]);
+      expect(userListings).toHaveLength(0);
+    });
+  });
+});

--- a/app/frontend/src/app/dashboard/page.tsx
+++ b/app/frontend/src/app/dashboard/page.tsx
@@ -88,8 +88,8 @@ function DashboardContent() {
 
   useEffect(() => {
     void callApi(() => fetchActivityFeed(20));
-    void fetchUserBids().then(setUserBids);
-    void fetchUserListings().then(setUserListings);
+    void fetchUserBids().then(setUserBids).catch(() => setUserBids([]));
+    void fetchUserListings().then(setUserListings).catch(() => setUserListings([]));
   }, [callApi, feedRetryCount]);
 
   useEffect(() => {

--- a/app/frontend/src/app/page.tsx
+++ b/app/frontend/src/app/page.tsx
@@ -17,8 +17,8 @@ export default function Home() {
     const handlePrefetch = () => {
       router.prefetch("/dashboard");
       router.prefetch("/marketplace");
-      fetchListings();
-      fetchAnalytics("30d");
+      fetchListings().catch(() => {});
+      fetchAnalytics("30d").catch(() => {});
     };
     const id = window.setTimeout(handlePrefetch, 250);
     return () => window.clearTimeout(id);

--- a/app/frontend/src/hooks/marketplaceApi.ts
+++ b/app/frontend/src/hooks/marketplaceApi.ts
@@ -1,4 +1,4 @@
-// Marketplace mock data and simulated API calls
+// Marketplace data and API calls
 
 import { getQuickexApiBase } from "@/lib/api";
 export type UsernameStatus = "auction" | "buyNow" | "sold" | "listed";
@@ -38,147 +38,11 @@ let cachedListings: MarketplaceListing[] | null = null;
 let cachedUserBids: UserBid[] | null = null;
 let cachedUserListings: UserListing[] | null = null;
 
-const MOCK_LISTINGS: MarketplaceListing[] = [
-  {
-    id: "1",
-    username: "pay",
-    currentBid: 5800,
-    buyNowPrice: 12000,
-    ownerAddress: "GDRH...4T9F",
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 2.5),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2), // 2 days ago
-    status: "auction",
-    category: "og",
-    bidCount: 34,
-    watchers: 210,
-    verified: true,
-  },
-  {
-    id: "2",
-    username: "sol",
-    currentBid: 3200,
-    buyNowPrice: 8500,
-    ownerAddress: "GCXY...8K3J",
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 5),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 12), // 12 hours ago
-    status: "auction",
-    category: "crypto",
-    bidCount: 19,
-    watchers: 98,
-    verified: true,
-  },
-  {
-    id: "3",
-    username: "nova",
-    currentBid: 1400,
-    buyNowPrice: 4000,
-    ownerAddress: "GBXT...2R7K",
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 6), // 6 hours ago
-    status: "auction",
-    category: "brand",
-    bidCount: 8,
-    watchers: 54,
-    verified: false,
-  },
-  {
-    id: "4",
-    username: "satoshi",
-    currentBid: 9900,
-    buyNowPrice: null,
-    ownerAddress: "GDKL...5W1M",
-    endsAt: new Date(Date.now() + 1000 * 60 * 47),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 48), // 2 days ago
-    status: "auction",
-    category: "trending",
-    bidCount: 62,
-    watchers: 445,
-    verified: true,
-  },
-  {
-    id: "5",
-    username: "alex",
-    currentBid: 780,
-    buyNowPrice: 2000,
-    ownerAddress: "GCMQ...9P2N",
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 36),
-    createdAt: new Date(Date.now() - 1000 * 60 * 30), // 30 minutes ago
-    status: "auction",
-    category: "short",
-    bidCount: 5,
-    watchers: 31,
-    verified: false,
-  },
-  {
-    id: "6",
-    username: "defi",
-    currentBid: 4100,
-    buyNowPrice: null,
-    ownerAddress: "GBKR...1Q0C",
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 12),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
-    status: "auction",
-    category: "crypto",
-    bidCount: 27,
-    watchers: 182,
-    verified: true,
-  },
-  {
-    id: "7",
-    username: "lux",
-    currentBid: 620,
-    buyNowPrice: 1500,
-    ownerAddress: "GDXP...3F4G",
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 48),
-    createdAt: new Date(Date.now() - 1000 * 60 * 15), // 15 minutes ago
-    status: "listed",
-    category: "brand",
-    bidCount: 3,
-    watchers: 22,
-    verified: false,
-  },
-  {
-    id: "8",
-    username: "web3",
-    currentBid: 2700,
-    buyNowPrice: 6000,
-    ownerAddress: "GBNH...7T5Q",
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 8),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3), // 3 hours ago
-    status: "auction",
-    category: "trending",
-    bidCount: 15,
-    watchers: 113,
-    verified: true,
-  },
-];
-
-const MOCK_USER_BIDS: UserBid[] = [
-  {
-    username: "nova",
-    myBid: 1200,
-    currentBid: 1400,
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
-    isWinning: false,
-  },
-  {
-    username: "lux",
-    myBid: 620,
-    currentBid: 620,
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 48),
-    isWinning: true,
-  },
-];
-
-const MOCK_USER_LISTINGS: UserListing[] = [
-  {
-    username: "stellardev",
-    minBid: 300,
-    currentBid: 480,
-    bidCount: 3,
-    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 72),
-  },
-];
+export function clearMarketplaceCache(): void {
+  cachedListings = null;
+  cachedUserBids = null;
+  cachedUserListings = null;
+}
 
 export function mapBackendListingToCardListing(item: BackendMarketplaceListing): MarketplaceListing {
   const createdAt = new Date(item.created_at || Date.now());
@@ -233,57 +97,39 @@ export async function fetchListings(options: FetchListingsOptions = {}): Promise
     url.searchParams.set("cursor", cursor);
   }
 
-  try {
-    const response = await fetch(url.toString(), {
-      method: "GET",
-      headers: { Accept: "application/json" },
-    });
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
 
-    if (!response.ok) {
-      throw new Error(`Failed to load marketplace listings (${response.status})`);
-    }
-
-    const data = (await response.json()) as {
-      listings: BackendMarketplaceListing[];
-      total: number;
-      next_cursor: string | null;
-      has_more: boolean;
-    };
-
-    const mapped = (data.listings || []).map(mapBackendListingToCardListing);
-    cachedListings = mapped;
-    return mapped;
-  } catch (err) {
-    console.warn("Marketplace backend query error, returning fallback list:", err);
-    cachedListings = MOCK_LISTINGS;
-    return MOCK_LISTINGS;
+  if (!response.ok) {
+    throw new Error(`Failed to load marketplace listings (${response.status})`);
   }
+
+  const data = (await response.json()) as {
+    listings?: BackendMarketplaceListing[];
+    total?: number;
+    next_cursor?: string | null;
+    has_more?: boolean;
+  };
+
+  const mapped = (data.listings || []).map(mapBackendListingToCardListing);
+  cachedListings = mapped;
+  return mapped;
 }
 
 export async function fetchUserBids(): Promise<UserBid[]> {
   if (cachedUserBids) {
-    return Promise.resolve(cachedUserBids);
+    return cachedUserBids;
   }
-
-  return new Promise((resolve) =>
-    setTimeout(() => {
-      cachedUserBids = MOCK_USER_BIDS;
-      resolve(MOCK_USER_BIDS);
-    }, 700),
-  );
+  return [];
 }
 
 export async function fetchUserListings(): Promise<UserListing[]> {
   if (cachedUserListings) {
-    return Promise.resolve(cachedUserListings);
+    return cachedUserListings;
   }
-
-  return new Promise((resolve) =>
-    setTimeout(() => {
-      cachedUserListings = MOCK_USER_LISTINGS;
-      resolve(MOCK_USER_LISTINGS);
-    }, 700),
-  );
+  return [];
 }
 
 export type BidResult = { success: true } | { success: false; reason: string };


### PR DESCRIPTION
## Overview
Removes fabricated mock data fallbacks (`MOCK_LISTINGS`, `MOCK_USER_BIDS`, `MOCK_USER_LISTINGS`) from `marketplaceApi.ts` so that API failures properly surface distinguishable error states with retry actions rather than silently rendering misleading mock listings and bids.

## Related Issue
Closes #833

## Changes
### Frontend Marketplace Hook & Pages (`app/frontend`)
* **[MODIFY]** `app/frontend/src/hooks/marketplaceApi.ts`
  * Removed `MOCK_LISTINGS`, `MOCK_USER_BIDS`, and `MOCK_USER_LISTINGS` constants
  * Removed mock fallback returns in `fetchListings`, `fetchUserBids`, and `fetchUserListings`
  * Added `clearMarketplaceCache()` helper for tests
* **[MODIFY]** `app/frontend/src/app/dashboard/page.tsx`
  * Handled promise rejections when loading user bids and listings
* **[MODIFY]** `app/frontend/src/app/page.tsx`
  * Added error catch handlers for prefetch calls
* **[ADD]** `app/frontend/__tests__/marketplaceApi.fetch.test.ts`
  * Added unit tests verifying success, empty results, 404/500 HTTP errors, and network failure responses without mock data fallbacks

## Verification Results
```text
node_modules/.bin/vitest run __tests__/marketplaceApi.*.test.ts

 ✓ __tests__/marketplaceApi.detail.test.ts (3 tests)
 ✓ __tests__/marketplaceApi.fetch.test.ts (7 tests)

Test Files  2 passed (2)
     Tests  10 passed (10)
```

| Acceptance Criteria | Status |
| :--- | :--- |
| The marketplace hook no longer returns mock listings, bids, or user listings under any code path | ✅ Mock data returns removed from `fetchListings`, `fetchUserBids`, `fetchUserListings` |
| API failure renders a distinguishable error state with a retry action, never fabricated data | ✅ `marketplace/page.tsx` renders explicit error UI with retry action |
| An empty result renders an empty state that is visually distinct from the error state | ✅ Empty array renders clean empty state UI with filter/search helper |
| The mock constants are deleted from the file | ✅ Deleted `MOCK_LISTINGS`, `MOCK_USER_BIDS`, `MOCK_USER_LISTINGS` |
| Tests cover success, empty, and failure responses | ✅ 7 unit tests in `marketplaceApi.fetch.test.ts` covering success, empty, 404/500, network errors |