### PR TITLE
feat(reconciliation): scheduled runs with configurable drift alerting (BE-124)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,22 @@ RATE_LIMIT_WINDOW=60
 RATE_LIMIT_MAX=100
 
 # ------------------------------------------------------------
+# Reconciliation (BE-124)
+# ------------------------------------------------------------
+# Max records per entity type processed per reconciliation run.
+RECONCILIATION_BATCH_SIZE=50
+# Enable the scheduled reconciliation worker.
+RECONCILIATION_ENABLED=true
+# Cron expression for scheduled reconciliation runs (default: every 5 minutes).
+RECONCILIATION_CRON_EXPRESSION=*/5 * * * *
+# Payment count discrepancy threshold that raises a drift alert.
+RECONCILIATION_DRIFT_COUNT_THRESHOLD=5
+# Payment amount discrepancy threshold (in stroops) that raises a drift alert.
+RECONCILIATION_DRIFT_AMOUNT_THRESHOLD_STROOPS=0
+# Consecutive failed/skipped reconciliation runs that raise an alert.
+RECONCILIATION_CONSECUTIVE_FAILURE_ALERT_THRESHOLD=3
+
+# ------------------------------------------------------------
 # Rust / Soroban
 # ------------------------------------------------------------
 

--- a/app/backend/src/config/app-config.service.ts
+++ b/app/backend/src/config/app-config.service.ts
@@ -248,6 +248,53 @@ export class AppConfigService {
   }
 
   /**
+   * Whether the scheduled reconciliation worker is enabled (BE-124).
+   */
+  get reconciliationEnabled(): boolean {
+    return this.configService.get("RECONCILIATION_ENABLED", { infer: true });
+  }
+
+  /**
+   * Cron expression for scheduled reconciliation runs (BE-124).
+   */
+  get reconciliationCronExpression(): string {
+    return this.configService.get("RECONCILIATION_CRON_EXPRESSION", {
+      infer: true,
+    });
+  }
+
+  /**
+   * Payment count discrepancy that raises a drift alert when exceeded (BE-124).
+   */
+  get reconciliationDriftCountThreshold(): number {
+    return this.configService.get("RECONCILIATION_DRIFT_COUNT_THRESHOLD", {
+      infer: true,
+    });
+  }
+
+  /**
+   * Payment amount discrepancy (in stroops) that raises a drift alert when
+   * exceeded. Kept as a string so it can preserve full precision for BigInt
+   * comparisons (BE-124).
+   */
+  get reconciliationDriftAmountThresholdStroops(): string {
+    return this.configService.get(
+      "RECONCILIATION_DRIFT_AMOUNT_THRESHOLD_STROOPS",
+      { infer: true },
+    );
+  }
+
+  /**
+   * Consecutive failed or skipped reconciliation runs that raise an alert (BE-124).
+   */
+  get reconciliationConsecutiveFailureAlertThreshold(): number {
+    return this.configService.get(
+      "RECONCILIATION_CONSECUTIVE_FAILURE_ALERT_THRESHOLD",
+      { infer: true },
+    );
+  }
+
+  /**
    * QuickEx Soroban contract id (optional). Used for ingestion and soroban preflight.
    */
   get quickexContractId(): string | undefined {

--- a/app/backend/src/config/env.schema.ts
+++ b/app/backend/src/config/env.schema.ts
@@ -282,6 +282,34 @@ export const envSchema = Joi.object({
       "Max records per entity type processed per reconciliation run",
     ),
 
+  // Scheduled reconciliation run + drift alerting (BE-124)
+  RECONCILIATION_ENABLED: Joi.boolean()
+    .default(true)
+    .description("Enable the scheduled reconciliation worker (BE-124)"),
+  RECONCILIATION_CRON_EXPRESSION: Joi.string()
+    .default("*/5 * * * *")
+    .description("Cron expression for scheduled reconciliation runs (BE-124)"),
+  RECONCILIATION_DRIFT_COUNT_THRESHOLD: Joi.number()
+    .integer()
+    .min(0)
+    .default(5)
+    .description(
+      "Payment count discrepancy that raises a drift alert when exceeded (BE-124)",
+    ),
+  RECONCILIATION_DRIFT_AMOUNT_THRESHOLD_STROOPS: Joi.string()
+    .empty("")
+    .default("0")
+    .description(
+      "Payment amount discrepancy (in stroops) that raises a drift alert when exceeded (BE-124)",
+    ),
+  RECONCILIATION_CONSECUTIVE_FAILURE_ALERT_THRESHOLD: Joi.number()
+    .integer()
+    .min(1)
+    .default(3)
+    .description(
+      "Consecutive failed or skipped reconciliation runs that raise an alert (BE-124)",
+    ),
+
   // Rate limiting — optional bcrypt-hashed API keys (comma-separated)
   // Generate a hash: node -e "require('bcrypt').hash('MY_KEY', 10).then(console.log)"
   API_KEYS: Joi.string()
@@ -662,6 +690,11 @@ export interface EnvConfig {
   SENDGRID_FROM_EMAIL?: string;
   EXPO_ACCESS_TOKEN?: string;
   RECONCILIATION_BATCH_SIZE: number;
+  RECONCILIATION_ENABLED: boolean;
+  RECONCILIATION_CRON_EXPRESSION: string;
+  RECONCILIATION_DRIFT_COUNT_THRESHOLD: number;
+  RECONCILIATION_DRIFT_AMOUNT_THRESHOLD_STROOPS: string;
+  RECONCILIATION_CONSECUTIVE_FAILURE_ALERT_THRESHOLD: number;
   API_KEYS?: string;
   RATE_LIMIT_PUBLIC_BURST_LIMIT: number;
   RATE_LIMIT_PUBLIC_BURST_TTL_MS: number;

--- a/app/backend/src/job-queue/handlers/reconciliation.handler.ts
+++ b/app/backend/src/job-queue/handlers/reconciliation.handler.ts
@@ -179,8 +179,17 @@ export class ReconciliationHandler implements JobHandler<ReconciliationPayload> 
       error.stack,
     );
 
-    // Note: Reconciliation failures are typically transient (Horizon unavailable)
-    // and will be retried on the next cron tick. No additional action needed here.
-    // Operators should monitor reconciliation failure metrics and alerts.
+    // Persist the failed run so the consecutive-failure alerting path (BE-124)
+    // can escalate when runs keep failing. Reconciliation is retried on the
+    // next cron tick, so no extra cleanup is needed here.
+    try {
+      await this.reconciliationService.recordFailedRun(error.message, {
+        batchSize: job.payload.batchSize,
+      });
+    } catch (hookError) {
+      this.logger.error(
+        `Failed to record reconciliation failure (jobId: ${job.id}): ${(hookError as Error).message}`,
+      );
+    }
   }
 }

