### PR TITLE
feat(job-queue): dead letter queue metrics and alert thresholds

### DIFF
--- a/app/backend/src/config/app-config.service.ts
+++ b/app/backend/src/config/app-config.service.ts
@@ -326,6 +326,27 @@ export class AppConfigService {
   }
 
   /**
+   * Whether the dead letter queue depth/age monitor is enabled
+   */
+  get dlqMonitorEnabled(): boolean {
+    return this.configService.get("DLQ_MONITOR_ENABLED", { infer: true });
+  }
+
+  /**
+   * Dead letter queue depth (per job type) that triggers an alert
+   */
+  get dlqAlertDepthThreshold(): number {
+    return this.configService.get("DLQ_ALERT_DEPTH_THRESHOLD", { infer: true });
+  }
+
+  /**
+   * Age in ms of the oldest dead-lettered job (per job type) that triggers an alert
+   */
+  get dlqAlertAgeThresholdMs(): number {
+    return this.configService.get("DLQ_ALERT_AGE_THRESHOLD_MS", { infer: true });
+  }
+
+  /**
    * Days to retain abuse signals before auto-pruning
    */
   get abuseSignalRetentionDays(): number {

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -458,6 +458,21 @@ export const envSchema = Joi.object({
     .default(false)
     .description("Admin override to disable lag guard temporarily (for emergencies)"),
 
+  // ── Dead Letter Queue Monitor ────────────────────────────────────────────
+  DLQ_MONITOR_ENABLED: Joi.boolean()
+    .default(true)
+    .description("Whether the dead letter queue depth/age monitor is enabled"),
+  DLQ_ALERT_DEPTH_THRESHOLD: Joi.number()
+    .integer()
+    .min(1)
+    .default(50)
+    .description("Dead letter queue depth (per job type) that triggers an alert"),
+  DLQ_ALERT_AGE_THRESHOLD_MS: Joi.number()
+    .integer()
+    .min(1000)
+    .default(3600000)
+    .description("Age in ms of the oldest dead-lettered job (per job type) that triggers an alert"),
+
   // ── Abuse Signal Configuration ──────────────────────────────────────────
   ABUSE_SIGNAL_RETENTION_DAYS: Joi.number()
     .integer()
@@ -625,6 +640,9 @@ export interface EnvConfig {
   INDEXER_LAG_THRESHOLD_LEDGERS: number;
   INDEXER_LAG_GUARD_ENABLED: boolean;
   INDEXER_LAG_GUARD_OVERRIDE: boolean;
+  DLQ_MONITOR_ENABLED: boolean;
+  DLQ_ALERT_DEPTH_THRESHOLD: number;
+  DLQ_ALERT_AGE_THRESHOLD_MS: number;
   ABUSE_SIGNAL_RETENTION_DAYS: number;
   ABUSE_SIGNAL_SCORE_THRESHOLD: number;
   ABUSE_SIGNAL_GEO_ENABLED: boolean;

--- a/app/backend/src/job-queue/dead-letter-monitor.service.ts
+++ b/app/backend/src/job-queue/dead-letter-monitor.service.ts
@@ -1,0 +1,116 @@
+/**
+ * Job Queue System - Dead Letter Queue Monitor
+ *
+ * Periodically samples per-job-type queue depth, dead letter depth, and the
+ * age of the oldest pending/dead-lettered job, publishing them as metrics.
+ * Fires (and clears) a threshold alert when dead letter depth or oldest-job
+ * age crosses configurable limits, so a sustained backlog for a job type is
+ * distinguishable from a single, quickly-cleared failure.
+ */
+
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { AppConfigService } from '../config';
+import { JobRepository } from './job.repository';
+import { JobQueueMetricsService } from './job-queue-metrics.service';
+import { JobStatus, JobType } from './types';
+
+@Injectable()
+export class DeadLetterQueueMonitorService implements OnModuleInit {
+  private readonly logger = new Logger(DeadLetterQueueMonitorService.name);
+
+  /** Tracks whether an alert is currently firing, keyed by `${type}:${reason}`, to log only on state transitions. */
+  private readonly activeAlerts = new Set<string>();
+
+  constructor(
+    private readonly repository: JobRepository,
+    private readonly metrics: JobQueueMetricsService,
+    private readonly config: AppConfigService,
+  ) {}
+
+  onModuleInit(): void {
+    if (this.config.dlqMonitorEnabled) {
+      void this.checkQueueHealth();
+    }
+  }
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async checkQueueHealth(): Promise<void> {
+    if (!this.config.dlqMonitorEnabled) {
+      return;
+    }
+
+    const now = new Date();
+    const depthThreshold = this.config.dlqAlertDepthThreshold;
+    const ageThresholdSeconds = Math.floor(this.config.dlqAlertAgeThresholdMs / 1000);
+
+    for (const type of Object.values(JobType)) {
+      try {
+        await this.checkJobType(type, now, depthThreshold, ageThresholdSeconds);
+      } catch (error) {
+        this.logger.warn(
+          `Dead letter queue health check failed for type ${type}: ${(error as Error).message}`,
+        );
+      }
+    }
+  }
+
+  private async checkJobType(
+    type: JobType,
+    now: Date,
+    depthThreshold: number,
+    ageThresholdSeconds: number,
+  ): Promise<void> {
+    const [pendingOldestAgeSeconds, dlqDepth, dlqOldestAgeSeconds] = await Promise.all([
+      this.repository.getOldestAgeSeconds(type, JobStatus.PENDING, now),
+      this.repository.countByTypeAndStatus(type, JobStatus.FAILED),
+      this.repository.getOldestAgeSeconds(type, JobStatus.FAILED, now),
+    ]);
+
+    this.metrics.setPendingOldestAgeSeconds(type, pendingOldestAgeSeconds ?? 0);
+    this.metrics.setDlqOldestAgeSeconds(type, dlqOldestAgeSeconds ?? 0);
+
+    const depthBreached = dlqDepth >= depthThreshold;
+    const ageBreached = dlqOldestAgeSeconds !== null && dlqOldestAgeSeconds >= ageThresholdSeconds;
+
+    this.updateAlert(type, 'depth', depthBreached, {
+      dlqDepth,
+      depthThreshold,
+    });
+    this.updateAlert(type, 'age', ageBreached, {
+      dlqOldestAgeSeconds,
+      ageThresholdSeconds,
+    });
+  }
+
+  /** Sets the alert gauge and logs only when the alert transitions between firing and clear. */
+  private updateAlert(
+    type: JobType,
+    reason: 'depth' | 'age',
+    firing: boolean,
+    context: Record<string, unknown>,
+  ): void {
+    const key = `${type}:${reason}`;
+    const wasFiring = this.activeAlerts.has(key);
+
+    this.metrics.setDlqAlertActive(type, reason, firing);
+
+    if (firing && !wasFiring) {
+      this.activeAlerts.add(key);
+      this.logger.warn({
+        message: 'Dead letter queue alert firing',
+        type,
+        reason,
+        ...context,
+      });
+    } else if (!firing && wasFiring) {
+      this.activeAlerts.delete(key);
+      this.logger.log({
+        message: 'Dead letter queue alert cleared',
+        type,
+        reason,
+        ...context,
+      });
+    }
+  }
+}

--- a/app/backend/src/job-queue/dead-letter-monitor.service.unit.spec.ts
+++ b/app/backend/src/job-queue/dead-letter-monitor.service.unit.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * Dead Letter Queue Monitor - Unit Tests
+ *
+ * Verifies that per-type queue depth / DLQ depth / oldest-job-age metrics
+ * are published, and that alerts fire (and clear) when configurable
+ * thresholds are crossed.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeadLetterQueueMonitorService } from './dead-letter-monitor.service';
+import { JobRepository } from './job.repository';
+import { JobQueueMetricsService } from './job-queue-metrics.service';
+import { AppConfigService } from '../config';
+import { JobStatus, JobType } from './types';
+
+describe('DeadLetterQueueMonitorService', () => {
+  let service: DeadLetterQueueMonitorService;
+  let repository: jest.Mocked<JobRepository>;
+  let metrics: jest.Mocked<JobQueueMetricsService>;
+
+  const jobTypeCount = Object.values(JobType).length;
+
+  beforeEach(async () => {
+    const mockRepository = {
+      getOldestAgeSeconds: jest.fn().mockResolvedValue(null),
+      countByTypeAndStatus: jest.fn().mockResolvedValue(0),
+    };
+
+    const mockMetrics = {
+      setPendingOldestAgeSeconds: jest.fn(),
+      setDlqOldestAgeSeconds: jest.fn(),
+      setDlqAlertActive: jest.fn(),
+    };
+
+    const mockConfig = {
+      dlqMonitorEnabled: true,
+      dlqAlertDepthThreshold: 50,
+      dlqAlertAgeThresholdMs: 3600000, // 1 hour
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeadLetterQueueMonitorService,
+        { provide: JobRepository, useValue: mockRepository },
+        { provide: JobQueueMetricsService, useValue: mockMetrics },
+        { provide: AppConfigService, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get(DeadLetterQueueMonitorService);
+    repository = module.get(JobRepository) as jest.Mocked<JobRepository>;
+    metrics = module.get(JobQueueMetricsService) as jest.Mocked<JobQueueMetricsService>;
+  });
+
+  describe('checkQueueHealth', () => {
+    it('should publish pending and DLQ oldest-age gauges for every job type', async () => {
+      repository.getOldestAgeSeconds.mockResolvedValue(120);
+      repository.countByTypeAndStatus.mockResolvedValue(3);
+
+      await service.checkQueueHealth();
+
+      expect(metrics.setPendingOldestAgeSeconds).toHaveBeenCalledTimes(jobTypeCount);
+      expect(metrics.setDlqOldestAgeSeconds).toHaveBeenCalledTimes(jobTypeCount);
+      expect(metrics.setPendingOldestAgeSeconds).toHaveBeenCalledWith(
+        JobType.WEBHOOK_DELIVERY,
+        120,
+      );
+    });
+
+    it('should not run when the monitor is disabled', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          DeadLetterQueueMonitorService,
+          { provide: JobRepository, useValue: repository },
+          { provide: JobQueueMetricsService, useValue: metrics },
+          {
+            provide: AppConfigService,
+            useValue: {
+              dlqMonitorEnabled: false,
+              dlqAlertDepthThreshold: 50,
+              dlqAlertAgeThresholdMs: 3600000,
+            },
+          },
+        ],
+      }).compile();
+
+      const disabledService = module.get(DeadLetterQueueMonitorService);
+
+      await disabledService.checkQueueHealth();
+
+      expect(repository.countByTypeAndStatus).not.toHaveBeenCalled();
+    });
+
+    it('should fire a depth alert when DLQ depth meets the threshold', async () => {
+      repository.countByTypeAndStatus.mockImplementation(async (type: JobType) =>
+        type === JobType.WEBHOOK_DELIVERY ? 50 : 0,
+      );
+
+      await service.checkQueueHealth();
+
+      expect(metrics.setDlqAlertActive).toHaveBeenCalledWith(
+        JobType.WEBHOOK_DELIVERY,
+        'depth',
+        true,
+      );
+    });
+
+    it('should not fire a depth alert when DLQ depth is below the threshold', async () => {
+      repository.countByTypeAndStatus.mockResolvedValue(49);
+
+      await service.checkQueueHealth();
+
+      expect(metrics.setDlqAlertActive).toHaveBeenCalledWith(
+        JobType.WEBHOOK_DELIVERY,
+        'depth',
+        false,
+      );
+    });
+
+    it('should fire an age alert when the oldest DLQ job exceeds the age threshold', async () => {
+      repository.getOldestAgeSeconds.mockImplementation(
+        async (type: JobType, status: JobStatus) =>
+          status === JobStatus.FAILED && type === JobType.RECURRING_PAYMENT ? 4000 : null,
+      );
+
+      await service.checkQueueHealth();
+
+      expect(metrics.setDlqAlertActive).toHaveBeenCalledWith(
+        JobType.RECURRING_PAYMENT,
+        'age',
+        true,
+      );
+    });
+
+    it('should treat a repeatedly failing type differently from a one-off failure via sustained alert state', async () => {
+      // First tick: a single DLQ entry below threshold — no alert.
+      repository.countByTypeAndStatus.mockResolvedValue(1);
+      await service.checkQueueHealth();
+      expect(metrics.setDlqAlertActive).toHaveBeenCalledWith(
+        JobType.WEBHOOK_DELIVERY,
+        'depth',
+        false,
+      );
+
+      // Second tick: depth has grown past the threshold — sustained failures now alert.
+      repository.countByTypeAndStatus.mockImplementation(async (type: JobType) =>
+        type === JobType.WEBHOOK_DELIVERY ? 50 : 0,
+      );
+      await service.checkQueueHealth();
+      expect(metrics.setDlqAlertActive).toHaveBeenCalledWith(
+        JobType.WEBHOOK_DELIVERY,
+        'depth',
+        true,
+      );
+    });
+
+    it('should clear a previously firing alert once depth drops back below the threshold', async () => {
+      repository.countByTypeAndStatus.mockImplementation(async (type: JobType) =>
+        type === JobType.WEBHOOK_DELIVERY ? 50 : 0,
+      );
+      await service.checkQueueHealth();
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      repository.countByTypeAndStatus.mockResolvedValue(0);
+      await service.checkQueueHealth();
+
+      expect(metrics.setDlqAlertActive).toHaveBeenCalledWith(
+        JobType.WEBHOOK_DELIVERY,
+        'depth',
+        false,
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Dead letter queue alert cleared',
+          type: JobType.WEBHOOK_DELIVERY,
+          reason: 'depth',
+        }),
+      );
+    });
+
+    it('should continue checking other job types when one lookup fails', async () => {
+      repository.countByTypeAndStatus.mockImplementation(async (type: JobType) => {
+        if (type === JobType.WEBHOOK_DELIVERY) {
+          throw new Error('db unavailable');
+        }
+        return 0;
+      });
+
+      await expect(service.checkQueueHealth()).resolves.not.toThrow();
+
+      // Other types still get checked despite the failure for one type.
+      expect(metrics.setDlqAlertActive).toHaveBeenCalledWith(
+        JobType.RECURRING_PAYMENT,
+        'depth',
+        false,
+      );
+    });
+  });
+});

