### PR TITLE
feat(frontend): API-key UI tests, reduced-motion, session recovery & config diagnostics

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.5.9",
+        "jsdom": "^30.0.1",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^3.2.3"
@@ -66,12 +67,46 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -87,6 +122,7 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -98,6 +134,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.1.tgz",
+      "integrity": "sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.9.tgz",
+      "integrity": "sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -717,6 +906,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -2254,6 +2461,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2274,6 +2482,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2349,7 +2558,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2459,7 +2669,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2470,7 +2679,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2481,7 +2689,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2537,7 +2744,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3139,7 +3345,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3180,6 +3385,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3447,6 +3653,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3662,6 +3878,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -3804,6 +4034,35 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -3876,6 +4135,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -3941,6 +4207,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3973,7 +4240,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4009,6 +4277,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4266,7 +4547,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4440,7 +4720,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5147,6 +5426,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -5175,7 +5467,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -5523,6 +5814,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5727,6 +6025,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -6126,6 +6465,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.11.0.tgz",
@@ -6141,6 +6490,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6164,6 +6514,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6568,6 +6925,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6686,6 +7056,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6701,6 +7072,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6713,7 +7085,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6768,7 +7141,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6778,7 +7150,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6817,8 +7188,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-qr-code": {
       "version": "2.0.18",
@@ -6838,7 +7208,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6905,8 +7274,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6959,6 +7327,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -7141,6 +7519,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7624,6 +8015,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -7706,7 +8104,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7744,6 +8141,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7755,6 +8172,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7886,7 +8329,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7912,6 +8354,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -8003,7 +8455,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8120,7 +8571,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8221,6 +8671,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -8354,6 +8852,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@quickex/api-client": "file:../../packages/api-client",
-    "openapi-fetch": "0.13.8",
     "i18next": "^26.0.1",
     "lucide-react": "^1.11.0",
     "next": "15.5.9",
+    "openapi-fetch": "0.13.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-i18next": "^17.0.4",
@@ -31,6 +31,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.9",
+    "jsdom": "^30.0.1",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^3.2.3"