--- a/app/backend/src/metrics/metrics.service.ts
+++ b/app/backend/src/metrics/metrics.service.ts
@@ -28,6 +28,8 @@ export class MetricsService implements OnModuleInit {
   private outboxDepth: client.Gauge<string>;
   private outboxDispatchLagSeconds: client.Gauge<string>;
   private outboxDispatchTotal: client.Counter<string>;
+  private reconciliationDriftActive: client.Gauge<string>;
+  private reconciliationConsecutiveFailures: client.Gauge<string>;
   private initialized = false;
 
   onModuleInit() {
@@ -179,6 +181,16 @@ export class MetricsService implements OnModuleInit {
         labelNames: ["event_type", "outcome"],
       });
 
+      this.reconciliationDriftActive = new client.Gauge({
+        name: "reconciliation_drift_active",
+        help: "Whether the latest reconciliation run exceeded drift thresholds (1) or not (0)",
+      });
+
+      this.reconciliationConsecutiveFailures = new client.Gauge({
+        name: "reconciliation_consecutive_failures",
+        help: "Number of consecutive failed or skipped reconciliation runs",
+      });
+
       this.register.registerMetric(this.httpRequestDuration);
       this.register.registerMetric(this.httpRequestTotal);
       this.register.registerMetric(this.rateLimitedRequestsTotal);
@@ -203,6 +215,8 @@ export class MetricsService implements OnModuleInit {
       this.register.registerMetric(this.outboxDepth);
       this.register.registerMetric(this.outboxDispatchLagSeconds);
       this.register.registerMetric(this.outboxDispatchTotal);
+      this.register.registerMetric(this.reconciliationDriftActive);
+      this.register.registerMetric(this.reconciliationConsecutiveFailures);
 
       this.initialized = true;
     } catch (error) {
@@ -452,6 +466,22 @@ export class MetricsService implements OnModuleInit {
     if (!this.initialized || !this.outboxDispatchTotal) return;
     try {
       this.outboxDispatchTotal.labels(eventType, outcome).inc();
+    } catch (error) {}
+  }
+
+  /** Set whether the latest reconciliation run exceeded drift thresholds (BE-124). */
+  setReconciliationDriftActive(active: 0 | 1) {
+    if (!this.initialized || !this.reconciliationDriftActive) return;
+    try {
+      this.reconciliationDriftActive.set(active);
+    } catch (error) {}
+  }
+
+  /** Set the current consecutive failed/skipped reconciliation run count (BE-124). */
+  setReconciliationConsecutiveFailures(count: number) {
+    if (!this.initialized || !this.reconciliationConsecutiveFailures) return;
+    try {
+      this.reconciliationConsecutiveFailures.set(count);
     } catch (error) {}
   }
 }

--- a/app/backend/src/metrics/metrics.service.unit.spec.ts
+++ b/app/backend/src/metrics/metrics.service.unit.spec.ts
@@ -140,7 +140,7 @@ describe("MetricsService", () => {
         labelNames: ["service", "error_type"],
       });
 
-      expect(mockRegistry.registerMetric).toHaveBeenCalledTimes(24);
+      expect(mockRegistry.registerMetric).toHaveBeenCalledTimes(26);
     });
 
     it("should handle initialization errors gracefully", () => {

--- a/app/backend/src/reconciliation/reconciliation-run.repository.ts
+++ b/app/backend/src/reconciliation/reconciliation-run.repository.ts
@@ -1,0 +1,212 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SupabaseService } from '../supabase/supabase.service';
+import {
+  ReconciliationRunStatus,
+  ReconciliationRunSummary,
+} from './types/reconciliation.types';
+
+/** Row shape of the `reconciliation_runs` table (snake_case). */
+interface ReconciliationRunRow {
+  run_id: string;
+  status: ReconciliationRunStatus;
+  batch_size: number | null;
+  started_at: string;
+  completed_at: string | null;
+  duration_ms: number | null;
+  escrows_processed: number;
+  escrows_irreconcilable: number;
+  payments_processed: number;
+  payments_irreconcilable: number;
+  count_discrepancy: number;
+  amount_discrepancy: string;
+  drift_exceeded: boolean;
+  alert_severity: 'warning' | 'critical' | null;
+  alert_message: string | null;
+  failure_reason: string | null;
+  skipped_reason: string | null;
+  drift_details: unknown;
+}
+
+/** Paginated result returned by {@link ReconciliationRunRepository.listRuns}. */
+export interface ReconciliationRunPage {
+  items: ReconciliationRunSummary[];
+  total: number;
+  hasMore: boolean;
+}
+
+/**
+ * ReconciliationRunRepository
+ *
+ * Data-access layer for the `reconciliation_runs` table (see
+ * `supabase/migrations/20260830000000_create_reconciliation_runs.sql`).
+ *
+ * Stores a summary per scheduled/manual reconciliation run, exposes run history
+ * to operators with per-run drift detail, and computes the current consecutive
+ * failed/skipped streak used by the drift alerting path (BE-124).
+ */
+@Injectable()
+export class ReconciliationRunRepository {
+  private readonly logger = new Logger(ReconciliationRunRepository.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /**
+   * Persist (or overwrite) a run summary. Idempotent on `run_id` so a retried
+   * run never creates duplicate history rows.
+   */
+  async save(summary: ReconciliationRunSummary): Promise<void> {
+    const { error } = await this.supabase
+      .getClient()
+      .from('reconciliation_runs')
+      .upsert(this.toRow(summary), { onConflict: 'run_id' });
+
+    if (error) {
+      this.logger.error(
+        `Failed to persist reconciliation run ${summary.runId}: ${error.message}`,
+      );
+    }
+  }
+
+  /**
+   * Return a page of run history, newest first. Optionally filtered by status.
+   */
+  async listRuns(options: {
+    limit: number;
+    offset: number;
+    status?: ReconciliationRunStatus;
+  }): Promise<ReconciliationRunPage> {
+    const effectiveLimit = Math.min(100, Math.max(1, options.limit));
+
+    let query = this.supabase
+      .getClient()
+      .from('reconciliation_runs')
+      .select('*', { count: 'exact' })
+      .order('started_at', { ascending: false });
+
+    if (options.status) {
+      query = query.eq('status', options.status);
+    }
+
+    const { data, error, count } = await query.range(
+      options.offset,
+      options.offset + effectiveLimit - 1,
+    );
+
+    if (error) {
+      this.logger.error(
+        `Failed to list reconciliation runs: ${error.message}`,
+      );
+      return { items: [], total: 0, hasMore: false };
+    }
+
+    const total = count ?? 0;
+    const items = (data ?? []).map((row: ReconciliationRunRow) =>
+      this.toSummary(row),
+    );
+
+    return {
+      items,
+      total,
+      hasMore: options.offset + effectiveLimit < total,
+    };
+  }
+
+  /** Look up a single run summary (with its drift detail) by run id. */
+  async findById(runId: string): Promise<ReconciliationRunSummary | null> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('reconciliation_runs')
+      .select('*')
+      .eq('run_id', runId)
+      .maybeSingle();
+
+    if (error) {
+      this.logger.error(
+        `Failed to find reconciliation run ${runId}: ${error.message}`,
+      );
+      return null;
+    }
+
+    return data ? this.toSummary(data as ReconciliationRunRow) : null;
+  }
+
+  /**
+   * Count how many of the most recent runs are incomplete (failed or skipped),
+   * scanning newest-first until a successful/drifted run breaks the streak.
+   * Used to alert when consecutive failed/skipped runs exceed a threshold.
+   */
+  async countConsecutiveIncompleteRuns(
+    lookback = 100,
+  ): Promise<number> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('reconciliation_runs')
+      .select('status')
+      .order('started_at', { ascending: false })
+      .limit(Math.max(1, lookback));
+
+    if (error) {
+      this.logger.error(
+        `Failed to read reconciliation run history: ${error.message}`,
+      );
+      return 0;
+    }
+
+    let consecutive = 0;
+    for (const row of data ?? []) {
+      if (row.status === 'failed' || row.status === 'skipped') {
+        consecutive += 1;
+      } else {
+        break;
+      }
+    }
+    return consecutive;
+  }
+
+  private toRow(summary: ReconciliationRunSummary): Record<string, unknown> {
+    return {
+      run_id: summary.runId,
+      status: summary.status,
+      batch_size: summary.batchSize ?? null,
+      started_at: summary.startedAt,
+      completed_at: summary.completedAt,
+      duration_ms: summary.durationMs,
+      escrows_processed: summary.escrowsProcessed,
+      escrows_irreconcilable: summary.escrowsIrreconcilable,
+      payments_processed: summary.paymentsProcessed,
+      payments_irreconcilable: summary.paymentsIrreconcilable,
+      count_discrepancy: summary.countDiscrepancy,
+      amount_discrepancy: summary.amountDiscrepancy,
+      drift_exceeded: summary.driftExceeded,
+      alert_severity: summary.alertSeverity ?? null,
+      alert_message: summary.alertMessage ?? null,
+      failure_reason: summary.failureReason ?? null,
+      skipped_reason: summary.skippedReason ?? null,
+      drift_details: summary.driftDetails,
+    };
+  }
+
+  private toSummary(row: ReconciliationRunRow): ReconciliationRunSummary {
+    return {
+      runId: row.run_id,
+      status: row.status,
+      batchSize: row.batch_size ?? undefined,
+      startedAt: row.started_at,
+      completedAt: row.completed_at,
+      durationMs: row.duration_ms,
+      escrowsProcessed: row.escrows_processed,
+      escrowsIrreconcilable: row.escrows_irreconcilable,
+      paymentsProcessed: row.payments_processed,
+      paymentsIrreconcilable: row.payments_irreconcilable,
+      countDiscrepancy: row.count_discrepancy,
+      amountDiscrepancy: row.amount_discrepancy,
+      driftExceeded: row.drift_exceeded,
+      alertSeverity: row.alert_severity ?? undefined,
+      alertMessage: row.alert_message ?? undefined,
+      failureReason: row.failure_reason ?? undefined,
+      skippedReason: row.skipped_reason ?? undefined,
+      driftDetails: (row.drift_details ?? []) as ReconciliationRunSummary['driftDetails'],
+    };
+  }
+}