--- a/app/backend/src/job-queue/job-executor.service.ts
+++ b/app/backend/src/job-queue/job-executor.service.ts
@@ -305,6 +305,7 @@ export class JobExecutor implements OnModuleInit {
       // Update gauge metrics: running -> pending
       this.metrics.updateJobsRunningCount(job.type, -1);
       this.metrics.updateJobsPendingCount(job.type, 1);
+      this.metrics.incrementJobsRetried(job.type);
 
       this.logger.log(
         `Job ${job.id} scheduled for retry in ${retryDelayMs}ms (type: ${job.type}, attempt: ${newAttempts}/${policy.maxAttempts})`,

--- a/app/backend/src/job-queue/job-executor.service.unit.spec.ts
+++ b/app/backend/src/job-queue/job-executor.service.unit.spec.ts
@@ -22,8 +22,7 @@ describe('JobExecutor', () => {
   let repository: jest.Mocked<JobRepository>;
   let registry: jest.Mocked<JobRegistry>;
   let cancellationStore: jest.Mocked<CancellationStore>;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let _metrics: jest.Mocked<JobQueueMetricsService>;
+  let metrics: jest.Mocked<JobQueueMetricsService>;
 
   beforeEach(async () => {
     // Create mock implementations
@@ -67,6 +66,7 @@ describe('JobExecutor', () => {
       updateJobsRunningCount: jest.fn(),
       updateJobsDlqCount: jest.fn(),
       recordJobExecutionDuration: jest.fn(),
+      incrementJobsRetried: jest.fn(),
     };
 
     // Provide sensible defaults on repository so tests need only override specific behaviours
@@ -87,7 +87,7 @@ describe('JobExecutor', () => {
     repository = module.get(JobRepository) as jest.Mocked<JobRepository>;
     registry = module.get(JobRegistry) as jest.Mocked<JobRegistry>;
     cancellationStore = module.get(CancellationStore) as jest.Mocked<CancellationStore>;
-    _metrics = module.get(JobQueueMetricsService) as jest.Mocked<JobQueueMetricsService>;
+    metrics = module.get(JobQueueMetricsService) as jest.Mocked<JobQueueMetricsService>;
   });
 
   describe('processDueJobs', () => {
@@ -495,6 +495,46 @@ describe('JobExecutor', () => {
       expect(cancellationStore.clearCancellation).toHaveBeenCalledWith('job-1');
     });
 
+    it('should emit success metrics when handler succeeds', async () => {
+      // Arrange
+      const mockJob = createMockJob('job-1', JobType.WEBHOOK_DELIVERY);
+      repository.findDueJobs.mockResolvedValue([mockJob]);
+
+      const mockHandler = {
+        execute: jest.fn().mockResolvedValue(undefined),
+        validate: jest.fn().mockResolvedValue(undefined),
+        onFailure: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const mockToken = {
+        isCancelled: jest.fn().mockReturnValue(false),
+        throwIfCancelled: jest.fn(),
+      };
+
+      registry.getPolicy.mockReturnValue({
+        maxAttempts: 3,
+        backoffStrategy: 'exponential',
+        initialDelayMs: 1000,
+        maxDelayMs: 60000,
+        visibilityTimeoutMs: 300000,
+      });
+      registry.getHandler.mockReturnValue(mockHandler);
+      cancellationStore.createToken.mockReturnValue(mockToken);
+      repository.updateJobStatus.mockResolvedValue();
+
+      // Act
+      await executor.processDueJobs();
+
+      // Assert: completion metrics recorded, no retry/DLQ metrics
+      expect(metrics.incrementJobsCompleted).toHaveBeenCalledWith(JobType.WEBHOOK_DELIVERY);
+      expect(metrics.recordJobExecutionDuration).toHaveBeenCalledWith(
+        JobType.WEBHOOK_DELIVERY,
+        expect.any(Number),
+      );
+      expect(metrics.incrementJobsRetried).not.toHaveBeenCalled();
+      expect(metrics.incrementJobsFailed).not.toHaveBeenCalled();
+    });
+
     it('should log successful job completion with duration', async () => {
       // Arrange
       const mockJob = createMockJob('job-1', JobType.WEBHOOK_DELIVERY);
@@ -592,8 +632,12 @@ describe('JobExecutor', () => {
       // Allow 100ms tolerance for test execution time
       expect(retryDelayMs).toBeGreaterThanOrEqual(900);
       expect(retryDelayMs).toBeLessThanOrEqual(1100);
-      
+
       expect(cancellationStore.clearCancellation).toHaveBeenCalledWith('job-1');
+
+      // Verify retry metric was emitted (not a permanent failure yet)
+      expect(metrics.incrementJobsRetried).toHaveBeenCalledWith(JobType.WEBHOOK_DELIVERY);
+      expect(metrics.incrementJobsFailed).not.toHaveBeenCalled();
     });
 
     it('should move job to DLQ when attempts >= maxAttempts', async () => {
@@ -646,8 +690,13 @@ describe('JobExecutor', () => {
         mockJob,
         expect.objectContaining({ message: 'Permanent failure' }),
       );
-      
+
       expect(cancellationStore.clearCancellation).toHaveBeenCalledWith('job-1');
+
+      // Verify DLQ metrics were emitted, and no retry metric for the terminal transition
+      expect(metrics.incrementJobsFailed).toHaveBeenCalledWith(JobType.WEBHOOK_DELIVERY);
+      expect(metrics.updateJobsDlqCount).toHaveBeenCalledWith(JobType.WEBHOOK_DELIVERY, 1);
+      expect(metrics.incrementJobsRetried).not.toHaveBeenCalled();
     });
 
     it('should log failure with attempt information', async () => {

--- a/app/backend/src/job-queue/job-queue-metrics.service.ts
+++ b/app/backend/src/job-queue/job-queue-metrics.service.ts
@@ -28,11 +28,15 @@ export class JobQueueMetricsService implements OnModuleInit {
   private jobsCompletedTotal: client.Counter<string>;
   private jobsFailedTotal: client.Counter<string>;
   private jobsCancelledTotal: client.Counter<string>;
+  private jobsRetriedTotal: client.Counter<string>;
 
   // Gauge metrics
   private jobsPendingCount: client.Gauge<string>;
   private jobsRunningCount: client.Gauge<string>;
   private jobsDlqCount: client.Gauge<string>;
+  private jobsDlqOldestAgeSeconds: client.Gauge<string>;
+  private jobsPendingOldestAgeSeconds: client.Gauge<string>;
+  private jobsDlqAlertActive: client.Gauge<string>;
 
   // Histogram metric
   private jobExecutionDuration: client.Histogram<string>;
@@ -103,6 +107,38 @@ export class JobQueueMetricsService implements OnModuleInit {
         name: 'jobs_dlq_count',
         help: 'Current number of jobs in dead letter queue',
         labelNames: ['type'],
+        registers: [register],
+      });
+
+      // Counter: jobs_retried_total
+      this.jobsRetriedTotal = new client.Counter({
+        name: 'jobs_retried_total',
+        help: 'Total number of job retry attempts scheduled (excludes the final DLQ transition)',
+        labelNames: ['type'],
+        registers: [register],
+      });
+
+      // Gauge: jobs_dlq_oldest_age_seconds
+      this.jobsDlqOldestAgeSeconds = new client.Gauge({
+        name: 'jobs_dlq_oldest_age_seconds',
+        help: 'Age in seconds of the oldest job currently in the dead letter queue',
+        labelNames: ['type'],
+        registers: [register],
+      });
+
+      // Gauge: jobs_pending_oldest_age_seconds
+      this.jobsPendingOldestAgeSeconds = new client.Gauge({
+        name: 'jobs_pending_oldest_age_seconds',
+        help: 'Age in seconds of the oldest pending job waiting in the queue',
+        labelNames: ['type'],
+        registers: [register],
+      });
+
+      // Gauge: jobs_dlq_alert_active
+      this.jobsDlqAlertActive = new client.Gauge({
+        name: 'jobs_dlq_alert_active',
+        help: 'Whether a dead letter queue alert is currently firing for a job type (1=firing, 0=clear)',
+        labelNames: ['type', 'reason'],
         registers: [register],
       });
 
@@ -272,9 +308,9 @@ export class JobQueueMetricsService implements OnModuleInit {
 
   /**
    * Record job execution duration
-   * 
+   *
    * Called when a job completes (successfully or with failure).
-   * 
+   *
    * @param type - Job type
    * @param durationSeconds - Duration in seconds
    */
@@ -285,6 +321,80 @@ export class JobQueueMetricsService implements OnModuleInit {
 
     try {
       this.jobExecutionDuration.labels(type).observe(durationSeconds);
+    } catch (error) {
+      // Silently fail
+    }
+  }
+
+  /**
+   * Increment jobs_retried_total counter
+   *
+   * Called when a job fails but is scheduled for another attempt (not yet DLQ).
+   *
+   * @param type - Job type
+   */
+  incrementJobsRetried(type: JobType): void {
+    if (!this.initialized || !this.jobsRetriedTotal) {
+      return;
+    }
+
+    try {
+      this.jobsRetriedTotal.labels(type).inc();
+    } catch (error) {
+      // Silently fail
+    }
+  }
+
+  /**
+   * Set jobs_dlq_oldest_age_seconds gauge
+   *
+   * @param type - Job type
+   * @param ageSeconds - Age of the oldest DLQ job in seconds
+   */
+  setDlqOldestAgeSeconds(type: JobType, ageSeconds: number): void {
+    if (!this.initialized || !this.jobsDlqOldestAgeSeconds) {
+      return;
+    }
+
+    try {
+      this.jobsDlqOldestAgeSeconds.labels(type).set(ageSeconds);
+    } catch (error) {
+      // Silently fail
+    }
+  }
+
+  /**
+   * Set jobs_pending_oldest_age_seconds gauge
+   *
+   * @param type - Job type
+   * @param ageSeconds - Age of the oldest pending job in seconds
+   */
+  setPendingOldestAgeSeconds(type: JobType, ageSeconds: number): void {
+    if (!this.initialized || !this.jobsPendingOldestAgeSeconds) {
+      return;
+    }
+
+    try {
+      this.jobsPendingOldestAgeSeconds.labels(type).set(ageSeconds);
+    } catch (error) {
+      // Silently fail
+    }
+  }
+
+  /**
+   * Set jobs_dlq_alert_active gauge
+   *
+   * @param type - Job type
+   * @param reason - Which threshold triggered the alert ('depth' or 'age')
+   * @param active - Whether the alert is currently firing
+   */
+  setDlqAlertActive(type: JobType, reason: 'depth' | 'age', active: boolean): void {
+    if (!this.initialized || !this.jobsDlqAlertActive) {
+      return;
+    }
+
+    try {
+      this.jobsDlqAlertActive.labels(type, reason).set(active ? 1 : 0);
     } catch (error) {
       // Silently fail
     }

--- a/app/backend/src/job-queue/job-queue-metrics.service.unit.spec.ts
+++ b/app/backend/src/job-queue/job-queue-metrics.service.unit.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Job Queue Metrics Service - Unit Tests
+ *
+ * Uses a real prom-client registry (via MetricsService) so assertions verify
+ * actual metric names, labels, and values as they would appear on /metrics.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { JobQueueMetricsService } from './job-queue-metrics.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { JobType } from './types';
+
+describe('JobQueueMetricsService', () => {
+  let service: JobQueueMetricsService;
+  let metricsService: MetricsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [JobQueueMetricsService, MetricsService],
+    }).compile();
+
+    metricsService = module.get(MetricsService);
+    metricsService.onModuleInit();
+
+    service = module.get(JobQueueMetricsService);
+    service.onModuleInit();
+  });
+
+  it('should emit jobs_retried_total on retry', async () => {
+    service.incrementJobsRetried(JobType.WEBHOOK_DELIVERY);
+
+    const output = await metricsService.getRegistry().metrics();
+
+    expect(output).toContain('jobs_retried_total');
+    expect(output).toMatch(
+      /jobs_retried_total\{type="webhook_delivery"\} 1/,
+    );
+  });
+
+  it('should emit jobs_dlq_oldest_age_seconds and jobs_dlq_alert_active on dead-letter', async () => {
+    service.setDlqOldestAgeSeconds(JobType.WEBHOOK_DELIVERY, 4200);
+    service.setDlqAlertActive(JobType.WEBHOOK_DELIVERY, 'age', true);
+
+    const output = await metricsService.getRegistry().metrics();
+
+    expect(output).toMatch(
+      /jobs_dlq_oldest_age_seconds\{type="webhook_delivery"\} 4200/,
+    );
+    expect(output).toMatch(
+      /jobs_dlq_alert_active\{type="webhook_delivery",reason="age"\} 1/,
+    );
+  });
+
+  it('should emit jobs_completed_total on job success', async () => {
+    service.incrementJobsCompleted(JobType.WEBHOOK_DELIVERY);
+
+    const output = await metricsService.getRegistry().metrics();
+
+    expect(output).toMatch(
+      /jobs_completed_total\{type="webhook_delivery"\} 1/,
+    );
+  });
+
+  it('should clear an alert by setting the gauge back to 0', async () => {
+    service.setDlqAlertActive(JobType.WEBHOOK_DELIVERY, 'depth', true);
+    service.setDlqAlertActive(JobType.WEBHOOK_DELIVERY, 'depth', false);
+
+    const output = await metricsService.getRegistry().metrics();
+
+    expect(output).toMatch(
+      /jobs_dlq_alert_active\{type="webhook_delivery",reason="depth"\} 0/,
+    );
+  });
+
+  it('should not throw when metrics are used before initialization', () => {
+    const uninitialized = new JobQueueMetricsService(new MetricsService());
+
+    expect(() => uninitialized.incrementJobsRetried(JobType.WEBHOOK_DELIVERY)).not.toThrow();
+    expect(() => uninitialized.setDlqOldestAgeSeconds(JobType.WEBHOOK_DELIVERY, 10)).not.toThrow();
+    expect(() =>
+      uninitialized.setDlqAlertActive(JobType.WEBHOOK_DELIVERY, 'depth', true),
+    ).not.toThrow();
+  });
+});

--- a/app/backend/src/job-queue/job-queue.module.ts
+++ b/app/backend/src/job-queue/job-queue.module.ts
@@ -15,6 +15,7 @@ import { CancellationStore } from "./cancellation-token";
 import { JobQueueInitializer } from "./job-queue-initializer.service";
 import { JobAdminController } from "./job-admin.controller";
 import { JobQueueMetricsService } from "./job-queue-metrics.service";
+import { DeadLetterQueueMonitorService } from "./dead-letter-monitor.service";
 import { SupabaseModule } from "../supabase/supabase.module";
 import { NotificationsModule } from "../notifications/notifications.module";
 import { LinksModule } from "../links/links.module";
@@ -75,6 +76,7 @@ import {
     CancellationStore,
     JobQueueInitializer,
     JobQueueMetricsService,
+    DeadLetterQueueMonitorService,
     WebhookDeliveryHandler,
     RecurringPaymentHandler,
     ExportGenerationHandler,

--- a/app/backend/src/job-queue/job.repository.ts
+++ b/app/backend/src/job-queue/job.repository.ts
@@ -318,6 +318,68 @@ export class JobRepository {
   }
 
   /**
+   * Count jobs of a given type and status
+   *
+   * Used by the dead letter queue monitor to report per-type queue depth
+   * (e.g. pending backlog, DLQ depth) as metrics.
+   *
+   * @param type - Job type
+   * @param status - Job status
+   * @returns Number of matching jobs
+   */
+  async countByTypeAndStatus(type: JobType, status: JobStatus): Promise<number> {
+    const { count, error } = await this.client
+      .from('jobs')
+      .select('*', { count: 'exact', head: true })
+      .eq('type', type)
+      .eq('status', status);
+
+    if (error) {
+      this.logger.warn(`countByTypeAndStatus failed for ${type}/${status}: ${error.message}`);
+      return 0;
+    }
+
+    return count ?? 0;
+  }
+
+  /**
+   * Age in seconds of the oldest job of a given type and status
+   *
+   * Used by the dead letter queue monitor to report how long the oldest
+   * pending or dead-lettered job of a type has been waiting.
+   *
+   * @param type - Job type
+   * @param status - Job status
+   * @param now - Reference time (defaults to current time)
+   * @returns Age in seconds, or null if there are no matching jobs
+   */
+  async getOldestAgeSeconds(
+    type: JobType,
+    status: JobStatus,
+    now: Date = new Date(),
+  ): Promise<number | null> {
+    const { data, error } = await this.client
+      .from('jobs')
+      .select('created_at')
+      .eq('type', type)
+      .eq('status', status)
+      .order('created_at', { ascending: true })
+      .limit(1);
+
+    if (error) {
+      this.logger.warn(`getOldestAgeSeconds failed for ${type}/${status}: ${error.message}`);
+      return null;
+    }
+
+    if (!data || data.length === 0) {
+      return null;
+    }
+
+    const ageMs = now.getTime() - new Date((data[0] as { created_at: string }).created_at).getTime();
+    return Math.max(0, Math.round(ageMs / 1000));
+  }
+
+  /**
    * Map a database row to a Job object
    * 
    * @param row - Database row

--- a/app/backend/src/job-queue/job.repository.unit.spec.ts
+++ b/app/backend/src/job-queue/job.repository.unit.spec.ts
@@ -267,4 +267,109 @@ describe('JobRepository - Basic Verification', () => {
       });
     });
   });
+
+  describe('countByTypeAndStatus', () => {
+    it('should return the count for a given type and status', async () => {
+      const mockEqStatus = jest.fn().mockResolvedValue({ count: 7, error: null });
+      const mockEqType = jest.fn().mockReturnValue({ eq: mockEqStatus });
+      const mockSelect = jest.fn().mockReturnValue({ eq: mockEqType });
+
+      mockSupabaseClient.from.mockReturnValue({ select: mockSelect });
+
+      const count = await repository.countByTypeAndStatus(
+        JobType.WEBHOOK_DELIVERY,
+        JobStatus.FAILED,
+      );
+
+      expect(count).toBe(7);
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('jobs');
+      expect(mockSelect).toHaveBeenCalledWith('*', { count: 'exact', head: true });
+      expect(mockEqType).toHaveBeenCalledWith('type', JobType.WEBHOOK_DELIVERY);
+      expect(mockEqStatus).toHaveBeenCalledWith('status', JobStatus.FAILED);
+    });
+
+    it('should return 0 when the query errors', async () => {
+      const mockEqStatus = jest.fn().mockResolvedValue({
+        count: null,
+        error: { message: 'db error' },
+      });
+      const mockEqType = jest.fn().mockReturnValue({ eq: mockEqStatus });
+      const mockSelect = jest.fn().mockReturnValue({ eq: mockEqType });
+
+      mockSupabaseClient.from.mockReturnValue({ select: mockSelect });
+
+      const count = await repository.countByTypeAndStatus(
+        JobType.WEBHOOK_DELIVERY,
+        JobStatus.FAILED,
+      );
+
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('getOldestAgeSeconds', () => {
+    it('should return the age in seconds of the oldest matching job', async () => {
+      const now = new Date('2026-01-01T00:10:00.000Z');
+      const createdAt = new Date('2026-01-01T00:00:00.000Z').toISOString();
+
+      const mockLimit = jest.fn().mockResolvedValue({
+        data: [{ created_at: createdAt }],
+        error: null,
+      });
+      const mockOrder = jest.fn().mockReturnValue({ limit: mockLimit });
+      const mockEqStatus = jest.fn().mockReturnValue({ order: mockOrder });
+      const mockEqType = jest.fn().mockReturnValue({ eq: mockEqStatus });
+      const mockSelect = jest.fn().mockReturnValue({ eq: mockEqType });
+
+      mockSupabaseClient.from.mockReturnValue({ select: mockSelect });
+
+      const ageSeconds = await repository.getOldestAgeSeconds(
+        JobType.WEBHOOK_DELIVERY,
+        JobStatus.FAILED,
+        now,
+      );
+
+      expect(ageSeconds).toBe(600);
+      expect(mockSelect).toHaveBeenCalledWith('created_at');
+      expect(mockEqType).toHaveBeenCalledWith('type', JobType.WEBHOOK_DELIVERY);
+      expect(mockEqStatus).toHaveBeenCalledWith('status', JobStatus.FAILED);
+    });
+
+    it('should return null when there are no matching jobs', async () => {
+      const mockLimit = jest.fn().mockResolvedValue({ data: [], error: null });
+      const mockOrder = jest.fn().mockReturnValue({ limit: mockLimit });
+      const mockEqStatus = jest.fn().mockReturnValue({ order: mockOrder });
+      const mockEqType = jest.fn().mockReturnValue({ eq: mockEqStatus });
+      const mockSelect = jest.fn().mockReturnValue({ eq: mockEqType });
+
+      mockSupabaseClient.from.mockReturnValue({ select: mockSelect });
+
+      const ageSeconds = await repository.getOldestAgeSeconds(
+        JobType.WEBHOOK_DELIVERY,
+        JobStatus.FAILED,
+      );
+
+      expect(ageSeconds).toBeNull();
+    });
+
+    it('should return null when the query errors', async () => {
+      const mockLimit = jest.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'db error' },
+      });
+      const mockOrder = jest.fn().mockReturnValue({ limit: mockLimit });
+      const mockEqStatus = jest.fn().mockReturnValue({ order: mockOrder });
+      const mockEqType = jest.fn().mockReturnValue({ eq: mockEqStatus });
+      const mockSelect = jest.fn().mockReturnValue({ eq: mockEqType });
+
+      mockSupabaseClient.from.mockReturnValue({ select: mockSelect });
+
+      const ageSeconds = await repository.getOldestAgeSeconds(
+        JobType.WEBHOOK_DELIVERY,
+        JobStatus.FAILED,
+      );
+
+      expect(ageSeconds).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds per-job-type retry counter (`jobs_retried_total`), DLQ/pending oldest-job-age gauges (`jobs_dlq_oldest_age_seconds`, `jobs_pending_oldest_age_seconds`), and a DLQ alert gauge (`jobs_dlq_alert_active{type,reason}`) to `JobQueueMetricsService`, on top of the existing queue-depth/DLQ-depth gauges.
- Wires the retry counter into `JobExecutor.handleJobFailure` so every retry (not just the final DLQ transition) is counted.
- Adds `JobRepository.countByTypeAndStatus` / `getOldestAgeSeconds` to query per-type queue depth and oldest-job age.
- Adds `DeadLetterQueueMonitorService`, a `@Cron(EVERY_MINUTE)` service that samples pending/DLQ depth and age per job type, publishes the gauges, and fires/clears `jobs_dlq_alert_active` when DLQ depth or oldest-DLQ-job age crosses a configurable threshold (logged on each firing/clearing transition so a repeatedly-failing job type is distinguishable from a one-off failure that clears quickly).
- New config: `DLQ_MONITOR_ENABLED` (default `true`), `DLQ_ALERT_DEPTH_THRESHOLD` (default `50`), `DLQ_ALERT_AGE_THRESHOLD_MS` (default `3600000`), following the same pattern as the existing indexer-lag guard config.

## Changes
- `app/backend/src/config/env.schema.ts`, `app-config.service.ts`: new DLQ monitor config
- `app/backend/src/job-queue/job-queue-metrics.service.ts`: new metrics + setter methods
- `app/backend/src/job-queue/job-executor.service.ts`: emit retry metric on scheduled retry
- `app/backend/src/job-queue/job.repository.ts`: per-type depth/age queries
- `app/backend/src/job-queue/dead-letter-monitor.service.ts` (new): cron-based monitor + alerting
- `app/backend/src/job-queue/job-queue.module.ts`: register the new monitor service
- Tests added/updated for all of the above (executor retry/DLQ/success metric emission, repository queries, metrics service against a real prom-client registry, monitor alert firing/clearing)

## Test plan
- [x] `npx jest src/job-queue src/metrics src/config` — 18 suites / 258 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all changed files — clean
- [ ] Manual verification against a live Prometheus/Alertmanager setup (out of scope for this repo, which has no existing alerting infra — the DLQ alert is exposed as a gauge for external alerting to consume, matching the existing `indexer_lag_guard_status` pattern)

closes #824