### PR TITLE
feat(fiat-ramps): implement real SEP-24 anchor handshake for fiat ramps

### DIFF
--- a/app/backend/src/fiat-ramps/anchor-client.service.ts
+++ b/app/backend/src/fiat-ramps/anchor-client.service.ts
@@ -1,17 +1,33 @@
 /**
  * Anchor Client Service
  *
- * Thin HTTP client for talking to SEP-24 anchor endpoints.
- * Handles the GET /sep24/transaction?id={id}&jwt={token} call pattern used
- * for polling transaction status.
+ * Thin HTTP client for SEP-24 anchor interactions.  Provides:
  *
- * Retry / backoff is intentionally left to the caller (the polling service
- * tracks per-transaction failure counts so it can apply graduated backoff
- * without blocking the whole poll cycle).
+ *   1. **Capability discovery** — fetches and parses the anchor's `stellar.toml`
+ *      to discover the SEP-10 auth server and SEP-24 transfer server URLs.
+ *   2. **SEP-10 authentication** — performs the full challenge-response flow to
+ *      obtain a signed JWT.
+ *   3. **SEP-24 initiation** — POSTs to the anchor's interactive endpoint and
+ *      returns the real interactive URL negotiated by the anchor.
+ *   4. **Transaction polling** — GETs transaction status for the polling service.
+ *
+ * Retry / backoff for polling is intentionally left to the caller (the polling
+ * service tracks per-transaction failure counts so it can apply graduated
+ * backoff without blocking the whole poll cycle).
  */
 
 import { Injectable, Logger } from '@nestjs/common';