--- a/app/backend/src/reconciliation/reconciliation-worker.service.ts
+++ b/app/backend/src/reconciliation/reconciliation-worker.service.ts
@@ -1,5 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { CronJob } from 'cron';
 
 import { AppConfigService } from '../config/app-config.service';
 import { ReconciliationService } from './reconciliation.service';
@@ -11,17 +16,21 @@ import { ReconciliationPayload } from '../job-queue/types/job-payloads.types';
 /**
  * ReconciliationWorkerService
  *
- * Runs on a configurable cron schedule (default: every 5 minutes).
- * Enqueues reconciliation jobs via the unified job queue system.
- * The visibility timeout prevents concurrent reconciliation jobs.
+ * Runs reconciliation on a configurable schedule (BE-124) — the cron
+ * expression defaults to every 5 minutes and can be overridden via
+ * RECONCILIATION_CRON_EXPRESSION, with the whole worker toggled via
+ * RECONCILIATION_ENABLED.
  *
- * The worker is self-serialising: if a previous run is still in progress
- * when the next tick fires, the new tick is skipped to prevent thundering
- * herds against the Horizon API.
+ * Each tick enqueues a reconciliation job through the unified job queue
+ * system; the actual run (and its persisted summary) is handled by the
+ * ReconciliationHandler. The worker is self-serialising: if a previous run is
+ * still in progress when the next tick fires, the tick is skipped and recorded
+ * so consecutive skipped/failed runs are alertable (BE-124).
  */
 @Injectable()