--- a/app/frontend/src/app/globals.css
+++ b/app/frontend/src/app/globals.css
@@ -158,3 +158,22 @@ button:disabled {
   opacity: .6;
   cursor: not-allowed;
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Reduced motion (FE-69)
+   Respect the OS `prefers-reduced-motion: reduce` setting for motion-sensitive
+   users. Applied globally so every animated surface is covered by shared CSS
+   rather than patched per page. Content stays fully usable; no information is
+   conveyed by motion alone.
+   ────────────────────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/app/frontend/src/app/misconfiguration/misconfiguration.test.tsx
+++ b/app/frontend/src/app/misconfiguration/misconfiguration.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import MisconfigurationPage from "./page";
+import { ENV_SPEC, RUNTIME_CONFIG_DOCS_URL } from "@/lib/env";
+
+const originalEnv = process.env;
+
+function setEnv(overrides: Record<string, string | undefined>) {
+  process.env = { ...originalEnv, ...overrides };
+}
+
+afterEach(() => {
+  cleanup();
+  process.env = originalEnv;
+});
+
+describe("MisconfigurationPage (FE-71)", () => {
+  it("names a missing required key and its expected shape", () => {
+    setEnv({
+      NEXT_PUBLIC_QUICKEX_API_URL: undefined,
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+    });
+    render(<MisconfigurationPage />);
+
+    expect(screen.getByText("NEXT_PUBLIC_QUICKEX_API_URL")).toBeTruthy();
+    // Expected-shape guidance from the spec is shown.
+    expect(
+      screen.getByText(new RegExp(ENV_SPEC.NEXT_PUBLIC_QUICKEX_API_URL.expected, "i")),
+    ).toBeTruthy();
+  });
+
+  it("reports an invalid value with the reason and expected shape", () => {
+    setEnv({
+      NEXT_PUBLIC_QUICKEX_API_URL: "https://api.example",
+      NEXT_PUBLIC_STELLAR_NETWORK: "bogusnet",
+    });
+    render(<MisconfigurationPage />);
+
+    expect(screen.getByText(/NEXT_PUBLIC_STELLAR_NETWORK/)).toBeTruthy();
+    expect(
+      screen.getAllByText(/testnet.*mainnet|mainnet.*testnet/i).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("never renders the actual invalid value beyond the reason string", () => {
+    // A secret-looking value must not leak into the DOM as a standalone token.
+    setEnv({
+      NEXT_PUBLIC_QUICKEX_API_URL: "not-a-url",
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+    });
+    const { container } = render(<MisconfigurationPage />);
+    // The page shows the key name; it does not print a "value: <secret>" line.
+    expect(container.textContent).not.toContain("NEXT_PUBLIC_QUICKEX_API_URL=");
+  });
+
+  it("links to the runtime config documentation", () => {
+    setEnv({ NEXT_PUBLIC_QUICKEX_API_URL: undefined });
+    render(<MisconfigurationPage />);
+    const link = screen.getByRole("link", {
+      name: /runtime configuration documentation/i,
+    });
+    expect(link.getAttribute("href")).toBe(RUNTIME_CONFIG_DOCS_URL);
+  });
+});

--- a/app/frontend/src/app/misconfiguration/page.tsx
+++ b/app/frontend/src/app/misconfiguration/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { validateEnv } from "@/lib/env";
+import { getEnvKeySpec, RUNTIME_CONFIG_DOCS_URL, validateEnv } from "@/lib/env";
 
 export default function MisconfigurationPage() {
   const validation = validateEnv();
@@ -38,12 +38,20 @@ export default function MisconfigurationPage() {
               <h3 className="font-semibold text-red-800 mb-2">
                 Missing Required Variables:
               </h3>
-              <ul className="list-disc list-inside space-y-1 text-red-700">
-                {validation.missing.map((key) => (
-                  <li key={key} className="font-mono text-sm">
-                    {key}
-                  </li>
-                ))}
+              <ul className="list-disc list-inside space-y-2 text-red-700">
+                {validation.missing.map((key) => {
+                  const spec = getEnvKeySpec(key);
+                  return (
+                    <li key={key} className="text-sm">
+                      <span className="font-mono font-semibold">{key}</span>
+                      {spec && (
+                        <span className="block pl-4 text-xs text-red-600">
+                          {spec.description} Expected: {spec.expected}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           )}
@@ -53,21 +61,41 @@ export default function MisconfigurationPage() {
               <h3 className="font-semibold text-red-800 mb-2">
                 Invalid Variables:
               </h3>
-              <ul className="list-disc list-inside space-y-1 text-red-700">
-                {validation.invalid.map(({ key, reason }) => (
-                  <li key={key} className="text-sm">
-                    <span className="font-mono">{key}</span>: {reason}
-                  </li>
-                ))}
+              <ul className="list-disc list-inside space-y-2 text-red-700">
+                {validation.invalid.map(({ key, reason }) => {
+                  const spec = getEnvKeySpec(key);
+                  return (
+                    <li key={key} className="text-sm">
+                      <span className="font-mono font-semibold">{key}</span>:{" "}
+                      {reason}
+                      {spec && (
+                        <span className="block pl-4 text-xs text-red-600">
+                          Expected: {spec.expected}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           )}
         </div>
 
-        <div className="text-center text-sm text-muted">
+        <div className="text-center text-sm text-muted space-y-2">
           <p>
             Please contact your system administrator or check the deployment
             configuration.
+          </p>
+          <p>
+            <a
+              href={RUNTIME_CONFIG_DOCS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline hover:no-underline"
+            >
+              View the runtime configuration documentation
+            </a>{" "}
+            for the full list of keys and their expected values.
           </p>
         </div>
       </div>

--- a/app/frontend/src/app/settings/developer/developer.test.tsx
+++ b/app/frontend/src/app/settings/developer/developer.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import DeveloperSettings from "./page";
+
+vi.mock("@/lib/api", () => ({ getQuickexApiBase: () => "http://test.local" }));
+
+const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+Object.defineProperty(globalThis, "navigator", {
+  value: { clipboard: { writeText: clipboardWrite } },
+  writable: true,
+});
+
+const existingKey = {
+  id: "k1",
+  name: "Existing Key",
+  key_prefix: "qx_live_abc123",
+  scopes: ["links:read"],
+  is_active: true,
+  request_count: 3,
+  monthly_quota: 1000,
+  last_used_at: null,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const usage = { total_keys: 1, total_requests: 3, quota: 1000 };
+
+function jsonRes(body: unknown, ok = true, status = 200) {
+  return Promise.resolve({ ok, status, json: () => Promise.resolve(body) });
+}
+
+type Routes = Record<string, (init?: RequestInit) => Promise<unknown>>;
+
+function installFetch(routes: Routes) {
+  global.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    const path = url.replace("http://test.local", "");
+    const method = (init?.method ?? "GET").toUpperCase();
+    const handler = routes[`${method} ${path}`];
+    if (!handler) {
+      return jsonRes({ message: `unhandled ${method} ${path}` }, false, 404);
+    }
+    return handler(init);
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  clipboardWrite.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("DeveloperSettings API key management (FE-68)", () => {
+  it("shows only the prefix for existing keys, not a full secret", async () => {
+    installFetch({
+      "GET /api-keys": () => jsonRes([existingKey]),
+      "GET /api-keys/usage": () => jsonRes(usage),
+    });
+    render(<DeveloperSettings />);
+
+    await waitFor(() => expect(screen.getByText("Existing Key")).toBeTruthy());
+    // A masked/reveal affordance exists; the full secret is never present.
+    expect(screen.getByRole("button", { name: /reveal/i })).toBeTruthy();
+    expect(screen.queryByText(/won't be shown again|won.t be shown again/i)).toBeNull();
+  });
+
+  it("creates a key and reveals the secret exactly once with a warning", async () => {
+    const created = {
+      id: "k2",
+      name: "CI Bot",
+      key_prefix: "qx_live_new999",
+      scopes: ["links:read"],
+      is_active: true,
+      request_count: 0,
+      monthly_quota: 1000,
+      last_used_at: null,
+      created_at: "2026-02-01T00:00:00Z",
+      key: "qx_live_new999_FULLSECRETVALUE",
+    };
+    installFetch({
+      "GET /api-keys": () => jsonRes([]),
+      "GET /api-keys/usage": () => jsonRes({ total_keys: 0, total_requests: 0, quota: 1000 }),
+      "POST /api-keys": () => jsonRes(created),
+    });
+    render(<DeveloperSettings />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/no api keys yet/i)).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /create new key/i }));
+    fireEvent.change(screen.getByPlaceholderText(/production app/i), {
+      target: { value: "CI Bot" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /links:read/i }));
+    fireEvent.click(screen.getByRole("button", { name: /generate key/i }));
+
+    // One-time reveal: the full secret and the "won't be shown again" warning.
+    await waitFor(() =>
+      expect(screen.getByText("qx_live_new999_FULLSECRETVALUE")).toBeTruthy(),
+    );
+    expect(screen.getByText(/won.t be shown again/i)).toBeTruthy();
+
+    // Copy affordance writes the raw secret. Scope to the key's action row via
+    // its unique Rotate button so we don't match a sample-request copy button.
+    const actionRow = screen
+      .getByRole("button", { name: /rotate/i })
+      .closest("div") as HTMLElement;
+    fireEvent.click(within(actionRow).getByRole("button", { name: /copy/i }));
+    expect(clipboardWrite).toHaveBeenCalledWith("qx_live_new999_FULLSECRETVALUE");
+  });
+
+  it("revokes a key after explicit confirmation", async () => {
+    const deleteCalls: string[] = [];
+    installFetch({
+      "GET /api-keys": () => jsonRes([existingKey]),
+      "GET /api-keys/usage": () => jsonRes(usage),
+      "DELETE /api-keys/k1": () => {
+        deleteCalls.push("k1");
+        return jsonRes({});
+      },
+    });
+    render(<DeveloperSettings />);
+
+    await waitFor(() => expect(screen.getByText("Existing Key")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /^revoke$/i }));
+    // Confirmation is required before the destructive call.
+    fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+    await waitFor(() => expect(deleteCalls).toEqual(["k1"]));
+    await waitFor(() => expect(screen.queryByText("Existing Key")).toBeNull());
+  });
+
+  it("surfaces a backend error when revocation fails", async () => {
+    installFetch({
+      "GET /api-keys": () => jsonRes([existingKey]),
+      "GET /api-keys/usage": () => jsonRes(usage),
+      "DELETE /api-keys/k1": () =>
+        jsonRes({ message: "Key is locked by admin" }, false, 409),
+    });
+    render(<DeveloperSettings />);
+
+    await waitFor(() => expect(screen.getByText("Existing Key")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /^revoke$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/key is locked by admin/i)).toBeTruthy(),
+    );
+  });
+});

--- a/app/frontend/src/components/SessionExpiryProvider.test.tsx
+++ b/app/frontend/src/components/SessionExpiryProvider.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { SessionExpiryProvider } from "./SessionExpiryProvider";
+import { useFormDraft } from "@/hooks/useFormDraft";
+import {
+  loadFormDraft,
+  notifyAuthExpired,
+  resetAuthListeners,
+} from "@/lib/auth-session";
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => "/pay/link-123",
+}));
+
+// A minimal payment-like form that drafts its input.
+function PayForm() {
+  const [value, setValue] = useFormDraft<{ amount: string }>("pay-form", {
+    amount: "",
+  });
+  return (
+    <input
+      aria-label="amount"
+      value={value.amount}
+      onChange={(e) => setValue({ amount: e.target.value })}
+    />
+  );
+}
+
+beforeEach(() => {
+  resetAuthListeners();
+  window.sessionStorage.clear();
+  pushMock.mockClear();
+});
+
+afterEach(() => cleanup());
+
+describe("SessionExpiryProvider (FE-70)", () => {
+  it("shows a re-auth prompt on auth expiry and preserves form input", async () => {
+    render(
+      <SessionExpiryProvider onReauthenticate={() => Promise.resolve(true)}>
+        <PayForm />
+      </SessionExpiryProvider>,
+    );
+
+    // User types into the payment form.
+    fireEvent.change(screen.getByLabelText("amount"), {
+      target: { value: "42.5" },
+    });
+    // The draft is persisted immediately.
+    expect(loadFormDraft("pay-form")).toEqual({ amount: "42.5" });
+
+    // Session expires mid-form.
+    notifyAuthExpired({ reason: "Session expired" });
+    await waitFor(() =>
+      expect(screen.getByRole("dialog", { name: /session expired/i })).toBeTruthy(),
+    );
+
+    // The in-progress input is still saved (not lost).
+    expect(loadFormDraft("pay-form")).toEqual({ amount: "42.5" });
+  });
+
+  it("returns to the originating route after reconnecting", async () => {
+    render(
+      <SessionExpiryProvider onReauthenticate={() => Promise.resolve(true)}>
+        <PayForm />
+      </SessionExpiryProvider>,
+    );
+
+    notifyAuthExpired();
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: /reconnect/i }));
+
+    // Prompt dismissed and the user is routed back to where they were.
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(pushMock).toHaveBeenCalledWith("/pay/link-123");
+  });
+
+  it("keeps the prompt and shows an error when re-auth fails", async () => {
+    render(
+      <SessionExpiryProvider onReauthenticate={() => Promise.resolve(false)}>
+        <PayForm />
+      </SessionExpiryProvider>,
+    );
+
+    notifyAuthExpired();
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /reconnect/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/re-authentication failed/i)).toBeTruthy(),
+    );
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/frontend/src/components/SessionExpiryProvider.tsx
+++ b/app/frontend/src/components/SessionExpiryProvider.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  onAuthExpired,
+  saveOriginRoute,
+  takeOriginRoute,
+  type AuthExpiredDetail,
+} from "@/lib/auth-session";
+
+type SessionExpiryContextValue = {
+  expired: boolean;
+  /** Manually trigger the expiry flow (also fired by the fetch wrapper). */
+  triggerExpiry: (detail?: AuthExpiredDetail) => void;
+};
+
+const SessionExpiryContext = createContext<SessionExpiryContextValue | null>(
+  null,
+);
+
+export function useSessionExpiry(): SessionExpiryContextValue {
+  const ctx = useContext(SessionExpiryContext);
+  if (!ctx) {
+    throw new Error(
+      "useSessionExpiry must be used within a SessionExpiryProvider",
+    );
+  }
+  return ctx;
+}
+
+type Props = {
+  children: ReactNode;
+  /**
+   * Performs the actual re-authentication (e.g. reconnect wallet / refresh
+   * session). Resolves `true` on success. Defaults to a no-op success so the
+   * UX can be exercised without wallet infrastructure.
+   */
+  onReauthenticate?: () => Promise<boolean>;
+};
+
+/**
+ * Centralises detection of authentication failures and presents a single
+ * re-authentication prompt (FE-70). On success the user is returned to the
+ * route they started from rather than the home page, and any form drafts saved
+ * via `useFormDraft` remain intact so a payment in progress is not lost.
+ */
+export function SessionExpiryProvider({ children, onReauthenticate }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [expired, setExpired] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
+  const [reason, setReason] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const triggerExpiry = useCallback(
+    (detail?: AuthExpiredDetail) => {
+      saveOriginRoute(detail?.route ?? pathname ?? "/");
+      setReason(detail?.reason ?? null);
+      setError(null);
+      setExpired(true);
+    },
+    [pathname],
+  );
+
+  useEffect(() => onAuthExpired(triggerExpiry), [triggerExpiry]);
+
+  const reconnect = useCallback(async () => {
+    setReconnecting(true);
+    setError(null);
+    try {
+      const ok = onReauthenticate ? await onReauthenticate() : true;
+      if (!ok) {
+        setError("Re-authentication failed. Please try again.");
+        return;
+      }
+      setExpired(false);
+      const origin = takeOriginRoute();
+      if (origin) {
+        router.push(origin);
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setReconnecting(false);
+    }
+  }, [onReauthenticate, router]);
+
+  return (
+    <SessionExpiryContext.Provider value={{ expired, triggerExpiry }}>
+      {children}
+      {expired && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Session expired"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+        >
+          <div className="w-full max-w-sm space-y-4 rounded-2xl border border-border-strong bg-card p-6 text-foreground shadow-xl">
+            <h2 className="text-lg font-bold">Your session expired</h2>
+            <p className="text-sm text-muted">
+              Reconnect to continue. Your in-progress input has been saved and
+              will be restored automatically.
+            </p>
+            {reason && <p className="text-xs text-subtle">{reason}</p>}
+            {error && <p className="text-xs text-danger">{error}</p>}
+            <button
+              type="button"
+              onClick={reconnect}
+              disabled={reconnecting}
+              className="w-full rounded-xl bg-primary px-4 py-3 text-sm font-bold text-white transition disabled:opacity-50"
+            >
+              {reconnecting ? "Reconnecting…" : "Reconnect"}
+            </button>
+          </div>
+        </div>
+      )}
+    </SessionExpiryContext.Provider>
+  );
+}

--- a/app/frontend/src/hooks/useFormDraft.ts
+++ b/app/frontend/src/hooks/useFormDraft.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  clearFormDraft,
+  loadFormDraft,
+  saveFormDraft,
+} from "@/lib/auth-session";
+
+/**
+ * Form state that persists to session storage so in-progress input survives a
+ * re-authentication round trip (FE-70). Restores any saved draft on mount.
+ *
+ * Returns a `[value, setValue, clear]` tuple; `setValue` both updates state and
+ * persists the draft, and `clear` removes the persisted draft.
+ */
+export function useFormDraft<T>(
+  key: string,
+  initial: T,
+): readonly [T, (next: T) => void, () => void] {
+  const [value, setValue] = useState<T>(initial);
+
+  useEffect(() => {
+    const saved = loadFormDraft<T>(key);
+    if (saved !== null) {
+      setValue(saved);
+    }
+  }, [key]);
+
+  const update = useCallback(
+    (next: T) => {
+      setValue(next);
+      saveFormDraft(key, next);
+    },
+    [key],
+  );
+
+  const clear = useCallback(() => {
+    clearFormDraft(key);
+    setValue(initial);
+  }, [key, initial]);
+
+  return [value, update, clear] as const;
+}

--- a/app/frontend/src/hooks/usePrefersReducedMotion.test.tsx
+++ b/app/frontend/src/hooks/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { cleanup, render, screen } from "@testing-library/react";
+import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+function mockMatchMedia(matches: boolean) {
+  let listener: Listener | null = null;
+  const mql = {
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    addEventListener: (_: string, cb: Listener) => {
+      listener = cb;
+    },
+    removeEventListener: () => {
+      listener = null;
+    },
+    addListener: (cb: Listener) => {
+      listener = cb;
+    },
+    removeListener: () => {
+      listener = null;
+    },
+    dispatch: (next: boolean) =>
+      listener?.({ matches: next } as MediaQueryListEvent),
+  };
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  return mql;
+}
+
+function Probe() {
+  const reduced = usePrefersReducedMotion();
+  return <span data-testid="v">{reduced ? "reduced" : "full"}</span>;
+}
+
+afterEach(() => cleanup());
+
+describe("usePrefersReducedMotion (FE-69)", () => {
+  it("returns true when the OS prefers reduced motion", () => {
+    mockMatchMedia(true);
+    render(<Probe />);
+    expect(screen.getByTestId("v").textContent).toBe("reduced");
+  });
+
+  it("returns false when reduced motion is not requested", () => {
+    mockMatchMedia(false);
+    render(<Probe />);
+    expect(screen.getByTestId("v").textContent).toBe("full");
+  });
+
+  it("global stylesheet neutralizes motion under the reduce media query", () => {
+    // Documented check: the shared reset exists so animated surfaces are
+    // covered globally rather than per page.
+    const css = readFileSync(
+      path.resolve(__dirname, "../app/globals.css"),
+      "utf8",
+    );
+    expect(css).toMatch(/prefers-reduced-motion:\s*reduce/);
+    expect(css).toMatch(/animation-duration:\s*0\.01ms\s*!important/);
+    expect(css).toMatch(/transition-duration:\s*0\.01ms\s*!important/);
+  });
+});

--- a/app/frontend/src/hooks/usePrefersReducedMotion.ts
+++ b/app/frontend/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * Reports whether the user has requested reduced motion at the OS level
+ * (FE-69). Components that drive animation from JavaScript (e.g. auto-playing
+ * carousels or spinners) should gate that motion on this hook, in addition to
+ * the global CSS reset in `globals.css`.
+ *
+ * SSR-safe: returns `false` until mounted, then subscribes to changes.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+    const mql = window.matchMedia(QUERY);
+    setPrefersReduced(mql.matches);
+
+    const onChange = (event: MediaQueryListEvent) => {
+      setPrefersReduced(event.matches);
+    };
+
+    // addEventListener is the modern API; fall back for older engines.
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, []);
+
+  return prefersReduced;
+}

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -5,3 +5,25 @@
 export const getQuickexApiBase = (): string =>
   process.env.NEXT_PUBLIC_QUICKEX_API_URL?.replace(/\/$/, "") ||
   "http://localhost:4000";
+
+import { isAuthFailure, notifyAuthExpired } from "@/lib/auth-session";
+
+/**
+ * `fetch` wrapper that centrally detects authentication/session expiry (FE-70).
+ * On a 401/403 it announces an auth-expiry event (consumed by
+ * `SessionExpiryProvider`) so the app surfaces a single re-authentication
+ * prompt instead of a generic API error, then still returns the response so the
+ * caller can handle it.
+ */
+export async function fetchWithAuth(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const res = await fetch(input, init);
+  if (isAuthFailure(res.status)) {
+    const route =
+      typeof window !== "undefined" ? window.location.pathname : undefined;
+    notifyAuthExpired({ route, reason: "Your session or wallet connection expired." });
+  }
+  return res;
+}

--- a/app/frontend/src/lib/auth-session.test.tsx
+++ b/app/frontend/src/lib/auth-session.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearFormDraft,
+  isAuthFailure,
+  loadFormDraft,
+  notifyAuthExpired,
+  onAuthExpired,
+  resetAuthListeners,
+  saveFormDraft,
+  saveOriginRoute,
+  takeOriginRoute,
+} from "./auth-session";
+import { fetchWithAuth } from "./api";
+
+beforeEach(() => {
+  resetAuthListeners();
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("auth-session core (FE-70)", () => {
+  it("classifies 401/403 as auth failures", () => {
+    expect(isAuthFailure(401)).toBe(true);
+    expect(isAuthFailure(403)).toBe(true);
+    expect(isAuthFailure(200)).toBe(false);
+    expect(isAuthFailure(500)).toBe(false);
+  });
+
+  it("notifies subscribers and supports unsubscribe", () => {
+    const seen: string[] = [];
+    const off = onAuthExpired((d) => seen.push(d.reason ?? ""));
+    notifyAuthExpired({ reason: "expired" });
+    off();
+    notifyAuthExpired({ reason: "again" });
+    expect(seen).toEqual(["expired"]);
+  });
+
+  it("round-trips a form draft", () => {
+    saveFormDraft("pay", { amount: "10", memo: "hi" });
+    expect(loadFormDraft("pay")).toEqual({ amount: "10", memo: "hi" });
+    clearFormDraft("pay");
+    expect(loadFormDraft("pay")).toBeNull();
+  });
+
+  it("returns the origin route once, then clears it", () => {
+    saveOriginRoute("/pay/abc");
+    expect(takeOriginRoute()).toBe("/pay/abc");
+    expect(takeOriginRoute()).toBeNull();
+  });
+});
+
+describe("fetchWithAuth (FE-70)", () => {
+  it("fires an auth-expiry event on a 401 response", async () => {
+    const listener = vi.fn();
+    onAuthExpired(listener);
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ status: 401, ok: false }) as unknown as typeof fetch;
+
+    const res = await fetchWithAuth("/api/whoami");
+    expect(res.status).toBe(401);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire on a successful response", async () => {
+    const listener = vi.fn();
+    onAuthExpired(listener);
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ status: 200, ok: true }) as unknown as typeof fetch;
+
+    await fetchWithAuth("/api/whoami");
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/app/frontend/src/lib/auth-session.ts
+++ b/app/frontend/src/lib/auth-session.ts
@@ -1,0 +1,97 @@
+/**
+ * auth-session.ts (FE-70)
+ *
+ * Central primitives for detecting authentication/session expiry and recovering
+ * from it without losing in-progress work:
+ *
+ * - a tiny event bus so any layer (fetch wrapper, wallet hook) can announce an
+ *   auth failure and the app can respond in one place;
+ * - form-draft persistence so input survives a re-authentication round trip;
+ * - origin-route capture so the user returns to where they were.
+ */
+
+export type AuthExpiredDetail = {
+  /** Route the user was on when the failure happened. */
+  route?: string;
+  /** Optional human-readable reason (never a secret/token). */
+  reason?: string;
+};
+
+type Listener = (detail: AuthExpiredDetail) => void;
+
+const listeners = new Set<Listener>();
+
+/** Subscribe to auth-expiry events. Returns an unsubscribe function. */
+export function onAuthExpired(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Announce that authentication has expired; notifies all subscribers. */
+export function notifyAuthExpired(detail: AuthExpiredDetail = {}): void {
+  for (const listener of [...listeners]) {
+    listener(detail);
+  }
+}
+
+/** Remove all subscribers (test helper). */
+export function resetAuthListeners(): void {
+  listeners.clear();
+}
+
+/** Whether an HTTP status represents an authentication/authorization failure. */
+export function isAuthFailure(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+const DRAFT_PREFIX = "quickex:form-draft:";
+const ORIGIN_KEY = "quickex:reauth-origin";
+
+function storage(): Storage | null {
+  try {
+    return typeof window !== "undefined" ? window.sessionStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist an in-progress form draft keyed by a stable form id. */
+export function saveFormDraft<T>(key: string, data: T): void {
+  try {
+    storage()?.setItem(DRAFT_PREFIX + key, JSON.stringify(data));
+  } catch {
+    /* storage may be unavailable or full — drafting is best-effort */
+  }
+}
+
+/** Load a previously-saved form draft, or null if none/invalid. */
+export function loadFormDraft<T>(key: string): T | null {
+  const raw = storage()?.getItem(DRAFT_PREFIX + key);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Remove a saved form draft. */
+export function clearFormDraft(key: string): void {
+  storage()?.removeItem(DRAFT_PREFIX + key);
+}
+
+/** Remember the originating route to return to after re-authentication. */
+export function saveOriginRoute(route: string): void {
+  storage()?.setItem(ORIGIN_KEY, route);
+}
+
+/** Read and clear the saved origin route (one-shot). */
+export function takeOriginRoute(): string | null {
+  const s = storage();
+  if (!s) return null;
+  const route = s.getItem(ORIGIN_KEY);
+  if (route) s.removeItem(ORIGIN_KEY);
+  return route;
+}

--- a/app/frontend/src/lib/env.ts
+++ b/app/frontend/src/lib/env.ts
@@ -11,6 +11,41 @@ const requiredEnvVars = [
 
 type RequiredEnvVar = typeof requiredEnvVars[number];
 
+/**
+ * Link to the runtime configuration documentation, surfaced on the
+ * misconfiguration page for remediation guidance.
+ */
+export const RUNTIME_CONFIG_DOCS_URL =
+  "https://github.com/Pulsefy/QiuckEx/blob/main/docs/RUNTIME-CONFIG-MATRIX.md";
+
+/**
+ * Human-readable specification for each known configuration key. Only key
+ * names and their *expected shape* are described here — never actual values —
+ * so the misconfiguration page can guide contributors without leaking secrets.
+ */
+export type EnvKeySpec = {
+  /** Short description of what the variable is for. */
+  description: string;
+  /** Expected shape or allowed values (no real secrets/tokens). */
+  expected: string;
+};
+
+export const ENV_SPEC: Record<string, EnvKeySpec> = {
+  NEXT_PUBLIC_QUICKEX_API_URL: {
+    description: "Base URL of the QuickEx API the frontend talks to.",
+    expected: "A valid absolute URL, e.g. https://api.quickex.example",
+  },
+  NEXT_PUBLIC_STELLAR_NETWORK: {
+    description: "Target Stellar network for links and payments.",
+    expected: 'One of "testnet" or "mainnet"',
+  },
+};
+
+/** Look up the expected-shape spec for a configuration key, if known. */
+export function getEnvKeySpec(key: string): EnvKeySpec | undefined {
+  return ENV_SPEC[key];
+}
+
 // Validate environment variables
 export function validateEnv() {
   const missing: RequiredEnvVar[] = [];

--- a/app/frontend/vitest.config.ts
+++ b/app/frontend/vitest.config.ts
@@ -2,6 +2,13 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
+  // Use the automatic JSX runtime so React component tests transform without an
+  // explicit `import React`. Individual component test files opt into the jsdom
+  // environment via a `// @vitest-environment jsdom` docblock.
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
Four independent frontend improvements (FE-68…FE-71).

### FE-68 (#843) — Developer Settings API Key Management UI
The management surface already existed; this adds the missing **test coverage**: key creation, **one-time secret reveal** with a copy affordance + "won't be shown again" warning, existing keys showing only the prefix, **confirmed revocation**, and backend errors surfaced. Also wires up the vitest automatic-JSX runtime and adds `jsdom` so component tests (including the repo's existing ones) can run.

### FE-69 (#844) — Respect Prefers-Reduced-Motion
A shared global CSS reset under `@media (prefers-reduced-motion: reduce)` disables/reduces animations and transitions app-wide (not per page), plus a `usePrefersReducedMotion` hook for JS-driven motion. Content stays fully usable.

### FE-70 (#845) — Session Expiry & Re-Authentication UX
Central detection via an `auth-session` event bus + `fetchWithAuth` (401/403 → a single re-auth prompt from `SessionExpiryProvider`). `useFormDraft` preserves in-progress input across re-auth so a payment in progress isn't lost, and the user is returned to the **originating route** after reconnecting.

### FE-71 (#846) — Misconfiguration Page Diagnostics
The page now names each missing/invalid config key with its **expected shape** (from a new `ENV_SPEC` — only key names and validity, never values) and links to the runtime-config documentation.

### Validation
- **20 new tests pass** (vitest across all four areas).
- `tsc --noEmit` and ESLint clean on changed files.

Closes #843
Closes #844
Closes #845
Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)