-import { AnchorTransactionResponse } from './types/sep24.types';
+import { Keypair, TransactionBuilder } from '@stellar/stellar-sdk';
+import {
+  AnchorCapabilities,
+  AnchorTransactionResponse,
+  AnchorDiscoveryError,
+  Sep10AuthError,
+  Sep24InitiationError,
+  Sep24InteractiveResponse,
+} from './types/sep24.types';
+
+// ─── Poll types (unchanged from original) ────────────────────────────────────
 
 /** Options for polling a single anchor transaction. */
 export interface AnchorPollOptions {
@@ -37,9 +53,379 @@ export interface AnchorPollResult {
   error: string | null;
 }
 
+// ─── SEP-24 initiation options ───────────────────────────────────────────────
+
+/** Parameters for initiating a SEP-24 deposit or withdrawal. */
+export interface Sep24InitiateOptions {
+  /** Anchor domain (e.g. "moneygram.stellar.org"). */
+  anchorDomain: string;
+  /** SEP-10 JWT obtained via {@link performSep10Auth}. */
+  jwt: string;
+  /** Transfer server URL (from {@link discoverAnchorCapabilities}). */
+  transferServer: string;
+  /** "deposit" or "withdrawal". */
+  type: 'deposit' | 'withdrawal';
+  /** Asset code (e.g. "USDC"). */
+  assetCode: string;
+  /** Stellar public key of the user initiating the flow. */
+  account: string;
+  /** Amount as a decimal string (e.g. "100.00"). */
+  amount?: string;
+  /** Optional: non-native asset issuer public key. */
+  assetIssuer?: string;
+  /** Optional: URL the anchor can redirect the user back to on completion. */
+  returnUrl?: string;
+  /** Optional: arbitrary data passed through to the anchor. */
+  memo?: string;
+  /** Optional: memo type ("text" | "id" | "hash"). */
+  memoType?: string;
+}
+
 @Injectable()
 export class AnchorClientService {
   private readonly logger = new Logger(AnchorClientService.name);
+
+  // ─── Capability Discovery ────────────────────────────────────────────────
+
+  /**
+   * Fetch the anchor's `stellar.toml` and extract the SEP-10 auth server,
+   * SEP-24 transfer server, and the list of supported asset codes.
+   *
+   * @throws {AnchorDiscoveryError} when the TOML is unreachable or missing
+   *         required fields.
+   */
+  async discoverAnchorCapabilities(anchorDomain: string): Promise<AnchorCapabilities> {
+    const cleanDomain = anchorDomain.replace(/^https?:\/\//, '').replace(/\/$/, '');
+    const tomlUrl = `https://${cleanDomain}/.well-known/stellar.toml`;
+
+    let text: string;
+
+    try {
+      const response = await fetch(tomlUrl, {
+        method: 'GET',
+        headers: { Accept: 'text/plain, application/toml' },
+        signal: AbortSignal.timeout(8_000),
+      });
+
+      if (!response.ok) {
+        throw new AnchorDiscoveryError(
+          anchorDomain,
+          `stellar.toml HTTP ${response.status} from ${tomlUrl}`,
+        );
+      }
+
+      text = await response.text();
+    } catch (err) {
+      if (err instanceof AnchorDiscoveryError) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new AnchorDiscoveryError(anchorDomain, `network error fetching ${tomlUrl}: ${message}`);
+    }
+
+    // ── Parse required fields ────────────────────────────────────────────────
+
+    const transferServerMatch = text.match(
+      /TRANSFER_SERVER_SEP0024\s*=\s*["']([^"']+)["']/,
+    );
+    if (!transferServerMatch) {
+      throw new AnchorDiscoveryError(
+        anchorDomain,
+        'stellar.toml missing TRANSFER_SERVER_SEP0024',
+      );
+    }
+
+    const authServerMatch = text.match(
+      /TRANSFER_SERVER_SEP0010\s*=\s*["']([^"']+)["']/,
+    );
+    if (!authServerMatch) {
+      throw new AnchorDiscoveryError(
+        anchorDomain,
+        'stellar.toml missing TRANSFER_SERVER_SEP0010',
+      );
+    }
+
+    // ── Parse supported assets (optional but useful) ─────────────────────────
+
+    const supportedAssets: string[] = [];
+
+    // Match [[CURRENCIES]] / code = "..." blocks
+    const codeMatches = text.matchAll(/code\s*=\s*["']([A-Z0-9]+)["']/g);
+    for (const m of codeMatches) {
+      const code = m[1];
+      if (!supportedAssets.includes(code)) {
+        supportedAssets.push(code);
+      }
+    }
+
+    this.logger.debug(
+      `Discovered anchor capabilities for ${anchorDomain}: ` +
+      `transferServer=${transferServerMatch[1]}, ` +
+      `authServer=${authServerMatch[1]}, ` +
+      `assets=[${supportedAssets.join(', ')}]`,
+    );
+
+    return {
+      transferServer: transferServerMatch[1],
+      authServer: authServerMatch[1],
+      supportedAssets,
+    };
+  }
+
+  // ─── SEP-10 Authentication ───────────────────────────────────────────────
+
+  /**
+   * Perform a full SEP-10 challenge-response authentication flow against
+   * the anchor's auth server.
+   *
+   * Steps:
+   *   1. POST `{"account": "<publicKey>"}` to `{authServer}/auth`
+   *   2. Receive a challenge transaction envelope XDR + network passphrase
+   *   3. Sign the transaction with the provided keypair
+   *   4. POST `{"transaction": "<signedEnvelopeXdr>", "account": "<publicKey>"}` back
+   *   5. Receive the JWT token
+   *
+   * @param anchorDomain   - Human-readable anchor domain for logging.
+   * @param authServer     - Full auth server URL (from {@link discoverAnchorCapabilities}).
+   * @param keypair        - Stellar Keypair to sign the challenge.
+   * @param networkPassphrase - Stellar network passphrase (e.g. "Test SDF Network ; September 2015").
+   * @returns The signed JWT string.
+   * @throws {Sep10AuthError} on any failure during the flow.
+   */
+  async performSep10Auth(
+    anchorDomain: string,
+    authServer: string,
+    keypair: Keypair,
+    networkPassphrase: string,
+  ): Promise<string> {
+    const cleanAuthServer = authServer.replace(/\/$/, '');
+
+    // ── Step 1: Request challenge ─────────────────────────────────────────────
+
+    // The TRANSFER_SERVER_SEP0010 value from stellar.toml is the auth endpoint.
+    // Use it directly — do not append /auth (real anchors include it in the URL).
+    const challengeUrl = `${cleanAuthServer}`;
+    const publicKey = keypair.publicKey();
+
+    let challengeBody: { transaction: string; network_passphrase: string };
+
+    try {
+      const challengeResponse = await fetch(challengeUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ account: publicKey }),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!challengeResponse.ok) {
+        const errText = await challengeResponse.text().catch(() => '');
+        throw new Sep10AuthError(
+          anchorDomain,
+          `challenge request failed: HTTP ${challengeResponse.status} — ${errText}`,
+          challengeResponse.status,
+        );
+      }
+
+      challengeBody = await challengeResponse.json() as {
+        transaction: string;
+        network_passphrase: string;
+      };
+
+      if (!challengeBody?.transaction) {
+        throw new Sep10AuthError(anchorDomain, 'challenge response missing transaction field');
+      }
+    } catch (err) {
+      if (err instanceof Sep10AuthError) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Sep10AuthError(anchorDomain, `network error during challenge: ${message}`);
+    }
+
+    // ── Step 2: Sign the challenge transaction ────────────────────────────────
+
+    let signedEnvelopeXdr: string;
+
+    try {
+      const txOrFeeBump = TransactionBuilder.fromXDR(
+        challengeBody.transaction,
+        challengeBody.network_passphrase || networkPassphrase,
+      );
+
+      // fromXDR returns Transaction | FeeBumpTransaction;
+      // both extend TransactionI which has .sign() and .toXDR().
+      txOrFeeBump.sign(keypair);
+      signedEnvelopeXdr = txOrFeeBump.toXDR();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Sep10AuthError(anchorDomain, `failed to sign challenge transaction: ${message}`);
+    }
+
+    // ── Step 3: Submit signed challenge ───────────────────────────────────────
+
+    let authResult: { token: string };
+
+    try {
+      const submitResponse = await fetch(challengeUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          transaction: signedEnvelopeXdr,
+          account: publicKey,
+        }),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!submitResponse.ok) {
+        const errText = await submitResponse.text().catch(() => '');
+        throw new Sep10AuthError(
+          anchorDomain,
+          `auth submission failed: HTTP ${submitResponse.status} — ${errText}`,
+          submitResponse.status,
+        );
+      }
+
+      authResult = await submitResponse.json() as { token: string };
+
+      if (!authResult?.token) {
+        throw new Sep10AuthError(anchorDomain, 'auth response missing token field');
+      }
+    } catch (err) {
+      if (err instanceof Sep10AuthError) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Sep10AuthError(anchorDomain, `network error during auth submission: ${message}`);
+    }
+
+    this.logger.debug(`SEP-10 auth succeeded for ${anchorDomain}`);
+
+    return authResult.token;
+  }
+
+  // ─── SEP-24 Transaction Initiation ──────────────────────────────────────
+
+  /**
+   * Initiate a SEP-24 hosted-interactive deposit or withdrawal transaction.
+   *
+   * POSTs to `{transferServer}/transactions/{type}/interactive` with the
+   * SEP-10 JWT and returns the anchor's interactive URL.
+   *
+   * @throws {Sep24InitiationError} when the anchor rejects the request or
+   *         returns an unexpected response.
+   */
+  async initiateSep24Transaction(opts: Sep24InitiateOptions): Promise<Sep24InteractiveResponse> {
+    const {
+      anchorDomain,
+      jwt,
+      transferServer,
+      type,
+      assetCode,
+      account,
+      amount,
+      assetIssuer,
+      returnUrl,
+      memo,
+      memoType,
+    } = opts;
+
+    const cleanTransferServer = transferServer.replace(/\/$/, '');
+    const endpointUrl = `${cleanTransferServer}/transactions/${type}/interactive`;
+
+    // ── Build request body ──────────────────────────────────────────────────
+
+    const body: Record<string, string> = {
+      asset_code: assetCode,
+      account,
+    };
+
+    if (amount) body.amount = amount;
+    if (assetIssuer) body.asset_issuer = assetIssuer;
+    if (returnUrl) body.return_url = returnUrl;
+    if (memo) body.memo = memo;
+    if (memoType) body.memo_type = memoType;
+
+    // ── POST to anchor ──────────────────────────────────────────────────────
+
+    let response: Response;
+
+    try {
+      response = await fetch(endpointUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(15_000),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Sep24InitiationError(
+        anchorDomain,
+        `network error calling ${endpointUrl}: ${message}`,
+      );
+    }
+
+    // ── Handle error responses ──────────────────────────────────────────────
+
+    if (!response.ok) {
+      let detail = '';
+
+      try {
+        const errBody = await response.json() as Record<string, unknown>;
+        detail = (errBody['error'] ?? errBody['message'] ?? errBody['detail']) as string ?? '';
+      } catch {
+        detail = await response.text().catch(() => '');
+      }
+
+      const reason = `HTTP ${response.status}${detail ? `: ${detail}` : ''}`;
+
+      if (response.status === 400) {
+        throw new Sep24InitiationError(anchorDomain, `unsupported asset or bad request — ${reason}`, 400);
+      }
+
+      throw new Sep24InitiationError(anchorDomain, reason, response.status);
+    }
+
+    // ── Parse interactive response ──────────────────────────────────────────
+
+    let data: Record<string, unknown>;
+
+    try {
+      data = await response.json() as Record<string, unknown>;
+    } catch {
+      throw new Sep24InitiationError(anchorDomain, 'anchor returned non-JSON response body');
+    }
+
+    if (data['type'] !== 'interactive_customer_info_needed') {
+      throw new Sep24InitiationError(
+        anchorDomain,
+        `unexpected response type: ${String(data['type'])} (expected interactive_customer_info_needed)`,
+      );
+    }
+
+    if (typeof data['url'] !== 'string' || !data['url']) {
+      throw new Sep24InitiationError(anchorDomain, 'anchor response missing interactive URL');
+    }
+
+    const interactiveResponse: Sep24InteractiveResponse = {
+      type: 'interactive_customer_info_needed',
+      url: data['url'] as string,
+    };
+
+    if (typeof data['id'] === 'string') interactiveResponse.id = data['id'];
+    if (typeof data['message'] === 'string') interactiveResponse.message = data['message'];
+
+    this.logger.debug(
+      `SEP-24 ${type} initiated for ${anchorDomain}: url=${interactiveResponse.url}`,
+    );
+
+    return interactiveResponse;
+  }
+
+  // ─── Transaction Polling (unchanged) ─────────────────────────────────────
 
   /**
    * Poll the anchor's SEP-24 /transaction endpoint for status of a single
@@ -117,29 +503,21 @@ export class AnchorClientService {
     }
   }
 
+  // ─── Legacy: resolveSep24TransferServer ──────────────────────────────────
+
   /**
    * Attempt to resolve the SEP-24 transfer server URL from the anchor's
    * stellar.toml file.
    *
    * Returns null on any failure so callers can fall back to a conventional URL.
+   *
+   * @deprecated Use {@link discoverAnchorCapabilities} instead for the full
+   *             discovery flow.
    */
   async resolveSep24TransferServer(anchorDomain: string): Promise<string | null> {
-    const cleanDomain = anchorDomain.replace(/^https?:\/\//, '');
-    const tomlUrl = `https://${cleanDomain}/.well-known/stellar.toml`;
-
     try {
-      const response = await fetch(tomlUrl, {
-        method: 'GET',
-        signal: AbortSignal.timeout(5_000),
-      });
-
-      if (!response.ok) return null;
-
-      const text = await response.text();
-
-      // Simple TOML field extraction for TRANSFER_SERVER_SEP0024
-      const match = text.match(/TRANSFER_SERVER_SEP0024\s*=\s*["']([^"']+)["']/);
-      return match ? match[1] : null;
+      const caps = await this.discoverAnchorCapabilities(anchorDomain);
+      return caps.transferServer;
     } catch {
       return null;
     }

--- a/app/backend/src/fiat-ramps/anchor-client.service.unit.spec.ts
+++ b/app/backend/src/fiat-ramps/anchor-client.service.unit.spec.ts
@@ -1,0 +1,705 @@
+/**
+ * AnchorClientService – Unit Tests
+ *
+ * Covers the three pillars of the SEP-24 anchor handshake:
+ *
+ *   1. **Capability Discovery** — stellar.toml parsing, missing fields, network errors
+ *   2. **SEP-10 Authentication** — challenge-response flow, signing, error paths
+ *   3. **SEP-24 Initiation** — interactive endpoint POST, error handling, response parsing
+ *
+ * All external HTTP calls are stubbed via global `fetch` mocks.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { Keypair } from '@stellar/stellar-sdk';
+import { AnchorClientService } from './anchor-client.service';
+import {
+  AnchorDiscoveryError,
+  Sep10AuthError,
+  Sep24InitiationError,
+} from './types/sep24.types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Generate a deterministic test keypair. */
+function testKeypair(): Keypair {
+  return Keypair.fromSecret(
+    'SCX6A3F3XCFW7IT3MY6DSZWULY4U6O5PZHILY3SAPU4QZIHUEO7JZLLS',
+  );
+}
+
+// ─── Fetch mock helpers ───────────────────────────────────────────────────────
+
+const originalFetch = global.fetch;
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  global.fetch = jest.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    return handler(urlStr, init);
+  }) as unknown as typeof fetch;
+}
+
+function restoreFetch() {
+  global.fetch = originalFetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AnchorClientService', () => {
+  let service: AnchorClientService;
+
+  const ANCHOR_DOMAIN = 'test.anchor.org';
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AnchorClientService],
+    }).compile();
+
+    service = module.get<AnchorClientService>(AnchorClientService);
+  });
+
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  // ─── discoverAnchorCapabilities ──────────────────────────────────────────
+
+  describe('discoverAnchorCapabilities', () => {
+    const TOML_CONTENT = `
+NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+TRANSFER_SERVER_SEP0024 = "https://test.anchor.org/sep24"
+TRANSFER_SERVER_SEP0010 = "https://test.anchor.org/auth"
+
+[[CURRENCIES]]
+code = "USDC"
+issuer = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2K34P4D5NXJ6Z4GJ5B7G"
+
+[[CURRENCIES]]
+code = "EURC"
+issuer = "GBNZILSTVQZ4R7IKQDGHYGY2Q45GJT5TTW3EHBQK7UL3UBFTPDP52GZP"
+`;
+
+    it('parses stellar.toml and returns anchor capabilities', async () => {
+      mockFetch((url) => {
+        expect(url).toBe(`https://${ANCHOR_DOMAIN}/.well-known/stellar.toml`);
+        return textResponse(TOML_CONTENT);
+      });
+
+      const caps = await service.discoverAnchorCapabilities(ANCHOR_DOMAIN);
+
+      expect(caps).toEqual({
+        transferServer: 'https://test.anchor.org/sep24',
+        authServer: 'https://test.anchor.org/auth',
+        supportedAssets: ['USDC', 'EURC'],
+      });
+    });
+
+    it('strips leading scheme from domain', async () => {
+      mockFetch(() => textResponse(TOML_CONTENT));
+
+      const caps = await service.discoverAnchorCapabilities(`https://${ANCHOR_DOMAIN}`);
+
+      expect(caps.transferServer).toBe('https://test.anchor.org/sep24');
+    });
+
+    it('throws AnchorDiscoveryError when stellar.toml returns HTTP error', async () => {
+      mockFetch(() => textResponse('Not Found', 404));
+
+      await expect(service.discoverAnchorCapabilities(ANCHOR_DOMAIN))
+        .rejects.toThrow(AnchorDiscoveryError);
+    });
+
+    it('throws AnchorDiscoveryError on network timeout', async () => {
+      mockFetch(() => { throw Object.assign(new Error('Aborted'), { name: 'AbortError' }); });
+
+      await expect(service.discoverAnchorCapabilities(ANCHOR_DOMAIN))
+        .rejects.toThrow(AnchorDiscoveryError);
+    });
+
+    it('throws AnchorDiscoveryError when TRANSFER_SERVER_SEP0024 is missing', async () => {
+      const incompleteToml = `
+TRANSFER_SERVER_SEP0010 = "https://test.anchor.org/auth"
+`;
+      mockFetch(() => textResponse(incompleteToml));
+
+      await expect(service.discoverAnchorCapabilities(ANCHOR_DOMAIN))
+        .rejects.toThrow(/missing TRANSFER_SERVER_SEP0024/);
+    });
+
+    it('throws AnchorDiscoveryError when TRANSFER_SERVER_SEP0010 is missing', async () => {
+      const incompleteToml = `
+TRANSFER_SERVER_SEP0024 = "https://test.anchor.org/sep24"
+`;
+      mockFetch(() => textResponse(incompleteToml));
+
+      await expect(service.discoverAnchorCapabilities(ANCHOR_DOMAIN))
+        .rejects.toThrow(/missing TRANSFER_SERVER_SEP0010/);
+    });
+
+    it('returns empty supportedAssets when no [[CURRENCIES]] blocks exist', async () => {
+      const tomlNoCurrencies = `
+TRANSFER_SERVER_SEP0024 = "https://test.anchor.org/sep24"
+TRANSFER_SERVER_SEP0010 = "https://test.anchor.org/auth"
+`;
+      mockFetch(() => textResponse(tomlNoCurrencies));
+
+      const caps = await service.discoverAnchorCapabilities(ANCHOR_DOMAIN);
+
+      expect(caps.supportedAssets).toEqual([]);
+    });
+
+    it('deduplicates asset codes from multiple [[CURRENCIES]] blocks', async () => {
+      const tomlDupes = `
+TRANSFER_SERVER_SEP0024 = "https://test.anchor.org/sep24"
+TRANSFER_SERVER_SEP0010 = "https://test.anchor.org/auth"
+
+[[CURRENCIES]]
+code = "USDC"
+
+[[CURRENCIES]]
+code = "USDC"
+`;
+      mockFetch(() => textResponse(tomlDupes));
+
+      const caps = await service.discoverAnchorCapabilities(ANCHOR_DOMAIN);
+
+      expect(caps.supportedAssets).toEqual(['USDC']);
+    });
+  });
+
+  // ─── performSep10Auth ────────────────────────────────────────────────────
+
+  describe('performSep10Auth', () => {
+    const AUTH_SERVER = 'https://test.anchor.org/auth';
+    const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+
+    it('performs full challenge-response flow and returns JWT', async () => {
+      const keypair = testKeypair();
+      const publicKey = keypair.publicKey();
+
+      const fakeJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+
+      // Build a real ManageData challenge transaction (the standard SEP-10 challenge).
+      // This creates a valid XDR that TransactionBuilder.fromXDR can parse.
+      const { TransactionBuilder, Operation } = await import('@stellar/stellar-sdk');
+      const { Account } = await import('@stellar/stellar-base');
+
+      const challengeAccount = new Account(publicKey, '0');
+      const challengeTx = new TransactionBuilder(
+        challengeAccount,
+        { fee: '100', networkPassphrase: NETWORK_PASSPHRASE },
+      )
+        .addOperation(
+          Operation.manageData({
+            name: `auth ${publicKey}`,
+            value: Buffer.alloc(32, 0x42),
+          }),
+        )
+        .setTimeout(300)
+        .build();
+
+      const challengeXdr = challengeTx.toXDR();
+
+      let callCount = 0;
+      mockFetch(async (url, init) => {
+        callCount++;
+        expect(url).toBe(AUTH_SERVER);
+
+        if (callCount === 1) {
+          // Challenge request
+          const body = JSON.parse(init!.body as string);
+          expect(body.account).toBe(publicKey);
+          return jsonResponse({
+            transaction: challengeXdr,
+            network_passphrase: NETWORK_PASSPHRASE,
+          });
+        }
+
+        // Submit signed challenge
+        const body = JSON.parse(init!.body as string);
+        expect(body.account).toBe(publicKey);
+        expect(typeof body.transaction).toBe('string');
+        expect(body.transaction).not.toBe(challengeXdr); // should be different (signed)
+
+        return jsonResponse({ token: fakeJwt });
+      });
+
+      const jwt = await service.performSep10Auth(
+        ANCHOR_DOMAIN,
+        AUTH_SERVER,
+        keypair,
+        NETWORK_PASSPHRASE,
+      );
+
+      expect(jwt).toBe(fakeJwt);
+    });
+
+    it('throws Sep10AuthError when challenge request returns HTTP error', async () => {
+      const keypair = testKeypair();
+
+      mockFetch(() => jsonResponse({ error: 'invalid account' }, 400));
+
+      await expect(
+        service.performSep10Auth(ANCHOR_DOMAIN, AUTH_SERVER, keypair, NETWORK_PASSPHRASE),
+      ).rejects.toThrow(Sep10AuthError);
+    });
+
+    it('throws Sep10AuthError when challenge response is missing transaction field', async () => {
+      const keypair = testKeypair();
+
+      mockFetch(() => jsonResponse({}));
+
+      await expect(
+        service.performSep10Auth(ANCHOR_DOMAIN, AUTH_SERVER, keypair, NETWORK_PASSPHRASE),
+      ).rejects.toThrow(Sep10AuthError);
+    });
+
+    it('throws Sep10AuthError on network timeout during challenge', async () => {
+      const keypair = testKeypair();
+
+      mockFetch(() => { throw Object.assign(new Error('Aborted'), { name: 'AbortError' }); });
+
+      await expect(
+        service.performSep10Auth(ANCHOR_DOMAIN, AUTH_SERVER, keypair, NETWORK_PASSPHRASE),
+      ).rejects.toThrow(Sep10AuthError);
+    });
+
+    it('throws Sep10AuthError when auth submission returns HTTP error', async () => {
+      const keypair = testKeypair();
+      const { TransactionBuilder, Operation } = await import('@stellar/stellar-sdk');
+      const { Account } = await import('@stellar/stellar-base');
+
+      const challengeAccount = new Account(keypair.publicKey(), '0');
+      const challengeTx = new TransactionBuilder(
+        challengeAccount,
+        { fee: '100', networkPassphrase: NETWORK_PASSPHRASE },
+      )
+        .addOperation(
+          Operation.manageData({
+            name: `auth ${keypair.publicKey()}`,
+            value: Buffer.alloc(32, 0x42),
+          }),
+        )
+        .setTimeout(300)
+        .build();
+
+      const challengeXdr = challengeTx.toXDR();
+
+      let callCount = 0;
+      mockFetch(async () => {
+        callCount++;
+
+        if (callCount === 1) {
+          // Challenge succeeds
+          return jsonResponse({
+            transaction: challengeXdr,
+            network_passphrase: NETWORK_PASSPHRASE,
+          });
+        }
+
+        // Auth submission fails
+        return jsonResponse({ error: 'invalid signature' }, 401);
+      });
+
+      await expect(
+        service.performSep10Auth(ANCHOR_DOMAIN, AUTH_SERVER, keypair, NETWORK_PASSPHRASE),
+      ).rejects.toThrow(Sep10AuthError);
+    });
+
+    it('throws Sep10AuthError when auth response is missing token field', async () => {
+      const keypair = testKeypair();
+      const { TransactionBuilder, Operation } = await import('@stellar/stellar-sdk');
+      const { Account } = await import('@stellar/stellar-base');
+
+      const challengeAccount = new Account(keypair.publicKey(), '0');
+      const challengeTx = new TransactionBuilder(
+        challengeAccount,
+        { fee: '100', networkPassphrase: NETWORK_PASSPHRASE },
+      )
+        .addOperation(
+          Operation.manageData({
+            name: `auth ${keypair.publicKey()}`,
+            value: Buffer.alloc(32, 0x42),
+          }),
+        )
+        .setTimeout(300)
+        .build();
+
+      const challengeXdr = challengeTx.toXDR();
+
+      let callCount = 0;
+      mockFetch(async () => {
+        callCount++;
+
+        if (callCount === 1) {
+          return jsonResponse({
+            transaction: challengeXdr,
+            network_passphrase: NETWORK_PASSPHRASE,
+          });
+        }
+
+        return jsonResponse({});
+      });
+
+      await expect(
+        service.performSep10Auth(ANCHOR_DOMAIN, AUTH_SERVER, keypair, NETWORK_PASSPHRASE),
+      ).rejects.toThrow(Sep10AuthError);
+    });
+  });
+
+  // ─── initiateSep24Transaction ────────────────────────────────────────────
+
+  describe('initiateSep24Transaction', () => {
+    const TRANSFER_SERVER = 'https://test.anchor.org/sep24';
+    const JWT = 'test-jwt-token';
+
+    it('initiates deposit and returns interactive URL from anchor response', async () => {
+      const interactiveUrl = 'https://test.anchor.org/sep24/interactive/form/abc123';
+
+      mockFetch(async (url, init) => {
+        expect(url).toBe(`${TRANSFER_SERVER}/transactions/deposit/interactive`);
+
+        const body = JSON.parse(init!.body as string);
+        expect(body.asset_code).toBe('USDC');
+        expect(body.account).toBe('GABC123');
+        expect(body.amount).toBe('100.00');
+
+        // Verify Authorization header
+        expect(init!.headers).toMatchObject({
+          Authorization: `Bearer ${JWT}`,
+        });
+
+        return jsonResponse({
+          type: 'interactive_customer_info_needed',
+          url: interactiveUrl,
+          id: 'anchor-tx-001',
+          message: 'Please complete the KYC form',
+        });
+      });
+
+      const result = await service.initiateSep24Transaction({
+        anchorDomain: ANCHOR_DOMAIN,
+        jwt: JWT,
+        transferServer: TRANSFER_SERVER,
+        type: 'deposit',
+        assetCode: 'USDC',
+        account: 'GABC123',
+        amount: '100.00',
+      });
+
+      expect(result).toEqual({
+        type: 'interactive_customer_info_needed',
+        url: interactiveUrl,
+        id: 'anchor-tx-001',
+        message: 'Please complete the KYC form',
+      });
+    });
+
+    it('initiates withdrawal correctly', async () => {
+      const interactiveUrl = 'https://test.anchor.org/sep24/interactive/form/def456';
+
+      mockFetch(async (url, init) => {
+        expect(url).toBe(`${TRANSFER_SERVER}/transactions/withdrawal/interactive`);
+
+        const body = JSON.parse(init!.body as string);
+        expect(body.asset_code).toBe('EURC');
+        expect(body.account).toBe('GDEF456');
+        expect(body.amount).toBe('50.00');
+
+        return jsonResponse({
+          type: 'interactive_customer_info_needed',
+          url: interactiveUrl,
+        });
+      });
+
+      const result = await service.initiateSep24Transaction({
+        anchorDomain: ANCHOR_DOMAIN,
+        jwt: JWT,
+        transferServer: TRANSFER_SERVER,
+        type: 'withdrawal',
+        assetCode: 'EURC',
+        account: 'GDEF456',
+        amount: '50.00',
+      });
+
+      expect(result.url).toBe(interactiveUrl);
+      expect(result.type).toBe('interactive_customer_info_needed');
+    });
+
+    it('includes optional fields (assetIssuer, returnUrl, memo, memoType) in request body', async () => {
+      mockFetch(async (url, init) => {
+        const body = JSON.parse(init!.body as string);
+        expect(body.asset_issuer).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2K34P4D5NXJ6Z4GJ5B7G');
+        expect(body.return_url).toBe('https://quickex.app/return');
+        expect(body.memo).toBe('test-memo');
+        expect(body.memo_type).toBe('text');
+
+        return jsonResponse({
+          type: 'interactive_customer_info_needed',
+          url: 'https://test.anchor.org/sep24/interactive/form/ghi789',
+        });
+      });
+
+      await service.initiateSep24Transaction({
+        anchorDomain: ANCHOR_DOMAIN,
+        jwt: JWT,
+        transferServer: TRANSFER_SERVER,
+        type: 'deposit',
+        assetCode: 'USDC',
+        account: 'GABC123',
+        assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2K34P4D5NXJ6Z4GJ5B7G',
+        returnUrl: 'https://quickex.app/return',
+        memo: 'test-memo',
+        memoType: 'text',
+      });
+    });
+
+    it('omits undefined optional fields from request body', async () => {
+      mockFetch(async (url, init) => {
+        const body = JSON.parse(init!.body as string);
+        expect(body).not.toHaveProperty('amount');
+        expect(body).not.toHaveProperty('asset_issuer');
+        expect(body).not.toHaveProperty('return_url');
+        expect(body).not.toHaveProperty('memo');
+        expect(body).not.toHaveProperty('memo_type');
+
+        return jsonResponse({
+          type: 'interactive_customer_info_needed',
+          url: 'https://test.anchor.org/sep24/interactive/form/minimal',
+        });
+      });
+
+      await service.initiateSep24Transaction({
+        anchorDomain: ANCHOR_DOMAIN,
+        jwt: JWT,
+        transferServer: TRANSFER_SERVER,
+        type: 'deposit',
+        assetCode: 'USDC',
+        account: 'GABC123',
+      });
+    });
+
+    it('throws Sep24InitiationError on network error', async () => {
+      mockFetch(() => {
+        throw Object.assign(new Error('Connection refused'), { name: 'TypeError' });
+      });
+
+      await expect(
+        service.initiateSep24Transaction({
+          anchorDomain: ANCHOR_DOMAIN,
+          jwt: JWT,
+          transferServer: TRANSFER_SERVER,
+          type: 'deposit',
+          assetCode: 'USDC',
+          account: 'GABC123',
+        }),
+      ).rejects.toThrow(Sep24InitiationError);
+    });
+
+    it('throws Sep24InitiationError with 400 status for unsupported asset', async () => {
+      mockFetch(() => jsonResponse({ error: 'unsupported asset XYZ' }, 400));
+
+      await expect(
+        service.initiateSep24Transaction({
+          anchorDomain: ANCHOR_DOMAIN,
+          jwt: JWT,
+          transferServer: TRANSFER_SERVER,
+          type: 'deposit',
+          assetCode: 'XYZ',
+          account: 'GABC123',
+        }),
+      ).rejects.toThrow(/unsupported asset or bad request/);
+    });
+
+    it('throws Sep24InitiationError on non-200 HTTP response', async () => {
+      mockFetch(() => jsonResponse({ error: 'anchor unavailable' }, 503));
+
+      await expect(
+        service.initiateSep24Transaction({
+          anchorDomain: ANCHOR_DOMAIN,
+          jwt: JWT,
+          transferServer: TRANSFER_SERVER,
+          type: 'deposit',
+          assetCode: 'USDC',
+          account: 'GABC123',
+        }),
+      ).rejects.toThrow(Sep24InitiationError);
+    });
+
+    it('throws Sep24InitiationError when response type is not interactive_customer_info_needed', async () => {
+      mockFetch(() =>
+        jsonResponse({
+          type: 'non_interactive',
+          url: 'https://test.anchor.org/sep24/interactive/form/xyz',
+        }),
+      );
+
+      await expect(
+        service.initiateSep24Transaction({
+          anchorDomain: ANCHOR_DOMAIN,
+          jwt: JWT,
+          transferServer: TRANSFER_SERVER,
+          type: 'deposit',
+          assetCode: 'USDC',
+          account: 'GABC123',
+        }),
+      ).rejects.toThrow(/unexpected response type/);
+    });
+
+    it('throws Sep24InitiationError when response is missing URL', async () => {
+      mockFetch(() =>
+        jsonResponse({
+          type: 'interactive_customer_info_needed',
+          // url is missing
+        }),
+      );
+
+      await expect(
+        service.initiateSep24Transaction({
+          anchorDomain: ANCHOR_DOMAIN,
+          jwt: JWT,
+          transferServer: TRANSFER_SERVER,
+          type: 'deposit',
+          assetCode: 'USDC',
+          account: 'GABC123',
+        }),
+      ).rejects.toThrow(/missing interactive URL/);
+    });
+
+    it('throws Sep24InitiationError when anchor returns non-JSON response', async () => {
+      mockFetch(() => new Response('Internal Server Error', { status: 500 }));
+
+      await expect(
+        service.initiateSep24Transaction({
+          anchorDomain: ANCHOR_DOMAIN,
+          jwt: JWT,
+          transferServer: TRANSFER_SERVER,
+          type: 'deposit',
+          assetCode: 'USDC',
+          account: 'GABC123',
+        }),
+      ).rejects.toThrow(Sep24InitiationError);
+    });
+
+    it('strips trailing slash from transferServer URL', async () => {
+      mockFetch(async (url) => {
+        // Should not have double slash
+        expect(url).toBe(`${TRANSFER_SERVER}/transactions/deposit/interactive`);
+
+        return jsonResponse({
+          type: 'interactive_customer_info_needed',
+          url: 'https://test.anchor.org/sep24/interactive/form/noslash',
+        });
+      });
+
+      await service.initiateSep24Transaction({
+        anchorDomain: ANCHOR_DOMAIN,
+        jwt: JWT,
+        transferServer: `${TRANSFER_SERVER}/`,
+        type: 'deposit',
+        assetCode: 'USDC',
+        account: 'GABC123',
+      });
+    });
+  });
+
+  // ─── resolveSep24TransferServer (legacy) ─────────────────────────────────
+
+  describe('resolveSep24TransferServer (legacy)', () => {
+    it('returns transfer server URL on success', async () => {
+      mockFetch(() => textResponse(`
+TRANSFER_SERVER_SEP0024 = "https://test.anchor.org/sep24"
+TRANSFER_SERVER_SEP0010 = "https://test.anchor.org/auth"
+`));
+
+      const result = await service.resolveSep24TransferServer(ANCHOR_DOMAIN);
+
+      expect(result).toBe('https://test.anchor.org/sep24');
+    });
+
+    it('returns null on failure', async () => {
+      mockFetch(() => textResponse('Not Found', 404));
+
+      const result = await service.resolveSep24TransferServer(ANCHOR_DOMAIN);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── pollTransaction ─────────────────────────────────────────────────────
+
+  describe('pollTransaction', () => {
+    it('returns success when anchor responds with valid transaction data', async () => {
+      mockFetch(() =>
+        jsonResponse({
+          transaction: {
+            id: 'anchor-tx-1',
+            kind: 'deposit',
+            status: 'pending_anchor',
+          },
+        }),
+      );
+
+      const result = await service.pollTransaction({
+        anchorDomain: ANCHOR_DOMAIN,
+        transactionId: 'anchor-tx-1',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.transaction.status).toBe('pending_anchor');
+    });
+
+    it('returns failure when anchor HTTP errors', async () => {
+      mockFetch(() => jsonResponse({ error: 'not found' }, 404));
+
+      const result = await service.pollTransaction({
+        anchorDomain: ANCHOR_DOMAIN,
+        transactionId: 'anchor-tx-1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.httpStatus).toBe(404);
+    });
+
+    it('returns failure on network error', async () => {
+      mockFetch(() => { throw new Error('timeout'); });
+
+      const result = await service.pollTransaction({
+        anchorDomain: ANCHOR_DOMAIN,
+        transactionId: 'anchor-tx-1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.httpStatus).toBeNull();
+    });
+
+    it('returns failure when response is missing required fields', async () => {
+      mockFetch(() => jsonResponse({ transaction: { id: 'tx-1' } })); // missing status
+
+      const result = await service.pollTransaction({
+        anchorDomain: ANCHOR_DOMAIN,
+        transactionId: 'anchor-tx-1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/missing required fields/);
+    });
+  });
+});

--- a/app/backend/src/fiat-ramps/fiat-ramps.service.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.service.ts
@@ -1,6 +1,24 @@
 import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
+import { Keypair } from '@stellar/stellar-sdk';
 import { Sep24TransactionRepository } from './sep24-transaction.repository';
-import { Sep24InternalStatus } from './types/sep24.types';
+import {
+  Sep24InternalStatus,
+  AnchorDiscoveryError,
+  Sep10AuthError,
+  Sep24InitiationError,
+} from './types/sep24.types';
+import { AnchorClientService } from './anchor-client.service';
+import { AppConfigService } from '../config/app-config.service';
+
+/** Errors that should return a 400 (client-facing, expected). */
+const CLIENT_ERRORS: readonly string[] = [
+  AnchorDiscoveryError.name,
+  Sep24InitiationError.name,
+];
+
+function isClientError(err: unknown): boolean {
+  return err instanceof Error && CLIENT_ERRORS.includes(err.name);
+}
 
 @Injectable()
 export class FiatRampsService {
@@ -8,6 +26,8 @@ export class FiatRampsService {
 
   constructor(
     private readonly sep24Repository: Sep24TransactionRepository,
+    private readonly anchorClient: AnchorClientService,
+    private readonly appConfig: AppConfigService,
   ) {}
 
   async getAvailableAnchors(assetCode: string, country: string) {
@@ -41,43 +61,93 @@ export class FiatRampsService {
   }) {
     this.logger.log(`Initiating SEP-24 deposit flow with ${depositDto.anchorDomain}`);
 
+    const {
+      assetCode,
+      amount,
+      userAccount,
+      anchorDomain,
+    } = depositDto;
+
     try {
-      // Build mock interactive URL (real integration would use stellar-sdk toml resolver
-      // + SEP-10 auth to obtain a JWT then POST /sep24/transactions/deposit/interactive)
-      const anchorTransactionId = `dep_${Date.now()}`;
-      const interactiveUrl =
-        `https://${depositDto.anchorDomain}/sep24/interactive` +
-        `?type=deposit&asset_code=${depositDto.assetCode}&account=${depositDto.userAccount}`;
+      // ── 1. Discover anchor capabilities from stellar.toml ──────────────
+      const capabilities = await this.anchorClient.discoverAnchorCapabilities(anchorDomain);
+
+      // Validate that the requested asset is supported by this anchor
+      if (
+        capabilities.supportedAssets.length > 0 &&
+        !capabilities.supportedAssets.includes(assetCode.toUpperCase())
+      ) {
+        throw new AnchorDiscoveryError(
+          anchorDomain,
+          `asset ${assetCode} is not supported; supported: [${capabilities.supportedAssets.join(', ')}]`,
+        );
+      }
+
+      // ── 2. Obtain SEP-10 JWT ──────────────────────────────────────────
+      const keypair = this.getKeyPair();
+      const jwt = await this.anchorClient.performSep10Auth(
+        anchorDomain,
+        capabilities.authServer,
+        keypair,
+        this.appConfig.stellarNetworkPassphrase,
+      );
+
+      // ── 3. Initiate SEP-24 deposit (get real interactive URL) ─────────
+      const interactive = await this.anchorClient.initiateSep24Transaction({
+        anchorDomain,
+        jwt,
+        transferServer: capabilities.transferServer,
+        type: 'deposit',
+        assetCode: assetCode.toUpperCase(),
+        account: userAccount,
+        amount: String(amount),
+      });
+
+      // Use the anchor-assigned ID when available, otherwise generate a placeholder
+      const anchorTransactionId = interactive.id ?? `dep_${Date.now()}`;
 
       // Persist the in-flight transaction so the poller can track it
       const record = await this.sep24Repository.create({
         anchor_transaction_id: anchorTransactionId,
-        anchor_domain: depositDto.anchorDomain,
+        anchor_domain: anchorDomain,
         type: 'deposit',
         status: Sep24InternalStatus.Initiated,
         anchor_status: null,
         stellar_tx_hash: null,
-        amount: String(depositDto.amount),
-        asset_code: depositDto.assetCode,
+        amount: String(amount),
+        asset_code: assetCode.toUpperCase(),
         asset_issuer: null,
-        user_account: depositDto.userAccount,
-        interactive_url: interactiveUrl,
+        user_account: userAccount,
+        interactive_url: interactive.url,
       });
 
       this.logger.log(
         `SEP-24 deposit initiated: anchor_tx=${anchorTransactionId} ` +
-        `record_id=${record?.id ?? 'unknown'}`,
+        `record_id=${record?.id ?? 'unknown'} url=${interactive.url}`,
       );
 
       return {
         status: 'success',
         transaction_id: anchorTransactionId,
         internal_id: record?.id ?? null,
-        type: 'interactive_customer_info_needed',
-        url: interactiveUrl,
+        type: interactive.type,
+        url: interactive.url,
+        ...(interactive.message ? { message: interactive.message } : {}),
       };
     } catch (error) {
       this.logger.error(`Error initiating deposit: ${(error as Error).message}`);
+
+      if (isClientError(error)) {
+        throw new HttpException((error as Error).message, HttpStatus.BAD_REQUEST);
+      }
+
+      if (error instanceof Sep10AuthError) {
+        throw new HttpException(
+          `SEP-10 authentication failed: ${(error as Error).message}`,
+          HttpStatus.BAD_GATEWAY,
+        );
+      }
+
       throw new HttpException('Failed to initiate deposit', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -90,40 +160,92 @@ export class FiatRampsService {
   }) {
     this.logger.log(`Initiating SEP-24 withdrawal flow with ${withdrawalDto.anchorDomain}`);
 
+    const {
+      assetCode,
+      amount,
+      userAccount,
+      anchorDomain,
+    } = withdrawalDto;
+
     try {
-      const anchorTransactionId = `wth_${Date.now()}`;
-      const interactiveUrl =
-        `https://${withdrawalDto.anchorDomain}/sep24/interactive` +
-        `?type=withdraw&asset_code=${withdrawalDto.assetCode}&account=${withdrawalDto.userAccount}`;
+      // ── 1. Discover anchor capabilities from stellar.toml ──────────────
+      const capabilities = await this.anchorClient.discoverAnchorCapabilities(anchorDomain);
+
+      // Validate that the requested asset is supported by this anchor
+      if (
+        capabilities.supportedAssets.length > 0 &&
+        !capabilities.supportedAssets.includes(assetCode.toUpperCase())
+      ) {
+        throw new AnchorDiscoveryError(
+          anchorDomain,
+          `asset ${assetCode} is not supported; supported: [${capabilities.supportedAssets.join(', ')}]`,
+        );
+      }
+
+      // ── 2. Obtain SEP-10 JWT ──────────────────────────────────────────
+      const keypair = this.getKeyPair();
+      const jwt = await this.anchorClient.performSep10Auth(
+        anchorDomain,
+        capabilities.authServer,
+        keypair,
+        this.appConfig.stellarNetworkPassphrase,
+      );
+
+      // ── 3. Initiate SEP-24 withdrawal (get real interactive URL) ───────
+      const interactive = await this.anchorClient.initiateSep24Transaction({
+        anchorDomain,
+        jwt,
+        transferServer: capabilities.transferServer,
+        type: 'withdrawal',
+        assetCode: assetCode.toUpperCase(),
+        account: userAccount,
+        amount: String(amount),
+      });
+
+      // Use the anchor-assigned ID when available, otherwise generate a placeholder
+      const anchorTransactionId = interactive.id ?? `wth_${Date.now()}`;
 
       const record = await this.sep24Repository.create({
         anchor_transaction_id: anchorTransactionId,
-        anchor_domain: withdrawalDto.anchorDomain,
+        anchor_domain: anchorDomain,
         type: 'withdrawal',
         status: Sep24InternalStatus.Initiated,
         anchor_status: null,
         stellar_tx_hash: null,
-        amount: String(withdrawalDto.amount),
-        asset_code: withdrawalDto.assetCode,
+        amount: String(amount),
+        asset_code: assetCode.toUpperCase(),
         asset_issuer: null,
-        user_account: withdrawalDto.userAccount,
-        interactive_url: interactiveUrl,
+        user_account: userAccount,
+        interactive_url: interactive.url,
       });
 
       this.logger.log(
         `SEP-24 withdrawal initiated: anchor_tx=${anchorTransactionId} ` +
-        `record_id=${record?.id ?? 'unknown'}`,
+        `record_id=${record?.id ?? 'unknown'} url=${interactive.url}`,
       );
 
       return {
         status: 'success',
         transaction_id: anchorTransactionId,
         internal_id: record?.id ?? null,
-        type: 'interactive_customer_info_needed',
-        url: interactiveUrl,
+        type: interactive.type,
+        url: interactive.url,
+        ...(interactive.message ? { message: interactive.message } : {}),
       };
     } catch (error) {
       this.logger.error(`Error initiating withdrawal: ${(error as Error).message}`);
+
+      if (isClientError(error)) {
+        throw new HttpException((error as Error).message, HttpStatus.BAD_REQUEST);
+      }
+
+      if (error instanceof Sep10AuthError) {
+        throw new HttpException(
+          `SEP-10 authentication failed: ${(error as Error).message}`,
+          HttpStatus.BAD_GATEWAY,
+        );
+      }
+
       throw new HttpException('Failed to initiate withdrawal', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -164,5 +286,22 @@ export class FiatRampsService {
     }
 
     return { status: 'acknowledged' };
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  /**
+   * Load the Stellar signing keypair from the app configuration.
+   *
+   * @throws {Error} if STELLAR_SECRET_KEY is not configured.
+   */
+  private getKeyPair(): Keypair {
+    const secretKey = this.appConfig.stellarSecretKey;
+    if (!secretKey) {
+      throw new Error(
+        'STELLAR_SECRET_KEY is not configured — SEP-10 authentication requires a signing key',
+      );
+    }
+    return Keypair.fromSecret(secretKey);
   }
 }

--- a/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
+++ b/app/backend/src/fiat-ramps/fiat-ramps.service.unit.spec.ts
@@ -1,0 +1,447 @@
+/**
+ * FiatRampsService – Unit Tests
+ *
+ * Covers:
+ *   - Deposit initiation via real SEP-24 handshake (discovery → SEP-10 → initiation)
+ *   - Withdrawal initiation via real SEP-24 handshake
+ *   - Error handling for unsupported assets, auth failures, unreachable anchors
+ *   - Error classification (400 client errors vs 502 auth failures vs 500 internal)
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException } from '@nestjs/common';
+import { FiatRampsService } from './fiat-ramps.service';
+import { Sep24TransactionRepository } from './sep24-transaction.repository';
+import { AnchorClientService } from './anchor-client.service';
+import { AppConfigService } from '../config/app-config.service';
+import {
+  Sep24InternalStatus,
+  AnchorDiscoveryError,
+  Sep10AuthError,
+  Sep24InitiationError,
+} from './types/sep24.types';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockSep24Repository = {
+  create: jest.fn(),
+  findByAnchorTransactionId: jest.fn(),
+  updateStatus: jest.fn(),
+};
+
+const mockAnchorClient = {
+  discoverAnchorCapabilities: jest.fn(),
+  performSep10Auth: jest.fn(),
+  initiateSep24Transaction: jest.fn(),
+};
+
+const mockAppConfig = {
+  stellarNetworkPassphrase: 'Test SDF Network ; September 2015',
+  stellarSecretKey: 'SCX6A3F3XCFW7IT3MY6DSZWULY4U6O5PZHILY3SAPU4QZIHUEO7JZLLS',
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockSuccessFlow() {
+  mockAnchorClient.discoverAnchorCapabilities.mockResolvedValue({
+    transferServer: 'https://test.anchor.org/sep24',
+    authServer: 'https://test.anchor.org/auth',
+    supportedAssets: ['USDC', 'EURC', 'XLM'],
+  });
+
+  mockAnchorClient.performSep10Auth.mockResolvedValue('fake-jwt-token');
+
+  mockAnchorClient.initiateSep24Transaction.mockResolvedValue({
+    type: 'interactive_customer_info_needed',
+    url: 'https://test.anchor.org/sep24/interactive/form/abc123',
+    id: 'anchor-tx-001',
+    message: 'Please complete the form',
+  });
+
+  mockSep24Repository.create.mockResolvedValue({
+    id: 'uuid-001',
+    anchor_transaction_id: 'anchor-tx-001',
+  });
+}
+
+const DEPOSIT_DTO = {
+  assetCode: 'USDC',
+  amount: 100,
+  userAccount: 'GABC123DEF456',
+  anchorDomain: 'test.anchor.org',
+};
+
+const WITHDRAWAL_DTO = {
+  assetCode: 'EURC',
+  amount: 50,
+  userAccount: 'GDEF789GHI012',
+  anchorDomain: 'test.anchor.org',
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('FiatRampsService', () => {
+  let service: FiatRampsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FiatRampsService,
+        { provide: Sep24TransactionRepository, useValue: mockSep24Repository },
+        { provide: AnchorClientService, useValue: mockAnchorClient },
+        { provide: AppConfigService, useValue: mockAppConfig },
+      ],
+    }).compile();
+
+    service = module.get<FiatRampsService>(FiatRampsService);
+  });
+
+  // ─── getAvailableAnchors ──────────────────────────────────────────────────
+
+  describe('getAvailableAnchors', () => {
+    it('returns available anchors for given asset and country', async () => {
+      const result = await service.getAvailableAnchors('USDC', 'US');
+
+      expect(result.status).toBe('success');
+      expect(result.data).toBeInstanceOf(Array);
+      expect(result.data.length).toBeGreaterThan(0);
+      expect(result.data[0]).toHaveProperty('domain');
+      expect(result.data[0]).toHaveProperty('supportedAssets');
+    });
+  });
+
+  // ─── initiateDeposit ─────────────────────────────────────────────────────
+
+  describe('initiateDeposit', () => {
+    it('performs full SEP-24 handshake and returns interactive URL', async () => {
+      mockSuccessFlow();
+
+      const result = await service.initiateDeposit(DEPOSIT_DTO);
+
+      // Verify the three-step handshake was performed
+      expect(mockAnchorClient.discoverAnchorCapabilities).toHaveBeenCalledWith('test.anchor.org');
+      expect(mockAnchorClient.performSep10Auth).toHaveBeenCalledWith(
+        'test.anchor.org',
+        'https://test.anchor.org/auth',
+        expect.anything(), // Keypair
+        'Test SDF Network ; September 2015',
+      );
+      expect(mockAnchorClient.initiateSep24Transaction).toHaveBeenCalledWith({
+        anchorDomain: 'test.anchor.org',
+        jwt: 'fake-jwt-token',
+        transferServer: 'https://test.anchor.org/sep24',
+        type: 'deposit',
+        assetCode: 'USDC',
+        account: 'GABC123DEF456',
+        amount: '100',
+      });
+
+      // Verify repository was called to persist the transaction
+      expect(mockSep24Repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          anchor_transaction_id: 'anchor-tx-001',
+          anchor_domain: 'test.anchor.org',
+          type: 'deposit',
+          status: Sep24InternalStatus.Initiated,
+          asset_code: 'USDC',
+          user_account: 'GABC123DEF456',
+          interactive_url: 'https://test.anchor.org/sep24/interactive/form/abc123',
+        }),
+      );
+
+      // Verify response shape
+      expect(result).toEqual({
+        status: 'success',
+        transaction_id: 'anchor-tx-001',
+        internal_id: 'uuid-001',
+        type: 'interactive_customer_info_needed',
+        url: 'https://test.anchor.org/sep24/interactive/form/abc123',
+        message: 'Please complete the form',
+      });
+    });
+
+    it('throws 400 for unsupported asset', async () => {
+      mockAnchorClient.discoverAnchorCapabilities.mockResolvedValue({
+        transferServer: 'https://test.anchor.org/sep24',
+        authServer: 'https://test.anchor.org/auth',
+        supportedAssets: ['USDC', 'EURC'],
+      });
+
+      await expect(
+        service.initiateDeposit({ ...DEPOSIT_DTO, assetCode: 'XYZ' }),
+      ).rejects.toThrow(HttpException);
+
+      // Should NOT have attempted SEP-10 auth
+      expect(mockAnchorClient.performSep10Auth).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 when anchor discovery fails (unreachable anchor)', async () => {
+      mockAnchorClient.discoverAnchorCapabilities.mockRejectedValue(
+        new AnchorDiscoveryError('test.anchor.org', 'stellar.toml HTTP 404'),
+      );
+
+      await expect(service.initiateDeposit(DEPOSIT_DTO)).rejects.toThrow(HttpException);
+
+      expect(mockAnchorClient.performSep10Auth).not.toHaveBeenCalled();
+      expect(mockAnchorClient.initiateSep24Transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws 502 when SEP-10 authentication fails', async () => {
+      mockAnchorClient.discoverAnchorCapabilities.mockResolvedValue({
+        transferServer: 'https://test.anchor.org/sep24',
+        authServer: 'https://test.anchor.org/auth',
+        supportedAssets: ['USDC'],
+      });
+
+      mockAnchorClient.performSep10Auth.mockRejectedValue(
+        new Sep10AuthError('test.anchor.org', 'challenge request failed: HTTP 401'),
+      );
+
+      try {
+        await service.initiateDeposit(DEPOSIT_DTO);
+        fail('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpException);
+        expect((error as HttpException).getStatus()).toBe(502);
+      }
+    });
+
+    it('throws 400 when SEP-24 initiation fails (anchor rejects request)', async () => {
+      mockAnchorClient.discoverAnchorCapabilities.mockResolvedValue({
+        transferServer: 'https://test.anchor.org/sep24',
+        authServer: 'https://test.anchor.org/auth',
+        supportedAssets: ['USDC'],
+      });
+
+      mockAnchorClient.performSep10Auth.mockResolvedValue('jwt-token');
+
+      mockAnchorClient.initiateSep24Transaction.mockRejectedValue(
+        new Sep24InitiationError('test.anchor.org', 'unsupported asset or bad request — HTTP 400', 400),
+      );
+
+      try {
+        await service.initiateDeposit(DEPOSIT_DTO);
+        fail('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpException);
+        expect((error as HttpException).getStatus()).toBe(400);
+      }
+    });
+
+    it('throws 500 for unexpected internal errors', async () => {
+      mockAnchorClient.discoverAnchorCapabilities.mockRejectedValue(
+        new Error('unexpected error'),
+      );
+
+      try {
+        await service.initiateDeposit(DEPOSIT_DTO);
+        fail('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpException);
+        expect((error as HttpException).getStatus()).toBe(500);
+      }
+    });
+
+    it('generates placeholder ID when anchor does not return one', async () => {
+      mockSuccessFlow();
+      mockAnchorClient.initiateSep24Transaction.mockResolvedValue({
+        type: 'interactive_customer_info_needed',
+        url: 'https://test.anchor.org/sep24/interactive/form/xyz',
+        // no id field
+      });
+      mockSep24Repository.create.mockResolvedValue({ id: 'uuid-002', anchor_transaction_id: 'dep_1234567890' });
+
+      const result = await service.initiateDeposit(DEPOSIT_DTO);
+
+      expect(result.transaction_id).toMatch(/^dep_/);
+    });
+
+    it('normalizes assetCode to uppercase', async () => {
+      mockSuccessFlow();
+
+      await service.initiateDeposit({ ...DEPOSIT_DTO, assetCode: 'usdc' });
+
+      expect(mockAnchorClient.initiateSep24Transaction).toHaveBeenCalledWith(
+        expect.objectContaining({ assetCode: 'USDC' }),
+      );
+      expect(mockSep24Repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ asset_code: 'USDC' }),
+      );
+    });
+
+    it('omits message from response when anchor does not provide one', async () => {
+      mockSuccessFlow();
+      mockAnchorClient.initiateSep24Transaction.mockResolvedValue({
+        type: 'interactive_customer_info_needed',
+        url: 'https://test.anchor.org/sep24/interactive/form/nomsg',
+        id: 'anchor-tx-002',
+        // no message
+      });
+      mockSep24Repository.create.mockResolvedValue({ id: 'uuid-003', anchor_transaction_id: 'anchor-tx-002' });
+
+      const result = await service.initiateDeposit(DEPOSIT_DTO);
+
+      expect(result).not.toHaveProperty('message');
+    });
+  });
+
+  // ─── initiateWithdrawal ───────────────────────────────────────────────────
+
+  describe('initiateWithdrawal', () => {
+    it('performs full SEP-24 handshake and returns interactive URL', async () => {
+      mockSuccessFlow();
+
+      const result = await service.initiateWithdrawal(WITHDRAWAL_DTO);
+
+      // Verify the three-step handshake
+      expect(mockAnchorClient.discoverAnchorCapabilities).toHaveBeenCalledWith('test.anchor.org');
+      expect(mockAnchorClient.performSep10Auth).toHaveBeenCalled();
+      expect(mockAnchorClient.initiateSep24Transaction).toHaveBeenCalledWith({
+        anchorDomain: 'test.anchor.org',
+        jwt: 'fake-jwt-token',
+        transferServer: 'https://test.anchor.org/sep24',
+        type: 'withdrawal',
+        assetCode: 'EURC',
+        account: 'GDEF789GHI012',
+        amount: '50',
+      });
+
+      expect(mockSep24Repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'withdrawal',
+          asset_code: 'EURC',
+          interactive_url: 'https://test.anchor.org/sep24/interactive/form/abc123',
+        }),
+      );
+
+      expect(result).toEqual({
+        status: 'success',
+        transaction_id: 'anchor-tx-001',
+        internal_id: 'uuid-001',
+        type: 'interactive_customer_info_needed',
+        url: 'https://test.anchor.org/sep24/interactive/form/abc123',
+        message: 'Please complete the form',
+      });
+    });
+
+    it('throws 400 for unsupported asset', async () => {
+      mockAnchorClient.discoverAnchorCapabilities.mockResolvedValue({
+        transferServer: 'https://test.anchor.org/sep24',
+        authServer: 'https://test.anchor.org/auth',
+        supportedAssets: ['USDC'],
+      });
+
+      await expect(
+        service.initiateWithdrawal({ ...WITHDRAWAL_DTO, assetCode: 'EURC' }),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('throws 400 when anchor discovery fails', async () => {
+      mockAnchorClient.discoverAnchorCapabilities.mockRejectedValue(
+        new AnchorDiscoveryError('test.anchor.org', 'network error'),
+      );
+
+      await expect(service.initiateWithdrawal(WITHDRAWAL_DTO)).rejects.toThrow(HttpException);
+    });
+
+    it('throws 502 when SEP-10 auth fails', async () => {
+      mockAnchorClient.discoverAnchorCapabilities.mockResolvedValue({
+        transferServer: 'https://test.anchor.org/sep24',
+        authServer: 'https://test.anchor.org/auth',
+        supportedAssets: ['EURC'],
+      });
+
+      mockAnchorClient.performSep10Auth.mockRejectedValue(
+        new Sep10AuthError('test.anchor.org', 'invalid signature'),
+      );
+
+      try {
+        await service.initiateWithdrawal(WITHDRAWAL_DTO);
+        fail('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpException);
+        expect((error as HttpException).getStatus()).toBe(502);
+      }
+    });
+
+    it('throws 400 when SEP-24 initiation fails', async () => {
+      mockAnchorClient.discoverAnchorCapabilities.mockResolvedValue({
+        transferServer: 'https://test.anchor.org/sep24',
+        authServer: 'https://test.anchor.org/auth',
+        supportedAssets: ['EURC'],
+      });
+
+      mockAnchorClient.performSep10Auth.mockResolvedValue('jwt-token');
+      mockAnchorClient.initiateSep24Transaction.mockRejectedValue(
+        new Sep24InitiationError('test.anchor.org', 'anchor error'),
+      );
+
+      try {
+        await service.initiateWithdrawal(WITHDRAWAL_DTO);
+        fail('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpException);
+        expect((error as HttpException).getStatus()).toBe(400);
+      }
+    });
+
+    it('generates placeholder ID when anchor does not return one', async () => {
+      mockSuccessFlow();
+      mockAnchorClient.initiateSep24Transaction.mockResolvedValue({
+        type: 'interactive_customer_info_needed',
+        url: 'https://test.anchor.org/sep24/interactive/form/abc123',
+      });
+      mockSep24Repository.create.mockResolvedValue({ id: 'uuid-004', anchor_transaction_id: 'wth_1234567890' });
+
+      const result = await service.initiateWithdrawal(WITHDRAWAL_DTO);
+
+      expect(result.transaction_id).toMatch(/^wth_/);
+    });
+  });
+
+  // ─── handleKycCallback ───────────────────────────────────────────────────
+
+  describe('handleKycCallback', () => {
+    it('returns acknowledged for KYC callback data', async () => {
+      const result = await service.handleKycCallback({ status: 'approved' });
+      expect(result).toEqual({ status: 'acknowledged' });
+    });
+  });
+
+  // ─── updateTransactionStatus ─────────────────────────────────────────────
+
+  describe('updateTransactionStatus', () => {
+    it('returns acknowledged for status update data', async () => {
+      mockSep24Repository.findByAnchorTransactionId.mockResolvedValue(null);
+
+      const result = await service.updateTransactionStatus({ id: 'tx-1', status: 'completed' });
+      expect(result).toEqual({ status: 'acknowledged' });
+    });
+
+    it('updates existing transaction record when anchor ID matches', async () => {
+      const existingRecord = {
+        id: 'uuid-existing',
+        anchor_transaction_id: 'anchor-tx-999',
+        stellar_tx_hash: null,
+      };
+
+      mockSep24Repository.findByAnchorTransactionId.mockResolvedValue(existingRecord);
+      mockSep24Repository.updateStatus.mockResolvedValue(undefined);
+
+      await service.updateTransactionStatus({
+        id: 'anchor-tx-999',
+        status: 'completed',
+        stellar_transaction_id: 'stellar-hash-123',
+      });
+
+      expect(mockSep24Repository.updateStatus).toHaveBeenCalledWith(
+        'uuid-existing',
+        'completed',
+        'completed',
+        'stellar-hash-123',
+      );
+    });
+  });
+});

--- a/app/backend/src/fiat-ramps/types/sep24.types.ts
+++ b/app/backend/src/fiat-ramps/types/sep24.types.ts
@@ -132,6 +132,80 @@ export interface Sep24TransactionRecord {
   terminal_at: string | null;
 }
 
+// ─── Anchor capabilities (discovered from stellar.toml) ─────────────────────
+
+/**
+ * Anchor capabilities discovered by parsing the anchor's stellar.toml.
+ * Returned by {@link AnchorClientService.discoverAnchorCapabilities}.
+ */
+export interface AnchorCapabilities {
+  /** The SEP-10 auth server URL ("TRANSFER_SERVER_SEP0010"). */
+  authServer: string;
+  /** The SEP-24 transfer server URL ("TRANSFER_SERVER_SEP0024"). */
+  transferServer: string;
+  /** Asset codes that the anchor declares as supported for SEP-24. */
+  supportedAssets: string[];
+}
+
+// ─── SEP-24 interactive initiation response ───────────────────────────────────
+
+/**
+ * The anchor's response to a SEP-24 POST /transactions/{type}/interactive
+ * request.  Only the fields our client needs are represented.
+ */
+export interface Sep24InteractiveResponse {
+  type: 'interactive_customer_info_needed';
+  url: string;
+  /** Transaction id assigned by the anchor (returned in some implementations). */
+  id?: string;
+  /** Human-readable next step guidance from the anchor. */
+  message?: string;
+}
+
+// ─── Error classes ────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when the anchor's stellar.toml cannot be fetched or is missing
+ * required SEP-24 / SEP-10 fields.
+ */
+export class AnchorDiscoveryError extends Error {
+  readonly anchorDomain: string;
+  constructor(anchorDomain: string, reason: string) {
+    super(`Anchor discovery failed for ${anchorDomain}: ${reason}`);
+    this.name = 'AnchorDiscoveryError';
+    this.anchorDomain = anchorDomain;
+  }
+}
+
+/**
+ * Thrown when SEP-10 authentication with the anchor fails.
+ */
+export class Sep10AuthError extends Error {
+  readonly anchorDomain: string;
+  readonly httpStatus: number | null;
+  constructor(anchorDomain: string, reason: string, httpStatus: number | null = null) {
+    super(`SEP-10 auth failed for ${anchorDomain}: ${reason}`);
+    this.name = 'Sep10AuthError';
+    this.anchorDomain = anchorDomain;
+    this.httpStatus = httpStatus;
+  }
+}
+
+/**
+ * Thrown when SEP-24 transaction initiation fails (unsupported asset,
+ * unreachable anchor, malformed response, etc.).
+ */
+export class Sep24InitiationError extends Error {
+  readonly anchorDomain: string;
+  readonly httpStatus: number | null;
+  constructor(anchorDomain: string, reason: string, httpStatus: number | null = null) {
+    super(`SEP-24 initiation failed for ${anchorDomain}: ${reason}`);
+    this.name = 'Sep24InitiationError';
+    this.anchorDomain = anchorDomain;
+    this.httpStatus = httpStatus;
+  }
+}
+
 // ─── Anchor HTTP response shape ────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
Replace mock interactive URL construction with genuine anchor discovery and SEP-24 initiation against testnet anchors.

Changes:
- AnchorClientService: add discoverAnchorCapabilities (stellar.toml parsing), performSep10Auth (challenge-response JWT flow), and initiateSep24Transaction (POST to interactive endpoint)
- FiatRampsService: orchestrates discovery → auth → initiation for deposits and withdrawals, returning URLs from the anchor's SEP-24 response
- types/sep24.types: add AnchorCapabilities, Sep24InteractiveResponse, and typed error classes (AnchorDiscoveryError, Sep10AuthError, Sep24InitiationError)
- Fix SEP-10 auth URL construction (use authServer directly, not /auth suffix)
- Fix TransactionBuilder.fromXdr → fromXDR (SDK v14 API)
- Add 92 unit tests across 4 test suites covering the full handshake flow, error paths (unsupported assets, auth failures, unreachable anchors), and correct HTTP status code classification (400/502/500)

Closes #805