-export class ReconciliationWorkerService {
+export class ReconciliationWorkerService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(ReconciliationWorkerService.name);
+  private cronJob: CronJob | null = null;
   private isRunning = false;
   private lastReport: ReconciliationReport | null = null;
 
@@ -32,18 +41,57 @@ export class ReconciliationWorkerService {
   ) {}
 
   // ---------------------------------------------------------------------------
-  // Scheduled job — every 5 minutes by default.
-  // Override via RECONCILIATION_CRON_EXPRESSION env var for custom scheduling.
+  // Scheduling (BE-124) — dynamic cron from RECONCILIATION_CRON_EXPRESSION so
+  // the schedule is configurable without a deploy, instead of the previous
+  // hard-coded every-5-minutes decorator.
   // ---------------------------------------------------------------------------
 
-  @Cron(CronExpression.EVERY_5_MINUTES, {
-    name: 'reconciliation-worker',
-    timeZone: 'UTC',
-  })
-  async handleCron(): Promise<void> {
+  onModuleInit(): void {
+    if (!this.config.reconciliationEnabled) {
+      this.logger.log(
+        'Scheduled reconciliation worker disabled via RECONCILIATION_ENABLED',
+      );
+      return;
+    }
+
+    const expression = this.config.reconciliationCronExpression;
+    try {
+      this.cronJob = new CronJob(
+        expression,
+        () => void this.handleTick(),
+        null,
+        true,
+        'UTC',
+      );
+      this.logger.log(
+        `Scheduled reconciliation worker initialized (cron: ${expression})`,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to initialize reconciliation worker cron ('${expression}'): ${(err as Error).message}`,
+      );
+    }
+  }
+
+  onModuleDestroy(): void {
+    if (this.cronJob) {
+      this.cronJob.stop();
+      this.cronJob = null;
+      this.logger.log('Scheduled reconciliation worker stopped');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cron tick — enqueue a reconciliation job.
+  // ---------------------------------------------------------------------------
+
+  private async handleTick(): Promise<void> {
     if (this.isRunning) {
       this.logger.warn(
         'Reconciliation tick skipped — previous run still in progress',
+      );
+      await this.reconciliationService.recordSkippedRun(
+        'Previous reconciliation run still in progress',
       );
       return;
     }
@@ -53,9 +101,6 @@ export class ReconciliationWorkerService {
 
     try {
       const batchSize = this.config.reconciliationBatchSize;
-      
-      // Enqueue reconciliation job via JobQueueService
-      // Requirements: 10.2, 10.4
       const payload: ReconciliationPayload = {
         batchSize,
         // startLedger and endLedger are optional - not used in current implementation
@@ -67,14 +112,15 @@ export class ReconciliationWorkerService {
       );
 
       this.logger.log(`Reconciliation job enqueued: ${jobId} (batchSize: ${batchSize})`);
-      
-      // Note: The actual reconciliation execution is now handled by the job queue system.
-      // The visibility timeout (5 minutes) prevents concurrent reconciliation jobs.
     } catch (err) {
+      const message = (err as Error).message;
       this.logger.error(
-        `Failed to enqueue reconciliation job: ${(err as Error).message}`,
+        `Failed to enqueue reconciliation job: ${message}`,
         (err as Error).stack,
       );
+      await this.reconciliationService.recordFailedRun(message, {
+        batchSize: this.config.reconciliationBatchSize,
+      });
     } finally {
       this.isRunning = false;
     }
@@ -91,8 +137,18 @@ export class ReconciliationWorkerService {
     this.isRunning = true;
     try {
       const batchSize = this.config.reconciliationBatchSize;
-      this.lastReport = await this.reconciliationService.runReconciliation(batchSize);
-      return this.lastReport;
+      try {
+        this.lastReport = await this.reconciliationService.runReconciliation(batchSize);
+        return this.lastReport;
+      } catch (err) {
+        const message = (err as Error).message;
+        this.logger.error(
+          `Manual reconciliation run failed: ${message}`,
+          (err as Error).stack,
+        );
+        await this.reconciliationService.recordFailedRun(message, { batchSize });
+        throw err;
+      }
     } finally {
       this.isRunning = false;
     }

--- a/app/backend/src/reconciliation/reconciliation.controller.ts
+++ b/app/backend/src/reconciliation/reconciliation.controller.ts
@@ -18,7 +18,8 @@ import { ReconciliationWorkerService } from './reconciliation-worker.service';
 import { BackfillService, BackfillConfig, BackfillProgress, BackfillResult } from './backfill.service';
 import { AutoMatchService } from './auto-match.service';
 import { UnmatchedQueueRepository } from './unmatched-queue.repository';
-import { ReconciliationReport } from './types/reconciliation.types';
+import { ReconciliationRunRepository } from './reconciliation-run.repository';
+import { ReconciliationReport, ReconciliationRunStatus } from './types/reconciliation.types';
 import type { IncomingTransaction, MatchResult } from './types/auto-match.types';
 import { NetworkSafetyGuard } from '../feature-flags/network-safety.guard';
 import { RequiresFlag } from '../feature-flags/requires-flag.decorator';
@@ -35,7 +36,51 @@ export class ReconciliationController {
     private readonly backfill: BackfillService,
     private readonly autoMatch: AutoMatchService,
     private readonly unmatchedQueue: UnmatchedQueueRepository,
+    private readonly runHistory: ReconciliationRunRepository,
   ) {}
+
+  // ─── Run history (BE-124) ─────────────────────────────────────────────────
+
+  @Get('history')
+  @ApiOperation({ summary: 'List reconciliation run history with per-run summaries (operators only)' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Max rows (1–100, default 20)' })
+  @ApiQuery({ name: 'offset', required: false, type: Number, description: 'Zero-based row offset (default 0)' })
+  @ApiQuery({ name: 'status', required: false, enum: ['success', 'drift', 'failed', 'skipped'], description: 'Filter by run status' })
+  @ApiResponse({ status: 200, description: 'Paginated reconciliation run history' })
+  async listHistory(
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+    @Query('status') status?: string,
+  ) {
+    const parsedLimit = Math.min(100, Math.max(1, parseInt(limit ?? '20', 10) || 20));
+    const parsedOffset = Math.max(0, parseInt(offset ?? '0', 10) || 0);
+    const parsedStatus = this.parseRunStatus(status);
+    return this.runHistory.listRuns({
+      limit: parsedLimit,
+      offset: parsedOffset,
+      status: parsedStatus,
+    });
+  }
+
+  @Get('history/:runId')
+  @ApiOperation({ summary: 'Get a single reconciliation run with per-run drift detail (operators only)' })
+  @ApiResponse({ status: 200, description: 'Reconciliation run summary and drift detail' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  async getRun(@Param('runId') runId: string) {
+    const summary = await this.runHistory.findById(runId);
+    if (!summary) {
+      throw new NotFoundException(`Reconciliation run ${runId} not found`);
+    }
+    return summary;
+  }
+
+  private parseRunStatus(status?: string): ReconciliationRunStatus | undefined {
+    if (!status) return undefined;
+    if (status === 'success' || status === 'drift' || status === 'failed' || status === 'skipped') {
+      return status;
+    }
+    return undefined;
+  }
 
   // ─── Existing reconciliation endpoints ──────────────────────────────────────
 

--- a/app/backend/src/reconciliation/reconciliation.controller.unit.spec.ts
+++ b/app/backend/src/reconciliation/reconciliation.controller.unit.spec.ts
@@ -5,6 +5,7 @@ import { ReconciliationWorkerService } from "./reconciliation-worker.service";
 import { BackfillService } from "./backfill.service";
 import { AutoMatchService } from "./auto-match.service";
 import { UnmatchedQueueRepository } from "./unmatched-queue.repository";
+import { ReconciliationRunRepository } from "./reconciliation-run.repository";
 import { NetworkSafetyGuard } from "../feature-flags/network-safety.guard";
 
 describe("ReconciliationController", () => {
@@ -13,6 +14,7 @@ describe("ReconciliationController", () => {
   let backfill: jest.Mocked<BackfillService>;
   let autoMatch: jest.Mocked<AutoMatchService>;
   let unmatchedQueue: jest.Mocked<UnmatchedQueueRepository>;
+  let runHistory: jest.Mocked<ReconciliationRunRepository>;
 
   beforeEach(async () => {
     const mockWorker = {
@@ -39,6 +41,11 @@ describe("ReconciliationController", () => {
       dismiss: jest.fn(),
     };
 
+    const mockRunHistory = {
+      listRuns: jest.fn(),
+      findById: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ReconciliationController],
       providers: [
@@ -46,6 +53,7 @@ describe("ReconciliationController", () => {
         { provide: BackfillService, useValue: mockBackfill },
         { provide: AutoMatchService, useValue: mockAutoMatch },
         { provide: UnmatchedQueueRepository, useValue: mockUnmatchedQueue },
+        { provide: ReconciliationRunRepository, useValue: mockRunHistory },
       ],
     })
       .overrideGuard(NetworkSafetyGuard)
@@ -61,6 +69,9 @@ describe("ReconciliationController", () => {
     unmatchedQueue = module.get(
       UnmatchedQueueRepository,
     ) as jest.Mocked<UnmatchedQueueRepository>;
+    runHistory = module.get(
+      ReconciliationRunRepository,
+    ) as jest.Mocked<ReconciliationRunRepository>;
   });
 
   it("should be defined", () => {
@@ -295,6 +306,75 @@ describe("ReconciliationController", () => {
       await expect(
         controller.dismissUnmatched("missing", { resolvedBy: "GABC" }),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("run history (BE-124)", () => {
+    it("lists runs with parsing and clamping of pagination", async () => {
+      runHistory.listRuns.mockResolvedValue({
+        items: [],
+        total: 0,
+        hasMore: false,
+      } as never);
+
+      await controller.listHistory("500", "0", undefined);
+
+      expect(runHistory.listRuns).toHaveBeenCalledWith({
+        limit: 100,
+        offset: 0,
+        status: undefined,
+      });
+    });
+
+    it("passes through a valid status filter", async () => {
+      runHistory.listRuns.mockResolvedValue({
+        items: [],
+        total: 0,
+        hasMore: false,
+      } as never);
+
+      await controller.listHistory("10", "0", "drift");
+
+      expect(runHistory.listRuns).toHaveBeenCalledWith({
+        limit: 10,
+        offset: 0,
+        status: "drift",
+      });
+    });
+
+    it("ignores an invalid status filter", async () => {
+      runHistory.listRuns.mockResolvedValue({
+        items: [],
+        total: 0,
+        hasMore: false,
+      } as never);
+
+      await controller.listHistory("10", "0", "not-a-status");
+
+      expect(runHistory.listRuns).toHaveBeenCalledWith({
+        limit: 10,
+        offset: 0,
+        status: undefined,
+      });
+    });
+
+    it("returns a single run summary when found", async () => {
+      runHistory.findById.mockResolvedValue({
+        runId: "run-1",
+        status: "drift",
+      } as never);
+
+      const result = await controller.getRun("run-1");
+
+      expect(result).toEqual({ runId: "run-1", status: "drift" });
+    });
+
+    it("throws NotFoundException when run not found", async () => {
+      runHistory.findById.mockResolvedValue(null);
+
+      await expect(controller.getRun("missing")).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/app/backend/src/reconciliation/reconciliation.module.ts
+++ b/app/backend/src/reconciliation/reconciliation.module.ts
@@ -8,11 +8,13 @@ import { JobQueueModule } from "../job-queue/job-queue.module";
 import { FeatureFlagsModule } from "../feature-flags/feature-flags.module";
 import { AuditModule } from "../audit/audit.module";
 import { PreviewScopeModule } from "../preview-scope/preview-scope.module";
+import { SentryModule } from "../sentry";
 import { ReconciliationService } from "./reconciliation.service";
 import { ReconciliationWorkerService } from "./reconciliation-worker.service";
 import { BackfillService } from "./backfill.service";
 import { AutoMatchService } from "./auto-match.service";
 import { UnmatchedQueueRepository } from "./unmatched-queue.repository";
+import { ReconciliationRunRepository } from "./reconciliation-run.repository";
 import { ReconciliationController } from "./reconciliation.controller";
 
 @Module({
@@ -20,6 +22,7 @@ import { ReconciliationController } from "./reconciliation.controller";
     AppConfigModule,
     SupabaseModule,
     MetricsModule,
+    SentryModule,
     IngestionModule,
     forwardRef(() => JobQueueModule),
     FeatureFlagsModule,
@@ -32,6 +35,7 @@ import { ReconciliationController } from "./reconciliation.controller";
     BackfillService,
     AutoMatchService,
     UnmatchedQueueRepository,
+    ReconciliationRunRepository,
   ],
   controllers: [ReconciliationController],
   exports: [
@@ -40,6 +44,7 @@ import { ReconciliationController } from "./reconciliation.controller";
     BackfillService,
     AutoMatchService,
     UnmatchedQueueRepository,
+    ReconciliationRunRepository,
   ],
 })
 export class ReconciliationModule {}

--- a/app/backend/src/reconciliation/reconciliation.service.ts
+++ b/app/backend/src/reconciliation/reconciliation.service.ts
@@ -5,6 +5,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { AppConfigService } from '../config/app-config.service';
 import { SupabaseService } from '../supabase/supabase.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { SentryService } from '../sentry/sentry.service';
+import { ReconciliationRunRepository } from './reconciliation-run.repository';
 import {
   EscrowDbStatus,
   EscrowRecord,
@@ -14,13 +16,22 @@ import {
   PaymentRecord,
   PaymentReconciliationResult,
   ReconciliationAction,
+  ReconciliationDriftDetail,
   ReconciliationReport,
+  ReconciliationRunStatus,
+  ReconciliationRunSummary,
 } from './types/reconciliation.types';
 
 @Injectable()
 export class ReconciliationService {
   private readonly logger = new Logger(ReconciliationService.name);
   private readonly server: Horizon.Server;
+
+  /**
+   * Tracks whether the consecutive failed/skipped run alert is currently
+   * firing, so it is raised once per streak instead of on every tick (BE-124).
+   */
+  private consecutiveFailureAlerted = false;
 
   /** Statuses that need to be reconciled against the chain. */
   private readonly ACTIONABLE_ESCROW_STATUSES: EscrowDbStatus[] = [
@@ -37,6 +48,8 @@ export class ReconciliationService {
     private readonly config: AppConfigService,
     private readonly supabase: SupabaseService,
     private readonly metrics: MetricsService,
+    private readonly runRepository: ReconciliationRunRepository,
+    private readonly sentry: SentryService,
   ) {
     const horizonUrl =
       config.network === 'mainnet'
@@ -80,8 +93,20 @@ export class ReconciliationService {
     // Add totals comparison for payments
     report.totalsComparison = await this.comparePaymentTotals(runId);
 
-    // Generate alert if discrepancies exceed threshold
-    report.alert = this.generateDiscrepancyAlert(report);
+    // Classify the run (clean vs drift) and raise an alert when configured
+    // drift thresholds are exceeded (BE-124).
+    const classification = this.classifyRun(report);
+    report.alert = classification.alert;
+    this.metrics.setReconciliationDriftActive(
+      classification.status === 'drift' ? 1 : 0,
+    );
+
+    // Persist a summary for this run. Persistence is best-effort — a failed
+    // history write must never take down reconciliation itself.
+    await this.persistRunSummary(report, classification, batchSize);
+
+    // A completed (even drift-flagged) run breaks any consecutive-failure streak.
+    await this.evaluateConsecutiveFailures();
 
     this.logReport(report);
     return report;
@@ -408,8 +433,20 @@ export class ReconciliationService {
         BigInt(expectedTotalAmount) - BigInt(observedTotalAmount)
       ).toString();
 
-      // Threshold: alert if count discrepancy > 5 or amount discrepancy > 0
-      const exceedsThreshold = countDiscrepancy > 5 || amountDiscrepancy !== '0';
+      // Drift thresholds are configurable (BE-124): alert when the count
+      // discrepancy exceeds the configured count threshold or the absolute
+      // amount discrepancy exceeds the configured stroop threshold.
+      const countThreshold = this.config.reconciliationDriftCountThreshold;
+      const amountThreshold = BigInt(
+        this.config.reconciliationDriftAmountThresholdStroops,
+      );
+      const absAmountDiscrepancy = amountDiscrepancy.startsWith('-')
+        ? -BigInt(amountDiscrepancy)
+        : BigInt(amountDiscrepancy);
+
+      const exceedsThreshold =
+        countDiscrepancy > countThreshold ||
+        absAmountDiscrepancy > amountThreshold;
 
       this.logger.log(
         `[${runId}] Payment totals comparison: expected=${expectedCount}/${expectedTotalAmount}, observed=${observedCount}/${observedTotalAmount}, exceedsThreshold=${exceedsThreshold}`,
@@ -435,37 +472,255 @@ export class ReconciliationService {
   }
 
   /**
-   * Generate alert if discrepancies exceed configured threshold.
+   * Classify a finished run as clean or drifting and, when drift exceeds the
+   * configured thresholds, raise an alert through the monitoring path
+   * (metrics + Sentry + structured logs).
    */
-  private generateDiscrepancyAlert(report: ReconciliationReport): { severity: 'critical' | 'warning'; message: string; details: string } | undefined {
+  private classifyRun(
+    report: ReconciliationReport,
+  ): { status: Extract<ReconciliationRunStatus, 'success' | 'drift'>; alert?: ReconciliationReport['alert'] } {
     if (!report.totalsComparison?.payments.exceedsThreshold) {
-      return undefined;
+      return { status: 'success' };
     }
 
-    const { payments } = report.totalsComparison;
-    const { countDiscrepancy, amountDiscrepancy } = payments;
+    const { countDiscrepancy, amountDiscrepancy } = report.totalsComparison.payments;
 
-    // Critical if amount discrepancy or high count discrepancy
-    const isCritical = amountDiscrepancy !== '0' || countDiscrepancy > 10;
+    const amountThreshold = BigInt(
+      this.config.reconciliationDriftAmountThresholdStroops,
+    );
+    const absAmountDiscrepancy = amountDiscrepancy.startsWith('-')
+      ? -BigInt(amountDiscrepancy)
+      : BigInt(amountDiscrepancy);
+    const amountExceeds = absAmountDiscrepancy > amountThreshold;
 
-    const message = isCritical
-      ? 'Critical payment discrepancy detected'
-      : 'Payment discrepancy detected';
+    // Critical when money is off (amount drift) or the count discrepancy is
+    // more than double the configured count threshold; otherwise a warning.
+    const isCritical =
+      amountExceeds || countDiscrepancy > this.config.reconciliationDriftCountThreshold * 2;
 
-    const details = `Count discrepancy: ${countDiscrepancy}, Amount discrepancy: ${amountDiscrepancy}`;
+    const alert: ReconciliationReport['alert'] = {
+      severity: isCritical ? 'critical' : 'warning',
+      message: isCritical
+        ? 'Critical payment discrepancy detected'
+        : 'Payment discrepancy detected',
+      details: `Count discrepancy: ${countDiscrepancy}, Amount discrepancy: ${amountDiscrepancy}`,
+    };
 
-    this.logger.error(
-      `[${report.runId}] ${message}: ${details}`,
+    this.raiseDriftAlert(report.runId, alert);
+    return { status: 'drift', alert };
+  }
+
+  private raiseDriftAlert(runId: string, alert: ReconciliationReport['alert']): void {
+    if (!alert) return;
+
+    this.logger.error(`[${runId}] ${alert.message}: ${alert.details}`);
+
+    this.metrics.recordError(
+      'reconciliation',
+      alert.severity === 'critical' ? 'critical_drift' : 'warning_drift',
     );
 
-    // Record metric for alert
-    this.metrics.recordError('reconciliation', isCritical ? 'critical_discrepancy' : 'warning_discrepancy');
+    this.sentry.captureMessage(
+      `[reconciliation] ${alert.message}`,
+      alert.severity === 'critical' ? 'fatal' : 'warning',
+      {
+        runId,
+        details: alert.details,
+        severity: alert.severity,
+      },
+    );
+  }
 
-    return {
-      severity: isCritical ? ('critical' as const) : ('warning' as const),
-      message,
-      details,
+  // ---------------------------------------------------------------------------
+  // BE-124: Run history persistence + consecutive failure alerting
+  // ---------------------------------------------------------------------------
+
+  private async persistRunSummary(
+    report: ReconciliationReport,
+    classification: { status: ReconciliationRunStatus; alert?: ReconciliationReport['alert'] },
+    batchSize: number,
+  ): Promise<void> {
+    const totals = report.totalsComparison?.payments;
+
+    const summary: ReconciliationRunSummary = {
+      runId: report.runId,
+      status: classification.status,
+      batchSize,
+      startedAt: report.startedAt,
+      completedAt: report.completedAt,
+      durationMs: report.durationMs,
+      escrowsProcessed: report.escrows.processed,
+      escrowsIrreconcilable: report.escrows.irreconcilable,
+      paymentsProcessed: report.payments.processed,
+      paymentsIrreconcilable: report.payments.irreconcilable,
+      countDiscrepancy: totals?.countDiscrepancy ?? 0,
+      amountDiscrepancy: totals?.amountDiscrepancy ?? '0',
+      driftExceeded: totals?.exceedsThreshold ?? false,
+      alertSeverity: classification.alert?.severity,
+      alertMessage: classification.alert?.message,
+      driftDetails: this.buildDriftDetails(report),
     };
+
+    try {
+      await this.runRepository.save(summary);
+    } catch (err) {
+      this.logger.warn(
+        `[${report.runId}] Failed to persist run summary: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  private buildDriftDetails(report: ReconciliationReport): ReconciliationDriftDetail[] {
+    const details: ReconciliationDriftDetail[] = [];
+
+    for (const r of report.escrows.results) {
+      if (r.action === ReconciliationAction.NoOp) continue;
+      details.push({
+        entityType: 'escrow',
+        id: r.id,
+        onChainState: r.onChainState,
+        previousDbStatus: r.previousDbStatus,
+        resolvedDbStatus: r.resolvedDbStatus,
+        action: r.action,
+        irreconcilableReason: r.irreconcilableReason,
+      });
+    }
+
+    for (const r of report.payments.results) {
+      if (r.action === ReconciliationAction.NoOp) continue;
+      details.push({
+        entityType: 'payment',
+        id: r.id,
+        onChainState: r.onChainState,
+        previousDbStatus: r.previousDbStatus,
+        resolvedDbStatus: r.resolvedDbStatus,
+        action: r.action,
+        irreconcilableReason: r.irreconcilableReason,
+      });
+    }
+
+    return details;
+  }
+
+  /**
+   * Persist a failed run (e.g. a job execution failure, enqueue failure, or
+   * manual-trigger exception) so the consecutive-failure alerting path can
+   * see it. Best-effort — never throws back to the caller.
+   */
+  async recordFailedRun(
+    failureReason: string,
+    context?: { batchSize?: number },
+  ): Promise<void> {
+    const runId = uuidv4();
+    this.logger.error(`[${runId}] Reconciliation run failed: ${failureReason}`);
+    this.metrics.recordError('reconciliation', 'run_failed');
+
+    const summary: ReconciliationRunSummary = {
+      runId,
+      status: 'failed',
+      batchSize: context?.batchSize,
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      durationMs: null,
+      escrowsProcessed: 0,
+      escrowsIrreconcilable: 0,
+      paymentsProcessed: 0,
+      paymentsIrreconcilable: 0,
+      countDiscrepancy: 0,
+      amountDiscrepancy: '0',
+      driftExceeded: false,
+      failureReason,
+      driftDetails: [],
+    };
+
+    try {
+      await this.runRepository.save(summary);
+    } catch (err) {
+      this.logger.warn(
+        `[${runId}] Failed to persist failed run summary: ${(err as Error).message}`,
+      );
+    }
+
+    await this.evaluateConsecutiveFailures();
+  }
+
+  /**
+   * Persist a skipped run (e.g. a cron tick skipped because a previous run was
+   * still in progress) so the consecutive-failure alerting path can see it.
+   */
+  async recordSkippedRun(
+    skippedReason: string,
+    context?: { batchSize?: number },
+  ): Promise<void> {
+    const runId = uuidv4();
+    this.logger.warn(`[${runId}] Reconciliation run skipped: ${skippedReason}`);
+    this.metrics.recordError('reconciliation', 'run_skipped');
+
+    const summary: ReconciliationRunSummary = {
+      runId,
+      status: 'skipped',
+      batchSize: context?.batchSize,
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      durationMs: null,
+      escrowsProcessed: 0,
+      escrowsIrreconcilable: 0,
+      paymentsProcessed: 0,
+      paymentsIrreconcilable: 0,
+      countDiscrepancy: 0,
+      amountDiscrepancy: '0',
+      driftExceeded: false,
+      skippedReason,
+      driftDetails: [],
+    };
+
+    try {
+      await this.runRepository.save(summary);
+    } catch (err) {
+      this.logger.warn(
+        `[${runId}] Failed to persist skipped run summary: ${(err as Error).message}`,
+      );
+    }
+
+    await this.evaluateConsecutiveFailures();
+  }
+
+  /**
+   * Evaluate the current consecutive failed/skipped run streak and raise an
+   * alert when it reaches the configured threshold. The alert fires once per
+   * new streak (not on every tick) so operators are not spammed.
+   */
+  async evaluateConsecutiveFailures(): Promise<void> {
+    let consecutive: number;
+    try {
+      consecutive = await this.runRepository.countConsecutiveIncompleteRuns();
+    } catch (err) {
+      this.logger.warn(
+        `Unable to read reconciliation run history: ${(err as Error).message}`,
+      );
+      return;
+    }
+
+    this.metrics.setReconciliationConsecutiveFailures(consecutive);
+
+    const threshold = this.config.reconciliationConsecutiveFailureAlertThreshold;
+
+    if (consecutive >= threshold && !this.consecutiveFailureAlerted) {
+      this.consecutiveFailureAlerted = true;
+      const message =
+        `Reconciliation has ${consecutive} consecutive failed/skipped run(s) ` +
+        `(threshold: ${threshold})`;
+
+      this.logger.error(message);
+      this.metrics.recordError('reconciliation', 'consecutive_failures');
+      this.sentry.captureMessage(
+        `[reconciliation] ${message}`,
+        'warning',
+        { consecutiveFailures: consecutive, threshold },
+      );
+    } else if (consecutive < threshold) {
+      this.consecutiveFailureAlerted = false;
+    }
   }
 
   private logReport(report: ReconciliationReport): void {

--- a/app/backend/src/reconciliation/reconciliation.service.unit.spec.ts
+++ b/app/backend/src/reconciliation/reconciliation.service.unit.spec.ts
@@ -1,0 +1,285 @@
+import { ReconciliationService } from './reconciliation.service';
+import { ReconciliationRunRepository } from './reconciliation-run.repository';
+import { AppConfigService } from '../config/app-config.service';
+import { SupabaseService } from '../supabase/supabase.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { SentryService } from '../sentry/sentry.service';
+import { ReconciliationAction, ReconciliationReport } from './types/reconciliation.types';
+
+describe('ReconciliationService (BE-124)', () => {
+  let service: ReconciliationService;
+
+  const config = {
+    network: 'testnet',
+    reconciliationBatchSize: 50,
+    reconciliationDriftCountThreshold: 5,
+    reconciliationDriftAmountThresholdStroops: '0',
+    reconciliationConsecutiveFailureAlertThreshold: 3,
+  };
+
+  const supabase = {
+    fetchPendingEscrows: jest.fn(),
+    fetchPendingPayments: jest.fn(),
+    fetchPaidPayments: jest.fn(),
+  };
+
+  const metrics = {
+    recordExternalCall: jest.fn(),
+    recordError: jest.fn(),
+    setReconciliationDriftActive: jest.fn(),
+    setReconciliationConsecutiveFailures: jest.fn(),
+  };
+
+  const sentry = {
+    captureMessage: jest.fn(),
+    captureException: jest.fn(),
+  };
+
+  const runRepository = {
+    save: jest.fn().mockResolvedValue(undefined),
+    countConsecutiveIncompleteRuns: jest.fn().mockResolvedValue(0),
+    listRuns: jest.fn(),
+    findById: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    supabase.fetchPendingEscrows.mockResolvedValue([]);
+    supabase.fetchPendingPayments.mockResolvedValue([]);
+    supabase.fetchPaidPayments.mockResolvedValue([]);
+
+    service = new ReconciliationService(
+      config as unknown as AppConfigService,
+      supabase as unknown as SupabaseService,
+      metrics as unknown as MetricsService,
+      runRepository as unknown as ReconciliationRunRepository,
+      sentry as unknown as SentryService,
+    );
+  });
+
+  describe('clean run', () => {
+    it('classifies as success, persists a summary, and raises no alert', async () => {
+      const report: ReconciliationReport = await service.runReconciliation(10);
+
+      expect(report.alert).toBeUndefined();
+      expect(report.totalsComparison?.payments.exceedsThreshold).toBe(false);
+
+      expect(runRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          driftExceeded: false,
+          escrowsProcessed: 0,
+          paymentsProcessed: 0,
+        }),
+      );
+      expect(sentry.captureMessage).not.toHaveBeenCalled();
+      expect(metrics.setReconciliationDriftActive).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('drift over threshold', () => {
+    it('classifies as drift, raises a critical alert, and persists drift detail', async () => {
+      // Simulate an observed payment total that diverges from the DB.
+      (service as unknown as {
+        comparePaymentTotals: () => Promise<unknown>;
+      }).comparePaymentTotals = jest.fn().mockResolvedValue({
+        payments: {
+          expectedCount: 100,
+          observedCount: 80,
+          countDiscrepancy: 20,
+          expectedTotalAmount: '1000000',
+          observedTotalAmount: '900000',
+          amountDiscrepancy: '100000',
+          exceedsThreshold: true,
+        },
+      });
+
+      const report: ReconciliationReport = await service.runReconciliation(10);
+
+      expect(report.alert).toBeDefined();
+      expect(report.alert?.severity).toBe('critical');
+
+      expect(metrics.recordError).toHaveBeenCalledWith(
+        'reconciliation',
+        'critical_drift',
+      );
+      expect(sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Critical payment discrepancy'),
+        'fatal',
+        expect.objectContaining({ runId: report.runId }),
+      );
+
+      expect(runRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'drift',
+          driftExceeded: true,
+          countDiscrepancy: 20,
+          amountDiscrepancy: '100000',
+          alertSeverity: 'critical',
+        }),
+      );
+      expect(metrics.setReconciliationDriftActive).toHaveBeenCalledWith(1);
+    });
+
+    it('under the threshold classifies as success with no alert', async () => {
+      (service as unknown as {
+        comparePaymentTotals: () => Promise<unknown>;
+      }).comparePaymentTotals = jest.fn().mockResolvedValue({
+        payments: {
+          expectedCount: 10,
+          observedCount: 7,
+          countDiscrepancy: 3,
+          expectedTotalAmount: '1000',
+          observedTotalAmount: '1000',
+          amountDiscrepancy: '0',
+          exceedsThreshold: false,
+        },
+      });
+
+      const report: ReconciliationReport = await service.runReconciliation(10);
+
+      expect(report.alert).toBeUndefined();
+      expect(runRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'success' }),
+      );
+      expect(sentry.captureMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('run failure', () => {
+    it('persists a failed summary and alerts when consecutive failures reach the threshold', async () => {
+      // Three most recent runs are all failed/skipped.
+      runRepository.countConsecutiveIncompleteRuns.mockResolvedValue(3);
+
+      await service.recordFailedRun('Horizon unavailable');
+
+      expect(runRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'failed',
+          failureReason: 'Horizon unavailable',
+        }),
+      );
+
+      expect(metrics.recordError).toHaveBeenCalledWith(
+        'reconciliation',
+        'consecutive_failures',
+      );
+      expect(sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('3 consecutive failed/skipped run(s)'),
+        'warning',
+        expect.objectContaining({ consecutiveFailures: 3, threshold: 3 }),
+      );
+    });
+
+    it('does not alert when the streak is below the threshold', async () => {
+      runRepository.countConsecutiveIncompleteRuns.mockResolvedValue(2);
+
+      await service.recordFailedRun('temporary glitch');
+
+      expect(metrics.recordError).not.toHaveBeenCalledWith(
+        'reconciliation',
+        'consecutive_failures',
+      );
+      expect(sentry.captureMessage).not.toHaveBeenCalled();
+    });
+
+    it('alerts only once per streak', async () => {
+      runRepository.countConsecutiveIncompleteRuns.mockResolvedValue(3);
+
+      await service.recordFailedRun('failure 1');
+      await service.recordFailedRun('failure 2');
+
+      expect(
+        sentry.captureMessage.mock.calls.filter(([msg]) =>
+          String(msg).includes('consecutive failed/skipped'),
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('records skipped runs the same way', async () => {
+      runRepository.countConsecutiveIncompleteRuns.mockResolvedValue(3);
+
+      await service.recordSkippedRun('Previous run still in progress');
+
+      expect(runRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'skipped',
+          skippedReason: 'Previous run still in progress',
+        }),
+      );
+      expect(sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('3 consecutive'),
+        'warning',
+        expect.anything(),
+      );
+    });
+
+    it('resets the consecutive-failure alert once a run completes', async () => {
+      runRepository.countConsecutiveIncompleteRuns
+        .mockResolvedValueOnce(3) // failed streak
+        .mockResolvedValueOnce(3) // second failure in same streak
+        .mockResolvedValueOnce(0); // clean run after
+
+      await service.recordFailedRun('failure 1');
+      await service.recordFailedRun('failure 2');
+      await service.runReconciliation(10);
+
+      expect(runRepository.save).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: 'success' }),
+      );
+
+      // A fresh streak re-triggers the alert.
+      runRepository.countConsecutiveIncompleteRuns.mockResolvedValue(3);
+      await service.recordFailedRun('failure 3');
+      expect(sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('consecutive failed/skipped'),
+        'warning',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('buildDriftDetails', () => {
+    it('collapses non-actionable records to NoOp', () => {
+      const report = {
+        runId: 'r1',
+        escrows: {
+          results: [
+            {
+              id: 'e1',
+              onChainState: 'non_existent',
+              previousDbStatus: 'pending',
+              resolvedDbStatus: null,
+              action: ReconciliationAction.Flagged,
+              irreconcilable: true,
+              irreconcilableReason: 'account missing',
+            },
+            {
+              id: 'e2',
+              onChainState: 'active',
+              previousDbStatus: 'active',
+              resolvedDbStatus: 'active',
+              action: ReconciliationAction.NoOp,
+            },
+          ],
+        },
+        payments: { results: [] },
+      } as unknown as ReconciliationReport;
+
+      const details = (service as unknown as {
+        buildDriftDetails: (report: ReconciliationReport) => unknown[];
+      }).buildDriftDetails(report);
+
+      expect(details).toHaveLength(1);
+      expect(details[0]).toEqual(
+        expect.objectContaining({
+          entityType: 'escrow',
+          id: 'e1',
+          action: ReconciliationAction.Flagged,
+          irreconcilableReason: 'account missing',
+        }),
+      );
+    });
+  });
+});

--- a/app/backend/src/reconciliation/types/reconciliation.types.ts
+++ b/app/backend/src/reconciliation/types/reconciliation.types.ts
@@ -144,3 +144,46 @@ export interface ReconciliationReport {
     details: string;
   };
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// BE-124: Persisted run history + drift alerting
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Outcome of a reconciliation run once classified for persistence/alerting. */
+export type ReconciliationRunStatus = 'success' | 'drift' | 'failed' | 'skipped';
+
+/**
+ * Per-record drift detail persisted with each run so operators can see exactly
+ * which escrows/payments diverged and why, without a separate report store.
+ */
+export interface ReconciliationDriftDetail {
+  entityType: 'escrow' | 'payment';
+  id: string;
+  onChainState: OnChainState;
+  previousDbStatus: string | null;
+  resolvedDbStatus: string | null;
+  action: ReconciliationAction;
+  irreconcilableReason?: string;
+}
+
+/** Persistent summary of a single reconciliation run (BE-124). */
+export interface ReconciliationRunSummary {
+  runId: string;
+  status: ReconciliationRunStatus;
+  batchSize?: number;
+  startedAt: string;
+  completedAt: string | null;
+  durationMs: number | null;
+  escrowsProcessed: number;
+  escrowsIrreconcilable: number;
+  paymentsProcessed: number;
+  paymentsIrreconcilable: number;
+  countDiscrepancy: number;
+  amountDiscrepancy: string;
+  driftExceeded: boolean;
+  alertSeverity?: 'warning' | 'critical';
+  alertMessage?: string;
+  failureReason?: string;
+  skippedReason?: string;
+  driftDetails: ReconciliationDriftDetail[];
+}

--- a/app/backend/supabase/migrations/20260830000000_create_reconciliation_runs.sql
+++ b/app/backend/supabase/migrations/20260830000000_create_reconciliation_runs.sql
@@ -1,0 +1,45 @@
+-- BE-124: Scheduled reconciliation run history with drift alerting.
+--
+-- Persists a summary row for every scheduled/manual reconciliation run so
+-- operators can inspect run history, per-run drift detail, and consecutive
+-- failure streaks without digging through logs.
+
+create table if not exists reconciliation_runs (
+  run_id                  uuid        primary key,
+  status                  text        not null check (status in ('success', 'drift', 'failed', 'skipped')),
+  batch_size              integer,
+  started_at              timestamptz not null,
+  completed_at            timestamptz,
+  duration_ms             bigint,
+
+  escrows_processed       integer     not null default 0,
+  escrows_irreconcilable  integer     not null default 0,
+  payments_processed      integer     not null default 0,
+  payments_irreconcilable integer     not null default 0,
+
+  count_discrepancy       integer     not null default 0,
+  amount_discrepancy      text        not null default '0',
+  drift_exceeded          boolean     not null default false,
+
+  alert_severity          text        check (alert_severity in ('warning', 'critical')),
+  alert_message           text,
+  failure_reason          text,
+  skipped_reason          text,
+
+  -- Per-record drift detail (irreconcilable / updated / skipped records),
+  -- stored as JSON so the shape can evolve without a migration.
+  drift_details           jsonb       not null default '[]'::jsonb,
+
+  created_at              timestamptz not null default now()
+);
+
+-- Operator query indexes: newest runs first, by status, and single-run lookup.
+create index if not exists idx_reconciliation_runs_started_at
+  on reconciliation_runs (started_at desc);
+
+create index if not exists idx_reconciliation_runs_status_started_at
+  on reconciliation_runs (status, started_at desc);
+
+-- Consecutive failure streak computation scans the newest runs first.
+create index if not exists idx_reconciliation_runs_run_id
+  on reconciliation_runs (run_id);


### PR DESCRIPTION
## Closes

Closes #823 (BE-124: Scheduled Reconciliation Run with Drift Alerting)

## What

Turns reconciliation from a hard-coded every-5-minutes cron into a fully scheduled, monitorable job:

1. **Configurable schedule & thresholds** — the schedule and all alerting thresholds are now env-driven (no deploy needed to change them):
   - `RECONCILIATION_ENABLED` (default `true`) — toggle the scheduled worker
   - `RECONCILIATION_CRON_EXPRESSION` (default `*/5 * * * *`) — cron expression for scheduled runs
   - `RECONCILIATION_DRIFT_COUNT_THRESHOLD` (default `5`) — payment count discrepancy that raises a drift alert
   - `RECONCILIATION_DRIFT_AMOUNT_THRESHOLD_STROOPS` (default `0`) — amount discrepancy (stroops) that raises a drift alert; kept as a string for lossless BigInt comparison
   - `RECONCILIATION_CONSECUTIVE_FAILURE_ALERT_THRESHOLD` (default `3`) — consecutive failed/skipped runs that raise an alert

2. **Per-run summaries persisted to a new `reconciliation_runs` table** (see migration) — status (`success`/`drift`/`failed`/`skipped`), processed/irreconcilable counters, count/amount discrepancy, alert severity/message, failure/skip reason, and per-record drift detail (JSONB). Persistence is best-effort so a history write failure never breaks reconciliation.

3. **Drift alerting through the monitoring path** (metrics + Sentry + structured logs, not the user-facing notifications pipeline):
   - Each run is classified clean vs. drift against the configured thresholds; drift is **critical** when the amount threshold is exceeded or the count discrepancy is > 2× the count threshold, else a **warning**.
   - `reconciliation_drift_active` gauge is set to `0`/`1` after each run.
   - Alerts raise `recordError('reconciliation', 'critical_drift' | 'warning_drift')`, a Sentry `captureMessage`, and an error-level log.
   - Failed/skipped runs (`recordFailedRun`/`recordSkippedRun`) are persisted, the `reconciliation_consecutive_failures` gauge tracks the current streak, and a Sentry warning fires once per streak when it reaches the threshold (deduped so operators are not spammed every tick).

4. **Run history queryable by operators**:
   - `GET /reconciliation/history?limit=&offset=&status=` — paginated, newest-first, optional status filter
   - `GET /reconciliation/history/:runId` — single run summary with drift detail (404 when not found)

5. **Scheduling** — the worker now builds a dynamic [`CronJob`](https://www.npmjs.com/package/cron) at `onModuleInit` (same pattern as the seed-reset scheduler) instead of the hard-coded `@Cron(CronExpression.EVERY_5_MINUTES)` decorator. Ticks are self-serialising: a tick that fires while a run is still in progress is recorded as `skipped` so stalled runs are alertable via the consecutive-failure path. Enqueue/execution failures record a `failed` run.

## Why

Reconciliation ran silently every 5 minutes; drift and repeated failures were only visible in logs, and there was no per-run record operators could audit.

## How tested

Unit tests added covering the acceptance criteria:

- `reconciliation.service.unit.spec.ts`:
  - clean run → `success`, summary persisted, no alert
  - drift over threshold → `drift`, critical alert, drift detail persisted, gauges set
  - drift under threshold → `success`, no alert
  - failed run at the consecutive-failure threshold → alert with streak count
  - failed run below threshold → no thematic alert
  - alert fires only once per streak, resets after a clean run
  - skipped runs are recorded the same way; `buildDriftDetails` collapses non-actionable records
- `reconciliation.controller.unit.spec.ts`: pagination clamping, status filter validation, single-run lookup, 404s.

Note: dependency install/`npm test`/typecheck were **not** run in this branch (per instruction); the unit specs were written to match the existing jest + ts-jest config (`testRegex .*\.unit\.spec\.ts$`, `jest.setup.ts` env vars). **Please run `cd app/backend && npm run test:unit` (or equivalent) in CI/on merge.**

## Migration

Apply `app/backend/supabase/migrations/20260830000000_create_reconciliation_runs.sql` to the target database. It creates the `reconciliation_runs` table plus indexes for newest-first listing, status filtering, and single-run lookup.

## Files changed

- `app/backend/src/config/env.schema.ts` / `app/backend/src/config/app-config.service.ts` / `.env.example` — new `RECONCILIATION_*` config
- `app/backend/supabase/migrations/20260830000000_create_reconciliation_runs.sql` — new table
- `app/backend/src/reconciliation/reconciliation-run.repository.ts` — new (save / list / find / consecutive-streak)
- `app/backend/src/reconciliation/reconciliation.service.ts` — classify, persist, drift + consecutive-failure alerting
- `app/backend/src/reconciliation/reconciliation-worker.service.ts` — dynamic CronJob scheduling
- `app/backend/src/job-queue/handlers/reconciliation.handler.ts` — `onFailure` records a failed run
- `app/backend/src/reconciliation/reconciliation.controller.ts` — history endpoints
- `app/backend/src/reconciliation/reconciliation.module.ts` — register `SentryModule` + `ReconciliationRunRepository`
- `app/backend/src/metrics/metrics.service.ts` — new gauges (drift active, consecutive failures)
- `app/backend/src/reconciliation/reconciliation.service.unit.spec.ts` / `reconciliation.controller.unit.spec.ts` — tests

## Notes

- The alert path intentionally uses the ops monitoring stack (Prometheus metrics, Sentry, logs) instead of the user-facing `NotificationsModule`, so operators are alerted on fire without injecting a recipient key.
- Two Sentry duplicate-capture guard: Sentry import is via `../sentry` (barrel re-export of `SentryService`), matching the module structure.