### PR TITLE
docs(backend): module ownership and boundary map (DOC-W8-02)"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,9 @@ See [docs/MVP-ROADMAP.md](docs/MVP-ROADMAP.md) for the full roadmap and prioriti
 
 - Backend and Contract architecture diagrams are in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 - Check [docs/CAPABILITY-MAP.md](docs/CAPABILITY-MAP.md) to see which flows are Live, Partial, Mocked, or Experimental before building on them.
+- Before adding backend code, read [docs/BACKEND-MODULE-MAP.md](docs/BACKEND-MODULE-MAP.md) — it says what each module under `app/backend/src/` owns, which modules may depend on which, and how to decide whether your change extends an existing module or needs a new one.
+- Adding or translating user-facing copy? See [docs/LOCALIZATION-GUIDE.md](docs/LOCALIZATION-GUIDE.md) for how strings work across the frontend and mobile clients.
+- Operating a testnet environment? [docs/TESTNET-INCIDENT-RUNBOOK.md](docs/TESTNET-INCIDENT-RUNBOOK.md) covers detection, mitigation, and rollback per incident scenario.
 - See [docs/](docs/) for API, events, and payment flow documentation.
 
 ## Getting Help

--- a/RELEASE_READINESS_CHECKLIST.md
+++ b/RELEASE_READINESS_CHECKLIST.md
@@ -11,6 +11,8 @@ Related documents:
 - [app/contract/documentation/deployment-playbook.md](app/contract/documentation/deployment-playbook.md) — deploy, key management, rollback, and mitigation playbook
 - [app/mobile/RELEASE_CHECKLIST.md](app/mobile/RELEASE_CHECKLIST.md) — mobile pipeline, permissions, and privacy review
 - [app/backend/SMOKE_TESTS.md](app/backend/SMOKE_TESTS.md) — smoke test suites and remote-target usage
+- [docs/TESTNET-INCIDENT-RUNBOOK.md](docs/TESTNET-INCIDENT-RUNBOOK.md) — what to do when something breaks *after* release: detection signals, mitigation, and the specific tooling per scenario
+- [docs/BACKEND-MODULE-MAP.md](docs/BACKEND-MODULE-MAP.md) — backend module ownership and allowed dependency directions
 
 ---
 
@@ -157,8 +159,11 @@ Know the rollback path **before** shipping. In order of preference (mitigate bef
 4. **Frontend rollback**: revert to the previous Vercel deployment — see [VERCEL_DEPLOYMENT_GUIDE.md](app/frontend/VERCEL_DEPLOYMENT_GUIDE.md)
 5. **Mobile**: internal-distribution builds can be superseded by re-issuing the previous build profile; production store rollouts should be halted before promoting a replacement
 
+If an incident is already underway rather than anticipated, switch to the [Testnet Incident Response Runbook](docs/TESTNET-INCIDENT-RUNBOOK.md), which covers Soroban RPC outage, indexer lag, stuck payments, webhook backlog, and a bad contract deploy — including when to use the `testnet.contract_writes` write kill switch, and the reconciliation and support-bundle steps that close an incident out.
+
 Pre-release rollback checklist:
 
 - [ ] The previous known-good contract version/WASM hash is recorded and available in the registry history
 - [ ] The rollback or pause path for this specific release is written in the release PR
 - [ ] Monitoring hooks are in place for the rollout window: `health_check`, `get_deployment_metadata`, pause/upgrade events, schema-version mismatches, indexer lag metrics
+- [ ] The on-call operator for the rollout window knows where the [incident runbook](docs/TESTNET-INCIDENT-RUNBOOK.md) is and holds an admin-scoped API key

--- a/docs/BACKEND-MODULE-MAP.md
+++ b/docs/BACKEND-MODULE-MAP.md
@@ -1,0 +1,274 @@
+# Backend Module Ownership and Boundary Map
+
+`app/backend/src/` holds **50 top-level directories** accumulated across many waves. This document is the answer to three questions a contributor asks before writing backend code:
+
+1. **Who already owns this?** — one paragraph per module saying what it is responsible for.
+2. **May I import it from here?** — the allowed dependency directions, and which modules are shared infrastructure that anyone may depend on.
+3. **Does my change belong in an existing module or a new one?** — a decision procedure, not a vibe.
+
+It also flags the modules that are **thin, unwired, or duplicated**, so you do not build on something that is not actually serving traffic.
+
+Companion documents:
+
+- [CAPABILITY-MAP.md](./CAPABILITY-MAP.md) — whether a flow is Live / Partial / Mocked / Experimental. Read it for *maturity*; read this one for *ownership*.
+- [BACKEND-CLIENT-CONTRACT-MAP.md](./BACKEND-CLIENT-CONTRACT-MAP.md) — endpoint-level wiring between clients and the backend.
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — the cross-surface picture (frontend / backend / contracts).
+- [TESTNET-INCIDENT-RUNBOOK.md](./TESTNET-INCIDENT-RUNBOOK.md) — which of the operational modules to reach for during an incident.
+
+> **Scope note.** This document describes the tree as it exists today, including its inconsistencies. Where the current state violates the rules stated here, the violation is called out explicitly rather than quietly idealised away. Those call-outs are the backlog.
+
+---
+
+## 1. Layers
+
+Every module sits in exactly one layer. The layer determines who may import it.
+
+| Layer | Meaning | Modules |
+|---|---|---|
+| **L0 — Platform** | Framework-level concerns with no domain knowledge. Imported by anything. | `config`, `common`, `types`, `tracing`, `sentry`, `metrics`, `supabase` |
+| **L1 — Cross-cutting services** | Domain-agnostic capabilities every feature needs: identity, audit trail, gating, async work, eventing. Imported by any L2/L3 module. | `auth`, `api-keys`, `audit`, `feature-flags`, `job-queue`, `events`, `dto` |
+| **L2 — Chain access** | The only modules permitted to talk to Horizon, Soroban RPC, or read the on-chain event stream. | `stellar`, `transactions`, `ingestion`, `contracts` |
+| **L3 — Product domains** | Business features. May depend on L0–L2 and, sparingly, on named peers. | `links`, `usernames`, `payments`, `marketplace`, `refunds`, `receipts`, `fiat-ramps`, `notifications`, `analytics`, `dashboard-feed`, `transaction-timeline`, `scam-alerts`, `abuse-signals`, `asset-metadata`, `privacy`, `exports`, `reconciliation`, `developer` |
+| **L4 — Operations & environment** | Admin, diagnostics, release, and preview surfaces. May read from everything below; **nothing below may import them**. | `health`, `operations`, `indexer-lag`, `support-bundle`, `rc-validation`, `environment-parity`, `branch-preview`, `deployment-sync`, `preview-scope`, `runtime-config`, `soroban-tooling`, `manifests`, `crash-reporting`, `demos` |
+
+### The rule
+
+> **Imports point downward.** A module may import from its own layer or any layer below it. It may never import from a layer above.
+
+Two consequences worth stating plainly:
+
+- **L0 must not import L1–L4.** Platform code that knows about a product domain is no longer platform code.
+- **L4 is a sink.** `operations`, `support-bundle`, and `rc-validation` deliberately reach across many domains to assemble a diagnostic view. That is their job. It is also why nothing may depend on them — doing so would turn a read-only aggregate into a load-bearing dependency.
+
+### Known violations of the layering rule
+
+These are real, present in the tree today, and should be fixed rather than imitated:
+
+| Violation | Where | Why it is wrong |
+|---|---|---|
+| `supabase` (L0) imports reconciliation types | [supabase.service.ts:11](../app/backend/src/supabase/supabase.service.ts#L11) imports from `../reconciliation/types/reconciliation.types` | The database client should not know a product domain exists. Move the shared row shapes down into `supabase` or up into a neutral type module. |
+| `dto` (L1) imports `links` (L3) | [payment-link-status.dto.ts:2](../app/backend/src/dto/link/payment-link-status.dto.ts#L2) imports `LinkState` from `../../links/link-state-machine` | The shared DTO barrel now transitively drags in a product domain. `LinkState` is a contract shape and belongs in `dto`, with `links` importing it. |
+| Two `HorizonService` classes | [stellar/horizon.service.ts](../app/backend/src/stellar/horizon.service.ts) (88 lines) and [transactions/horizon.service.ts](../app/backend/src/transactions/horizon.service.ts) (291 lines) | Same class name, different capabilities, split consumer base. `asset-metadata`, `health`, and `soroban-tooling` use the `stellar` one; `links`, `payments`, `scam-alerts`, and `transaction-timeline` use the `transactions` one. Neither is a superset. This is the single largest source of "I could not find the existing owner" in the backend. |
+| Route-prefix collision on `links` | [links.controller.ts](../app/backend/src/links/links.controller.ts) and [scam-alerts.controller.ts](../app/backend/src/scam-alerts/scam-alerts.controller.ts) both declare `@Controller("links")` | Two modules serve sibling paths under one prefix. Route ownership is not discoverable from the URL. |
+
+---
+
+## 2. Module ownership
+
+Each entry states what the module owns, its layer, its externally served route prefix (if any), and its status. Status values:
+
+- **Active** — wired into [app.module.ts](../app/backend/src/app.module.ts) and serving.
+- **Conditional** — registered only under certain environment conditions.
+- **Unwired** — code exists, module is **not imported anywhere**; its controllers serve no traffic.
+- **Library** — intentionally has no Nest module, or is imported directly rather than registered globally.
+
+### L0 — Platform
+
+**`config`** — *Active. Library + `v1/network`.* Owns environment ingestion end to end: the Joi schema in [env.schema.ts](../app/backend/src/config/env.schema.ts) that validates every variable at boot, the typed accessor surface `AppConfigService`, and the derived config objects for CORS, rate-limit profiles, Stellar network selection, and SEP-24. Any question of the form "what is the current network / threshold / URL" is answered here, never by reading `process.env` at the point of use. It also serves `GET /v1/network` so clients can discover the network the backend is actually running against. It is the one module with zero backend dependencies.
+
+**`common`** — *Active. Library.* Owns request-lifecycle machinery shared by every route: the correlation-ID and organization-context middleware, the global HTTP exception filter and its error catalog, the idempotency store and interceptor, cursor pagination helpers, Winston logging config, redaction utilities, and the Soroban error-code mapper that turns raw contract errors into stable client-facing codes. If a behaviour must apply uniformly to all requests, it belongs here. `IdempotencyModule` lives under `common/idempotency` and is imported directly by `transactions` and `fiat-ramps` rather than registered globally.
+
+**`types`** — *Active. Library.* Owns ambient TypeScript declarations only — the augmented `Express.Request` carrying `apiKey`, `organizationContext`, and `previewScope`, plus shims for untyped dependencies. It contains no runtime code. When a guard or middleware attaches something to the request, its shape is declared here so every downstream handler sees it.
+
+**`tracing`** — *Active. Library.* Owns OpenTelemetry setup and the primitives that carry trace context: the OTel config, the `withSpan` helper, correlation baggage propagation, and `createTracedFetch`, which is how outbound HTTP (Horizon, Soroban RPC, Supabase, webhooks) gets spans without each caller instrumenting itself. It is a library rather than a Nest module because tracing must initialise before the Nest container.
+
+**`sentry`** — *Active.* Owns error reporting to Sentry: the instrumentation bootstrap that must run before anything else in [main.ts](../app/backend/src/main.ts), the exception filter that forwards unhandled errors, and the service wrapper used for explicit captures. It is first in the app module's import list for that reason.
+
+**`metrics`** — *Active. `metrics`.* Owns the Prometheus registry and every metric the backend exposes, plus the middleware and global interceptor that record HTTP volume, latency, active connections, and rate-limit rejections without per-route wiring. Domain modules record their own gauges and counters through `MetricsService` — they never construct a `prom-client` object themselves, which is what keeps metric names centrally reviewable. The `/metrics` endpoint is guarded separately from the rest of the API.
+
+**`supabase`** — *Active. Library.* Owns the single Supabase client instance, its traced `fetch`, and the error-normalisation layer that maps Postgres/PostgREST failures into typed application errors. Every module that reads or writes persistent state goes through `SupabaseService`; there is no second database client in the tree. *Boundary caveat:* it currently imports reconciliation types (see §1), which it should not.
+
+### L1 — Cross-cutting services
+
+**`auth`** — *Active. Library.* Owns request authorisation primitives with no routes of its own: `ApiKeyGuard` (validates `X-API-Key` and populates `req.apiKey`), `OrganizationRoleGuard` and `CustomThrottlerGuard` (both registered globally in the app module), and the decorators that configure them — `@RequireScopes`, `@RequireOrgRole`, `@RateLimitGroupTag`. `AuthModule` itself is not registered in `app.module.ts`; it is imported by the modules that need the guards (`job-queue`, `privacy`). Anything that decides *whether a caller may act* belongs here.
+
+**`api-keys`** — *Active. `api-keys`.* Owns the lifecycle of programmatic credentials: creation with bcrypt hashing and prefix-based lookup, scope assignment, per-key quota and rate limits, rotation, revocation, and usage counting. It is the store `auth`'s `ApiKeyGuard` reads from. The split is deliberate — `api-keys` owns the *record*, `auth` owns the *decision*.
+
+**`audit`** — *Active. `admin/audit`.* Owns the append-only record of privileged actions: `AuditService.log(actor, action, target, metadata, requestId)` plus an interceptor for automatic capture and a query endpoint for admin review. Sixteen modules write to it, which makes it the de facto forensic timeline during an incident. *Caveat:* the service also keeps an in-memory `logs` array alongside the Supabase write; treat the database as authoritative.
+
+**`feature-flags`** — *Active. `admin/feature-flags`, `feature-flags`.* Owns runtime gating: flag CRUD, cached evaluation, an uncached `evaluateFlagFresh` path, the `@RequiresFlag` decorator, and `NetworkSafetyGuard`. It also owns the **contract-write kill switch** — the `testnet.contract_writes` flag, which the guard reads *fresh on every request* so a flip propagates across instances without waiting for cache expiry, and audits every block. Any "turn this off in production without a deploy" requirement belongs here rather than in a new environment variable.
+
+**`job-queue`** — *Active. `admin/jobs`.* Owns all asynchronous and retried work: the job repository and executor, the registry mapping `JobType` to handlers, exponential-backoff retry with cancellation tokens, the dead-letter monitor that alerts on DLQ depth and oldest-job age, replay bookkeeping, queue metrics, and the admin surface for listing, cancelling, retrying, bulk-retrying, and inspecting the DLQ. Handlers for the six job types (`webhook_delivery`, `recurring_payment`, `export_generation`, `reconciliation`, `stellar_reconnect`, `sep24_status_poll`) live *inside* this module and call into their owning domain. That inversion is intentional: the queue owns scheduling and retry semantics, the domain owns the work. It is the widest-reaching L1 module by import count.
+
+**`events`** — *Active. Library.* Owns the transactional outbox: `OutboxService.stage()` is called inside the same database transaction as the originating state change, and `OutboxDispatcher` publishes durably afterwards, with depth and dispatch-lag metrics. It also owns the typed cross-module event contracts (`contract-registry.events.ts`, `notification.events.ts`) used with the Nest `EventEmitter`. Use the outbox when a state change and its side effect must not diverge; use the emitter for best-effort in-process fan-out.
+
+**`dto`** — *Active. Library.* Owns request/response shapes shared by more than one module — link, transaction, username, and pagination DTOs — so that two controllers describing the same concept cannot drift. Module-local DTOs stay in the owning module's `dto/` folder; a shape is promoted here only when a second module needs it. *Caveat:* it currently imports `LinkState` from `links` (see §1), inverting the intended direction.
+
+### L2 — Chain access
+
+**`stellar`** — *Active. `stellar`.* Owns classic-Stellar read paths that serve the link generator: the verified-asset list, strict-receive and strict-send path previews, quote issuance and retrieval, Soroban preflight simulation (flag-gated behind `testnet.contract_writes` + `NetworkSafetyGuard`), and the recurring-payment processor. It carries the smaller of the two `HorizonService` implementations, used by `asset-metadata`, `health`, and `soroban-tooling`.
+
+**`transactions`** — *Active. `transactions`.* Owns transaction composition and submission: listing transactions for an address, `compose` (with `build` as a backward-compatible alias), `simulate`, and `submit`, plus `SorobanRpcService` — which owns RPC endpoint selection, timeout and retry policy, and multi-endpoint failover with `soroban_rpc_failover_total` / `soroban_rpc_active_endpoint` metrics. It carries the larger `HorizonService`, used by `links`, `payments`, `scam-alerts`, and `transaction-timeline`. It also owns the simulation-error mapper and XDR param builders. **All Soroban RPC traffic goes through this module.**
+
+**`ingestion`** — *Active. `indexer`.* Owns the read side of the chain: polling Horizon and Soroban RPC for contract events, parsing them against versioned schemas, deriving stable event IDs, persisting them into the typed event repositories (escrow, stealth, privacy, admin), maintaining per-contract indexer checkpoints and cursors, and quarantining anything it cannot parse into `unparsed_soroban_events`. It also owns Horizon endpoint failover and the admin routes for reindexing and replaying unparsed events. Anything downstream that needs "what happened on chain" reads the tables this module fills — it does not poll the network itself.
+
+**`contracts`** — *Active. `contracts`, `v1/contracts/views`.* Owns the contract registry: which contract IDs and WASM hashes are active per environment, publish and rollback of registry entries, deployment artifacts, contract specs and derived read-only views, the method allowlist guard, and change webhooks that notify subscribers when the registry moves. Clients resolve contract addresses through this module rather than embedding them, which is what makes registry rollback a viable incident mitigation.
+
+### L3 — Product domains
+
+**`links`** — *Active. `links`, `payment-links`, `links/bulk`, `links/recurring`.* The largest domain module. Owns the payment link end to end: creation and metadata, the `DRAFT → ACTIVE → EXPIRED|PAID → REFUNDED` state machine, public status lookup used by the pay page, expiry sweeping, bulk/CSV generation, and the recurring-payment schedule with its repository and scheduler. Its link constraints and error catalog are the canonical definition of what a valid link is.
+
+**`usernames`** — *Active. `username`.* Owns the username namespace and public profile: reservation and creation, validation rules, public/private toggling, profile lookup by name, and the **discovery surface** — `search`, `trending`, `recently-active`, and `featured`, backed by a discovery cache. This module is the sole owner of user-facing discovery on the backend. If you are about to write a "find users" query anywhere else, it belongs here. (The frontend discovery page still renders local mock data instead of calling these endpoints — see [CAPABILITY-MAP.md](./CAPABILITY-MAP.md).)
+
+**`payments`** — *Active. `payments`.* Owns the recent-payments read for an address: a thin controller and service over `HorizonService.getPayments` with `since`/`limit` filtering. **Intentionally thin** — roughly forty lines of logic. It is *not* a general payments domain; nothing about link state, refunds, or reconciliation lives here despite the name. Treat it as a Horizon convenience read, and do not expand it without deciding whether the code actually belongs in `links` or `transactions`.
+
+**`marketplace`** — *Active. `marketplace`.* Owns username listings and bidding: creating and cancelling listings, listing queries with sorting and bid aggregation, listing detail with derived state hints, placing bids, and accepting a bid. Its error catalog defines the marketplace's rejection reasons. Backend routes are real; several client-side marketplace flows are still mocked.
+
+**`refunds`** — *Active. `admin/refunds`.* Owns refund eligibility and initiation: the eligibility rules for payments and escrows, reason codes, and the admin-initiated refund path, gated by feature flags and written to the audit log. Eligibility logic lives in `refunds.eligibility.ts` and is the single place that decides whether something is refundable.
+
+**`receipts`** — *Unwired. Would serve `v1/receipts`.* Owns the normalised payment receipt: it orchestrates Horizon, Soroban RPC, and indexer metadata, then normalises them into a stable receipt schema with a content hash for tamper evidence. **`ReceiptsModule` is not imported anywhere**, so `/v1/receipts` is not served. The normaliser and schema are complete; only the wiring is missing.
+
+**`fiat-ramps`** — *Active. `fiat-ramps`.* Owns the SEP-24 deposit/withdraw integration: anchor discovery via the SEP-1 TOML, SEP-10 authentication, interactive SEP-24 initiation, the transaction repository, and status polling — both the in-process poller and the `sep24_status_poll` job handler. It uses `IdempotencyModule` so a retried initiation does not open two anchor sessions.
+
+**`notifications`** — *Conditional (skipped on local Supabase). `notifications`, `notifications/preferences`, `webhooks`, `telegram`, `admin/notification-templates`.* The largest module in the tree by file count, and the one most often mistaken for several modules. It owns **all outbound user-facing messaging**: outbound webhook subscriptions with HMAC signing, secret regeneration, delivery logs, per-attempt inspection, manual redelivery, and replay limiting; in-app notifications with read/unread state; per-user notification preferences and their evaluator; a versioned notification-template system; rate limiting; the Telegram bot provider; and the pluggable `NotificationProvider` interface. Actual delivery is executed by the `webhook_delivery` job handler in `job-queue`.
+
+**`analytics`** — *Active. `analytics`.* Owns aggregate reporting for the dashboard: payment volume, conversion, per-asset breakdowns, and interval bucketing, computed through Supabase RPCs, plus the export of those reports. It reads persisted data only — it has no backend module dependencies at all. Distinct from `metrics`, which is operational telemetry about the service; `analytics` is product data about payments.
+
+**`dashboard-feed`** — *Active. `dashboard-feed`.* Owns the cursor-paginated cross-source activity feed for an address, fetching each source independently so one failing source degrades rather than empties the feed. Overlaps conceptually with `transaction-timeline`; the split is **feed = many entities for one address**, **timeline = one entity's history**.
+
+**`transaction-timeline`** — *Active. `transaction-timeline`.* Owns the per-transaction chronology: the ordered payment, refund, and webhook events for a single transaction, assembled from the repository plus Horizon. Use it when the question is "what happened to *this* payment"; use `dashboard-feed` when it is "what happened to *this account*".
+
+**`scam-alerts`** — *Active. `links` (shared prefix).* Owns pre-payment risk scanning of a link or destination: memo requirements per asset, whitelists and blocklists, high-value and unreasonable-amount thresholds, suspicious memo patterns, account-age and frequency heuristics, and external blocklist sources — returning a typed severity and alert type. It scans *content* a user is about to pay. *Caveat:* it shares the `links` route prefix with the `links` module (see §1).
+
+**`abuse-signals`** — *Active. `admin/abuse-signals`.* Owns behavioural abuse scoring at the request layer: middleware applied to the `payment-links` and `links` routes records signals, aggregates them by IP and actor with weighted scoring, exposes an admin review surface, and emits `abuse_signal_score` and outcome counters. The distinction from `scam-alerts` is **who is acting** (`abuse-signals`) versus **what is being paid** (`scam-alerts`).
+
+**`asset-metadata`** — *Active. `assets`.* Owns display metadata for Stellar assets: issuer TOML fetching with caching, branding and fallbacks (including native XLM), the verified-asset overlay, and admin asset routes. Any question of "what icon, name, or verification badge does this asset have" is answered here.
+
+**`privacy`** — *Active. `privacy`, `admin/privacy`.* Owns two related things: the **stealth-address cryptography** (ECDH envelopes, ephemeral keypairs, encryption and decryption of stealth payment metadata) and the **data-retention policy** — the scheduler that purges expired personal data on the configured schedule, with admin visibility into what was purged.
+
+**`exports`** — *Active. `exports`.* Owns user-requested data exports: accepting an export request, queueing it as an `export_generation` job, storing the artifact via `ExportStorageModule`, issuing signed download links, and retiring artifacts on the retention schedule. It owns the *request and delivery*; generation runs in `job-queue`.
+
+**`reconciliation`** — *Conditional (skipped on local Supabase). `reconciliation`.* Owns the ledger-versus-database truth check: scheduled and manually triggered runs, per-run reports with drift classification against configurable count and amount thresholds, alerting on drift and on consecutive failures, historical backfill, auto-matching of unmatched records, and the unmatched queue with resolve and dismiss actions. It is the authority on whether recorded state matches chain state, and its `reconciliation_drift_active` and `reconciliation_consecutive_failures` gauges are primary incident signals.
+
+**`developer`** — *Conditional (skipped on local Supabase). `developer`.* Owns the self-service developer surface: bulk API-key revocation, sample webhook event generation, webhook endpoint testing with a bounded timeout, an integration-health summary, and a ping. It is a convenience layer over `api-keys` and `notifications` — it should not accumulate its own persistent state.
+
+### L4 — Operations & environment
+
+**`health`** — *Active. `health`, `ready`, `status`.* Owns liveness, readiness, and public status. `/health` is shallow; `/ready` performs per-dependency checks with individual timeouts across Supabase, Horizon, and Soroban RPC and returns 503 when a critical dependency has hard-failed; `/status` is a throttled, ETag-cached, non-sensitive summary suitable for a public status page. Probe configuration belongs here, not in the individual dependencies.
+
+**`operations`** — *Active. `admin/operations`.* Owns the consolidated operator dashboard: indexer status, ingestion lag, webhook delivery backlog, and recent errors with actor redaction. It computes nothing itself — it reads `indexer-lag`, `notifications`, and `audit` and presents them together. This is the intended first stop during an incident.
+
+**`indexer-lag`** — *Active. Library.* Owns the lag measurement and the guard built on it: a one-minute cron comparing the network's latest ledger against the last indexed checkpoint, the `indexer_lag_ledgers` and `indexer_lag_guard_status` metrics, and `IndexerLagGuard` with `@RequiresIndexerLagCheck`, which rejects lag-sensitive routes when the indexer falls behind `INDEXER_LAG_THRESHOLD_LEDGERS`. `INDEXER_LAG_GUARD_ENABLED` and `INDEXER_LAG_GUARD_OVERRIDE` control enforcement.
+
+**`support-bundle`** — *Active. `admin/support/bundle`, `support/bundle-references`.* Owns the sanitised diagnostic export: a single admin-scoped JSON bundle of network config, contract registry state, indexer status and checkpoints, and recent errors, with secrets and PII redacted and request-ID inclusion opt-in. The reference sub-surface lets a bundle be cited from an issue without re-exporting it. This is the artifact to attach to a bug report or incident record.
+
+**`rc-validation`** — *Active. `admin/rc-validation`.* Owns the release-candidate gate: it aggregates smoke and readiness probes, contract-registry completeness, indexer lag, and environment parity into classified blockers with an overall `releaseReady` flag. `GET /admin/rc-validation/report` is step 0 of the [release readiness checklist](../RELEASE_READINESS_CHECKLIST.md).
+
+**`environment-parity`** — *Active. `api/environment-parity`.* Owns detection of configuration drift between environments — endpoints, versions, and feature flags — plus staging seed data and the shadow-traffic middleware that mirrors production-shaped requests at staging. Records `environment_parity_check_results` and `shadow_traffic_requests_total`.
+
+**`branch-preview`** — *Active.* Owns per-branch preview environment records: registration, cached lookup of a branch's API and frontend URLs, network and contract version, and the auto-expiry policy that reclaims stale previews. Falls back to configured defaults when a branch has no registration.
+
+**`deployment-sync`** — *Active.* Owns ingestion of GitHub deployment status: signature-verified webhooks, mapping GitHub deployment states onto internal branch-deployment records, and exposing the current deployment for a branch. It is how the backend learns that a preview or environment moved without polling GitHub.
+
+**`preview-scope`** — *Active. Library.* Owns data isolation for previews: middleware reading `X-Preview-Scope`, a service backed by the `preview_scopes` table, and a guard plus decorator that confine scoped requests to their own data. Any feature that must not leak preview data into shared tables depends on this.
+
+**`runtime-config`** — *Active. `v1/runtime-config`.* Owns the single client-facing bootstrap document: network config, resolved contract entries, feature-flag snapshot, preview metadata, and the mobile minimum-version policy. Clients fetch one document here instead of assembling config from four endpoints. See [RUNTIME-CONFIG-MATRIX.md](./RUNTIME-CONFIG-MATRIX.md).
+
+**`soroban-tooling`** — *Active. `developer/testnet`.* Owns testnet developer conveniences: contract deployment helpers and friendbot-style account funding. Testnet-only by construction — nothing here should ever be reachable on mainnet.
+
+**`manifests`** — *Unwired. Would serve `manifests`.* Owns structural diffing of environment manifests — contracts, URLs, and feature flags — producing a per-key `added | removed | modified | unchanged` diff. **`ManifestsModule` is not imported anywhere.** The diff algorithm is pure and self-contained; only the wiring is missing.
+
+**`crash-reporting`** — *Unwired. Would serve `crash-reporting`.* Owns opt-in client crash and log capture: a crash-capture filter, a bounded rolling log buffer, strict redaction of secrets and PII, issue submission, and per-user settings. **`CrashReportingModule` is not imported anywhere**, and the feature is disabled by default even when wired.
+
+**`demos`** — *Unwired. Would serve `v1/demo`, `seed-reset`.* Owns demo fixtures and the seed-reset lifecycle: seeding and clearing demo links and transactions, a scheduled reset, and status endpoints. **`DemoModule` is not imported anywhere**, so despite complete controllers, guards, and a scheduler, **seed reset is not currently served**. This matters operationally — see the [incident runbook](./TESTNET-INCIDENT-RUNBOOK.md).
+
+---
+
+## 3. Shared infrastructure
+
+Five modules are **shared infrastructure**: any module may depend on them, they may not depend on any product domain, and changing them affects everything.
+
+| Module | Contract with callers |
+|---|---|
+| `config` | Read configuration through `AppConfigService`. Never read `process.env` at a call site. Adding a variable means adding it to [env.schema.ts](../app/backend/src/config/env.schema.ts), the typed interface, `.env.example`, and an accessor. |
+| `supabase` | All persistence goes through `SupabaseService`. Do not create a second client. Repositories live in the owning domain, not here. |
+| `metrics` | Register metrics through `MetricsService` so names stay centrally reviewable. Adding one requires updating the registered-metric count assertion in the metrics tests. |
+| `common` | Behaviour that must apply to every request — middleware, filters, interceptors, idempotency, pagination, redaction. Domain logic never lands here. |
+| `tracing` | Outbound HTTP uses `createTracedFetch` or `withSpan`. Do not call bare `fetch` for an external dependency. |
+
+Three L1 modules are near-infrastructure — widely depended on, but they carry domain opinions and are not free to import:
+
+- **`auth` / `api-keys`** — every guarded route depends on them. Changing scope semantics is a breaking change across the API.
+- **`audit`** — write to it from any privileged action. Sixteen modules already do.
+- **`job-queue`** — adding a `JobType` means adding a handler here, and the handler calls into your domain rather than your domain owning the retry loop.
+
+---
+
+## 4. Deciding where new code goes
+
+Work through this in order. Stop at the first rule that fires.
+
+**1. Does an existing module already own this concept?**
+Search by concept, not by filename — the owner is often named for the domain, not the operation. The highest-yield checks, given the duplication in this tree:
+
+- Discovery, search, trending, featured, profile lookup → **`usernames`**. There is no other discovery owner.
+- Anything reading Horizon → one of the two `HorizonService`s. Extend the one your module's peers already use; do not add a third.
+- Anything calling Soroban RPC → **`transactions`** (`SorobanRpcService`).
+- Anything reading on-chain history → **`ingestion`** tables. Do not poll the chain from a domain module.
+- Outbound webhooks, in-app messages, templates, Telegram → **`notifications`**. All of it.
+- Retries, backoff, scheduled work → **`job-queue`**, as a handler.
+- Admin read-only aggregation → **`operations`** or **`support-bundle`**, not a new admin module.
+
+If an owner exists, **extend it**, even if that means the module grows.
+
+**2. Is it request-lifecycle behaviour that applies to every route?**
+→ `common` (middleware, filter, interceptor) or `auth` (a guard). Not a new module.
+
+**3. Is it a read-only diagnostic view assembled from other modules?**
+→ `operations` or `support-bundle`. A new L4 module is justified only when it owns state or a schedule of its own — `indexer-lag` and `environment-parity` qualify; a new endpoint that joins three existing services does not.
+
+**4. Is it a distinct product domain with its own persistent state, lifecycle, and vocabulary?**
+→ A new L3 module. All four must hold:
+
+- It owns at least one table no other module writes.
+- It has a lifecycle a state machine could describe, or an external integration boundary.
+- Its nouns do not already appear in another module's public surface.
+- You can state its ownership paragraph in this document without the word "and" joining two unrelated responsibilities.
+
+**5. Otherwise, it is a feature of an existing module.** Put it there.
+
+### Creating a module
+
+1. Give it a directory named for the **domain**, not the operation — `refunds`, not `refund-processor`.
+2. Declare its layer, and check every import points downward.
+3. Standard shape: `<name>.module.ts`, `<name>.controller.ts`, `<name>.service.ts`, `<name>.repository.ts` (Supabase access), `dto/`, `types/`, and errors in `errors/` when the domain has rejection reasons worth naming.
+4. **Register it in [app.module.ts](../app/backend/src/app.module.ts).** Four modules in this tree skipped this step and serve nothing. If registration is conditional, say so in the ownership paragraph.
+5. Choose a route prefix nobody else uses. Two modules already collide on `links`.
+6. Add its ownership paragraph to §2 of this document, and a row to [CAPABILITY-MAP.md](./CAPABILITY-MAP.md) with its maturity.
+
+### Extending a module
+
+- Cross-module reads go through the owner's **service**, never its repository. Repositories are module-private.
+- Needing a peer's repository means either the boundary is wrong or the shape belongs in `dto`.
+- Sharing a type with exactly one other module: export it from your service's module. With three or more: promote it to `dto`.
+- Adding an environment variable: schema, typed interface, `.env.example`, accessor. All four.
+
+---
+
+## 5. Status summary
+
+Modules that are **not fully wired** — do not build on these without wiring them first:
+
+| Module | Status | Consequence |
+|---|---|---|
+| `receipts` | Unwired — `ReceiptsModule` imported nowhere | `/v1/receipts` is not served. Normaliser and schema are complete. |
+| `manifests` | Unwired — `ManifestsModule` imported nowhere | `/manifests` is not served. The diff algorithm is pure and usable as a library today. |
+| `crash-reporting` | Unwired — `CrashReportingModule` imported nowhere | `/crash-reporting` is not served; also opt-in and off by default. |
+| `demos` | Unwired — `DemoModule` imported nowhere | `/v1/demo` and `/seed-reset` are **not served**, despite complete controllers, guards, and scheduler. |
+| `reconciliation` | Conditional | Skipped when `SUPABASE_URL` points at localhost or 127.0.0.1. Drift detection does not run locally. |
+| `notifications` | Conditional | Same condition. Webhooks and in-app notifications do not run locally. |
+| `developer` | Conditional | Same condition. |
+| `auth` | Library by design | Not in `app.module.ts`; two of its guards are registered globally there as `APP_GUARD` providers, and `AuthModule` is imported where the rest are needed. |
+| `common/idempotency` | Library by design | `IdempotencyModule` is imported by `transactions` and `fiat-ramps` rather than registered globally. |
+| `exports/export-storage` | Library by design | `ExportStorageModule` is imported by `exports` and `job-queue`. |
+
+Modules that are **intentionally thin** — small on purpose, and not the place to grow a domain:
+
+| Module | Why it is thin |
+|---|---|
+| `payments` | A single Horizon read with `since`/`limit` filtering. Despite the name it owns no payment domain logic — that lives in `links`, `transactions`, and `refunds`. |
+| `dashboard-feed` | One endpoint. Deliberately an aggregator over other modules' repositories with no state of its own. |
+| `types` | Ambient declarations only. Never add runtime code. |
+| `manifests` | A pure diff function and a DTO. Correct as-is; it just needs wiring. |
+| `soroban-tooling` | Two testnet helpers. Must never grow a mainnet path. |
+| `developer` | A convenience layer over `api-keys` and `notifications`. Should not acquire its own persistent state. |

--- a/docs/LOCALIZATION-GUIDE.md
+++ b/docs/LOCALIZATION-GUIDE.md
@@ -1,0 +1,339 @@
+# Localization Contributor Guide
+
+QuickEx ships user-facing copy on two clients — the Next.js web app (`app/frontend`) and the Expo mobile app (`app/mobile`). Each maintains its **own** `i18next` dictionary. There is no shared package, no translation-management platform, and no automated sync between them.
+
+This guide covers adding a string, adding a locale, and the conventions that keep the two dictionaries comparable. It ends with the **known drift** between them, which is the starting point for anyone doing translation work today.
+
+Companion documents:
+
+- [`app/mobile/src/lib/i18n/README.md`](../app/mobile/src/lib/i18n/README.md) — mobile-local notes and the shared-key inventory.
+- [CAPABILITY-MAP.md](./CAPABILITY-MAP.md) — which surfaces are Live vs Mocked, which tells you whether a screen is worth translating yet.
+
+---
+
+## 1. Where the strings live
+
+| | Frontend | Mobile |
+|---|---|---|
+| Dictionary | [`app/frontend/src/lib/i18n/translations.json`](../app/frontend/src/lib/i18n/translations.json) | [`app/mobile/src/lib/i18n/translations.json`](../app/mobile/src/lib/i18n/translations.json) |
+| `i18next` bootstrap | [`app/frontend/src/lib/i18n.ts`](../app/frontend/src/lib/i18n.ts) | [`app/mobile/src/lib/i18n.ts`](../app/mobile/src/lib/i18n.ts) |
+| Locale picker | [`app/frontend/src/components/LocaleSwitcher.tsx`](../app/frontend/src/components/LocaleSwitcher.tsx) | [`app/mobile/components/LocaleSwitcher.tsx`](../app/mobile/components/LocaleSwitcher.tsx) |
+| Parity check | [`app/frontend/scripts/check-i18n-parity.mjs`](../app/frontend/scripts/check-i18n-parity.mjs) | [`app/mobile/scripts/check-i18n-parity.mjs`](../app/mobile/scripts/check-i18n-parity.mjs) |
+| Parity test | [`app/frontend/__tests__/i18n-parity.test.ts`](../app/frontend/__tests__/i18n-parity.test.ts) | [`app/mobile/__tests__/i18n-key-parity.test.ts`](../app/mobile/__tests__/i18n-key-parity.test.ts) |
+| CI job | [`.github/workflows/frontend-ci.yml`](../.github/workflows/frontend-ci.yml) | [`.github/workflows/mobile-ci.yml`](../.github/workflows/mobile-ci.yml) |
+| Number/date formatting | [`app/frontend/src/lib/formatting.ts`](../app/frontend/src/lib/formatting.ts) | **none — see §6** |
+
+Both dictionaries are plain JSON with the shape `{ "<locale>": { "<key>": "<string>" } }`, both carry `en`, `es`, and `fr`, and `en` is the **base locale** on both.
+
+JSON rather than inline TypeScript is deliberate: the CI parity checks read the file without parsing source.
+
+> The `i18n.ts.backup` file that previously sat in the frontend tree **no longer exists**. If you find a reference to it, that reference is stale.
+
+---
+
+## 2. Adding a translatable string
+
+### Frontend
+
+1. **Add the key to all three locales** in [`src/lib/i18n/translations.json`](../app/frontend/src/lib/i18n/translations.json). All of `en`, `es`, and `fr` — the frontend parity check treats a missing key as a hard failure. If you do not have a real translation, ship the English text as a placeholder and note it in the PR; a missing key breaks the build, an untranslated one does not.
+
+   ```json
+   {
+     "en": { "cancelPayment": "Cancel payment" },
+     "es": { "cancelPayment": "Cancelar pago" },
+     "fr": { "cancelPayment": "Annuler le paiement" }
+   }
+   ```
+
+2. **Use it from a client component.** `useTranslation` requires the React context, so the component needs `'use client'`:
+
+   ```tsx
+   'use client';
+   import { useTranslation } from 'react-i18next';
+
+   export function CancelButton() {
+     const { t } = useTranslation();
+     return <button>{t('cancelPayment')}</button>;
+   }
+   ```
+
+   The `i18next` instance is initialised by the side-effect import `import '@/lib/i18n'`. Server components cannot call `t()` — pass translated text down as props, or make the leaf a client component.
+
+3. **Verify:** `pnpm --filter frontend check:i18n`
+
+### Mobile
+
+1. **Add the key to all three locales** in [`src/lib/i18n/translations.json`](../app/mobile/src/lib/i18n/translations.json). Same rule.
+
+2. **Use it from a screen or component:**
+
+   ```tsx
+   import { useTranslation } from 'react-i18next';
+
+   export function CancelButton() {
+     const { t } = useTranslation();
+     return <Text>{t('cancelPayment')}</Text>;
+   }
+   ```
+
+   Mobile derives its `resources` object from the JSON automatically, so no bootstrap edit is needed when adding a key — or a locale.
+
+3. **Verify:** `pnpm --filter mobile check:i18n`
+
+> **Before you test on mobile, read [drift item D1](#d1-the-mobile-i18n-bootstrap-import-is-broken).** The mobile bootstrap import is currently broken, so `t()` returns raw key names at runtime regardless of what is in the dictionary. Fixing that one-character path is a prerequisite for any mobile translation work being visible.
+
+### If the string appears on both clients
+
+Add it to both dictionaries, **under the same key name**, with the same meaning. Nothing enforces this — the two parity checks run independently and neither is aware of the other. See §4.
+
+---
+
+## 3. Key naming conventions
+
+The dictionaries use a **flat, single-level namespace**. There is no nesting and no `feature:key` prefixing today, on either client. Follow the existing shape rather than introducing a nested tree for one feature.
+
+| Rule | Example |
+|---|---|
+| `camelCase`, no dots, no dashes, no underscores | `allowedSourceAssets` |
+| Name the **concept**, not the location or the widget | `destinationRequired`, not `formError3` or `payPageInputError` |
+| Suffix a longer explanatory string with `Description` | `recipientAsset` / `recipientAssetDescription` |
+| Suffix placeholder text with `Placeholder` | `destinationLabel` / `destinationPlaceholder` |
+| Validation and error messages read as complete sentences ending in a period | `"Destination is required."` |
+| Labels, buttons, and headings do not end in a period | `"Run preflight"` |
+| Never key on the English text | `cancelPayment`, not `cancel_payment_button_text` |
+
+### Shared versus client-specific keys
+
+> **The rule: a key is shared when the same UI concept exists on both clients. Shared keys use the same name on both, and their `en` values must match exactly.**
+
+Three categories:
+
+- **Shared** — the concept exists on both clients. Use one key name on both. Changing the meaning on one means changing it on the other in the same PR. There are currently **49** such keys, inventoried in the [mobile README](../app/mobile/src/lib/i18n/README.md).
+- **Frontend-only** — web surfaces with no mobile counterpart (webhooks, API keys, analytics, marketplace, admin). **80** keys today. Do not mirror these into mobile "for symmetry" — an untranslated dead key is worse than an absent one, and the frontend parity check treats dead keys as failures.
+- **Mobile-only** — native concepts with no web counterpart: `linkReady`, `shareLink`, `copyLink`, `previewQR`, `notificationsTitle`, `close`, `noNotifications`, `appTitle`, `appSubtitle`, `payAgain`, `payNew`, `quickReceive`, `recentContacts`, `noRecentContacts`, `getStarted`, `scanToPay`, `connectWallet`, `contacts`. **18** keys today.
+
+When you add a key, decide which category it is in and act accordingly. When you *change* a shared key's English text, update both dictionaries — otherwise you add to the drift catalogued in §7.
+
+---
+
+## 4. Keeping the two clients aligned
+
+There is **no tooling that compares the frontend and mobile dictionaries**. Both parity checks only compare locales *within* one client against that client's `en`. Cross-client alignment is a review responsibility.
+
+The two checks are also not identical in strictness:
+
+| | Missing key (in a locale, present in `en`) | Dead key (in a locale, absent from `en`) |
+|---|---|---|
+| Frontend | ❌ exit 1 | ❌ exit 1 |
+| Mobile | ❌ exit 1 | ⚠️ warning, exit 0 |
+
+Both honour `I18N_BASE_LOCALE` to override the base locale, and both accept an explicit dictionary path as `argv[2]`.
+
+**Checklist when touching a shared key:**
+
+- [ ] Same key name in both dictionaries.
+- [ ] Identical `en` value in both.
+- [ ] All three locales updated in both.
+- [ ] Interpolation placeholders identical in name and count across every locale and both clients.
+- [ ] Shared-key inventory in the [mobile README](../app/mobile/src/lib/i18n/README.md) updated if the key moved category.
+- [ ] `pnpm --filter frontend check:i18n` and `pnpm --filter mobile check:i18n` both pass.
+
+---
+
+## 5. Adding a new locale
+
+Adding a locale is **one step on mobile and three on the frontend**, because the frontend bootstrap hardcodes its resource map while mobile derives it.
+
+### Frontend
+
+1. **Translate every key.** Copy the `en` block in `src/lib/i18n/translations.json`, add it under the new locale code, translate all 129 values. The parity check fails on any missing key, so a partial locale cannot land.
+
+2. **Register it in the bootstrap.** [`src/lib/i18n.ts`](../app/frontend/src/lib/i18n.ts) lists each locale explicitly:
+
+   ```ts
+   resources: {
+     en: { translation: translations.en },
+     es: { translation: translations.es },
+     fr: { translation: translations.fr },
+     de: { translation: translations.de },   // ← add
+   },
+   ```
+
+   **Skipping this step is silent.** The parity check passes, CI is green, and the locale simply never loads. Consider replacing this block with the derived form mobile already uses:
+
+   ```ts
+   const resources = Object.fromEntries(
+     Object.entries(translations).map(([lng, translation]) => [lng, { translation }]),
+   );
+   ```
+
+3. **Add it to the picker.** [`src/components/LocaleSwitcher.tsx`](../app/frontend/src/components/LocaleSwitcher.tsx) hardcodes its `<option>` list. Add the new one with its **endonym** — the language's name in itself (`Deutsch`, not `German`).
+
+4. Run `pnpm --filter frontend check:i18n`.
+
+### Mobile
+
+1. **Translate every key** in `src/lib/i18n/translations.json` — all 67, same rule.
+
+2. **Add it to the picker.** [`app/mobile/components/LocaleSwitcher.tsx`](../app/mobile/components/LocaleSwitcher.tsx) hardcodes its `<Picker.Item>` list. See [drift item D2](#d2-the-mobile-locale-picker-only-offers-english) — this picker currently offers only English, so adding a locale here means adding the missing `es` and `fr` items too.
+
+3. No bootstrap edit is required; `resources` is derived from the JSON.
+
+4. Run `pnpm --filter mobile check:i18n`.
+
+### Both clients
+
+- Use the **BCP 47 code** (`de`, `pt-BR`, `zh-Hans`). Match whatever `Intl` expects, since the same string is passed to the formatters in §6.
+- Selection persists to `localStorage` under `i18nextLng` on both clients, and `fallbackLng` is `en` on both.
+- **RTL locales (Arabic, Hebrew, Farsi) need layout work beyond the dictionary** — direction handling on the web and `I18nManager.forceRTL` on mobile. Neither client has any RTL support today. Do not add an RTL locale without that work.
+
+---
+
+## 6. Pluralization, interpolation, and formatting
+
+### Interpolation
+
+Use `i18next`'s `{{name}}` syntax and pass values as the second argument to `t()`:
+
+```json
+{ "totalFee": "Total fee: {{totalFee}} XLM" }
+```
+
+```tsx
+t('totalFee', { totalFee: formatNumber(fee, i18n.language) })
+```
+
+Rules:
+
+- **Placeholder names are part of the key's contract.** Every locale of a key must use the same placeholder names — a translator who renames `{{hopCount}}` produces a silently empty slot.
+- **Word order may change; placeholders may move.** That is the point of interpolation — never build a sentence by concatenating `t()` fragments.
+- **`escapeValue` is `false` on both clients.** i18next does no HTML-escaping of interpolated values. React escapes on render, so this is safe for normal use, but never feed an interpolated result into `dangerouslySetInnerHTML`.
+- **Interpolate formatted values, not raw ones.** Format the number or date first (below), then pass the string in.
+
+Keys using interpolation today: `profileCustomizationDescription`, `noPathsFound`, `payReceive`, `hops`, `estimatedNetworkFee`, `quoteExpiresIn`, `totalFee`, `latency`.
+
+### Pluralization
+
+**Neither dictionary uses plurals today** — there is not a single `_one` / `_other` key on either client. `hops` is `"{{hopCount}} hops"`, which is wrong at 1.
+
+When you add a countable string, use `i18next`'s suffix convention rather than an `if`:
+
+```json
+{
+  "en": { "hops_one": "{{count}} hop",  "hops_other": "{{count}} hops" },
+  "es": { "hops_one": "{{count}} salto", "hops_other": "{{count}} saltos" },
+  "fr": { "hops_one": "{{count}} saut",  "hops_other": "{{count}} sauts" }
+}
+```
+
+```tsx
+t('hops', { count: hopCount })
+```
+
+Notes:
+
+- The variable **must** be named `count`; that is what i18next reads to select the plural form.
+- Plural categories are per-language. `en`, `es`, and `fr` need `_one` and `_other`; other languages need more (`_zero`, `_few`, `_many`). Add exactly the categories the language uses.
+- **The parity checks compare key names literally**, so `hops_one` and `hops_other` are two independent keys. Every locale must carry the full set it needs, or CI fails. Migrating an existing key to plural form means updating both clients if it is shared.
+
+### Formatting amounts and dates
+
+**Never put a formatted number, currency, or date into the dictionary.** Separators, currency placement, and date order are locale properties, not translations. Keep the dictionary to the surrounding words and interpolate the formatted value.
+
+The frontend has helpers in [`src/lib/formatting.ts`](../app/frontend/src/lib/formatting.ts). All take an optional locale and fall back to `navigator.language`, then `en-US`:
+
+| Helper | Use for |
+|---|---|
+| `formatNumber(value, locale)` | Counts and plain quantities. Preserves up to 20 fractional digits and trims trailing zeros — safe for 7-decimal Stellar amounts, which `Intl.NumberFormat` would otherwise round. |
+| `formatAssetAmount(value, asset, locale)` | On-chain amounts with a ticker: `1 234,5678 USDC`. |
+| `formatCurrency(value, currency, locale)` | Fiat, 2 decimals, locale-correct symbol placement. |
+| `formatDate(value, locale)` / `formatDateTime(value, locale)` | Dates and timestamps, `dateStyle: 'medium'`. |
+| `getActiveLocale(locale)` | Canonicalise a locale string before passing it to `Intl` directly. |
+
+Always pass the active locale explicitly — `const { i18n } = useTranslation()`, then `formatDate(value, i18n.language)`. Omitting it silently reads the browser locale, which is not necessarily the locale the user selected in the app.
+
+Two gaps to be aware of:
+
+- **Mobile has no formatting helpers at all.** There is no `formatting.ts` under `app/mobile`. Mobile code that needs a formatted amount or date should port these helpers rather than reimplement them ad hoc — see [drift item D4](#d4-formatting-helpers-are-frontend-only-and-inconsistently-used).
+- **Much of the frontend bypasses them.** Roughly two dozen call sites hardcode `toLocaleString("en-US")` / `toLocaleDateString("en-US")` — including the developer settings, audit log, marketplace listing, and deployment panels. Those render US-formatted output regardless of the selected locale. Replacing a hardcoded `"en-US"` with a `formatting.ts` helper is a good first localization contribution.
+
+---
+
+## 7. Known drift — the current starting point
+
+Everything below is true of the tree as it stands. Treat this section as the backlog, not as background.
+
+### D1. The mobile i18n bootstrap import is broken
+
+[`app/mobile/app/_layout.tsx:15`](../app/mobile/app/_layout.tsx#L15) reads:
+
+```ts
+import "../../src/lib/i18n";
+```
+
+From `app/mobile/app/`, `../..` resolves to `app/` — so the path is `app/src/lib/i18n`, which does not exist. The correct path is `../src/lib/i18n`, and no `tsconfig` alias covers the current form (`@/*` maps to `./*` relative to `app/mobile`).
+
+**Consequence:** the `i18next` instance is never initialised at app start. `useTranslation()` still returns a `t` function, so nothing crashes — every call just returns the raw key name. The mobile dictionary is effectively inert at runtime, and the parity check cannot detect this because it only reads the JSON.
+
+**Fix:** change the path to `../src/lib/i18n`. Verify by confirming a screen renders `Dashboard` rather than `dashboard`.
+
+### D2. The mobile locale picker only offers English
+
+[`app/mobile/components/LocaleSwitcher.tsx`](../app/mobile/components/LocaleSwitcher.tsx) contains a single `<Picker.Item label="English" value="en" />` followed by `{/* Add more languages later */}`. The mobile dictionary carries complete `es` and `fr` translations that **no user can select**. The frontend picker offers all three.
+
+**Fix:** add `es` and `fr` items, or derive the list from `Object.keys(translations)` so the picker cannot drift from the dictionary again.
+
+### D3. The two dictionaries have diverged in size and content
+
+| | Frontend | Mobile |
+|---|---|---|
+| Keys per locale | 129 | 67 |
+| Locales | `en`, `es`, `fr` | `en`, `es`, `fr` |
+| Shared keys | **49** | **49** |
+| Client-only keys | 80 | 18 |
+
+Each client is internally at parity — all three locales carry the same key set. The drift is **between** clients, and it is not merely additive: **17 of the 49 shared keys have different English text on the two clients.**
+
+| Key | Frontend `en` | Mobile `en` |
+|---|---|---|
+| `networkError` | Network error when calling preflight. | Network error calling preflight. |
+| `destinationRequired` | Destination is required. | Destination address is required. |
+| `recipientAssetDescription` | Asset that the recipient receives. | Same as the amount currency above — what lands in the receiver's account after the path executes. |
+| `allowedSourceAssets` | Allowed source assets | Allowed source assets (payers) |
+| `allowedSourceAssetsDescription` | Assets the payer can send from. | Payers may use any of the selected assets; Horizon suggests paths and send amounts. |
+| `noPathsFound` | No paths found on `{{horizonUrl}}`. Try a different amount or asset mix. | No paths found for this combination on `{{horizonUrl}}`. Try other source assets or a smaller amount. |
+| `payReceive` | Pay `{{sourceAmount}}` `{{sourceAsset}}` → Receive … | Pay `{{sourceAmount}}` (`{{sourceAsset}}`) → receive … |
+| `hops` | `{{hopCount}}` hops | Hops: `{{hopCount}}` |
+| `sorobanPreflight` | Soroban preflight | Soroban preflight (composer) |
+| `sorobanPreflightDescription` | Run a simulation before sharing the payment link. | Runs the same simulation as `POST /transactions/compose` with `health_check` on `QUICKEX_CONTRACT_ID`. |
+| `sourceAccountPlaceholder` | Source account public key (G...) | Source account G… (funded, for sequence) |
+| `runPreflight` | Run preflight | Run preflight simulation |
+| `simulationOk` | Simulation succeeded. | Simulation OK — fees estimated. |
+| `totalFee` | Total fee: `{{totalFee}}` XLM | Total fee (incl. resource): `{{totalFee}}` XLM |
+| `latency` | Latency: `{{latency}}` ms | Latency `{{latency}}` ms |
+| `instantPaymentsDesc` | Generate payment links instantly with advanced path payment support. | Receive USDC, XLM, or any Stellar asset directly to your self-custody wallet. |
+
+Two patterns are visible, and they need different treatment:
+
+- **Cosmetic** (`latency`, `hops`, `networkError`, `runPreflight`) — pick one wording and apply it to both. Mechanical.
+- **Substantively different copy** (`sorobanPreflightDescription`, `recipientAssetDescription`, `allowedSourceAssetsDescription`, `instantPaymentsDesc`) — mobile carries developer-facing detail that the frontend deliberately does not. These are arguably not the same string. **Decide per key: converge on shared wording, or split into two client-specific keys.** Do not silently overwrite one with the other; the mobile copy references implementation details a web user has no context for.
+
+Note that the `es` and `fr` values follow their own client's `en`, so each divergence above is really three.
+
+### D4. Formatting helpers are frontend-only and inconsistently used
+
+`formatting.ts` exists only on the frontend, and much of the frontend does not use it — around two dozen call sites hardcode `"en-US"` (developer settings, audit logs, marketplace listings, activity feed, OG image route) or call `toLocaleString()` with no locale at all. Mobile has no helpers to bypass.
+
+**Fix, in order:** replace hardcoded `"en-US"` call sites with the helpers, threading `i18n.language` through; then port `formatting.ts` to mobile — ideally by extracting it somewhere both clients can consume rather than copying it.
+
+### D5. No cross-client parity tooling
+
+The two `check-i18n-parity.mjs` scripts are near-identical, differ only in strictness on dead keys (frontend fails, mobile warns), and neither knows the other client exists. Nothing would have caught D3.
+
+**Fix:** a third check asserting that keys present in both dictionaries carry identical `en` values, with an explicit allowlist for keys intentionally worded differently. Until that exists, the checklist in §4 is the only guard.
+
+### D6. The mobile README's shared-key inventory is manually maintained
+
+[`app/mobile/src/lib/i18n/README.md`](../app/mobile/src/lib/i18n/README.md) lists the shared and mobile-only keys by hand. Its inventory is currently **accurate** — all 49 shared keys and 18 mobile-only keys are correctly listed — but it will silently rot on the next change, and it already contains one stale pointer: it says the web dictionary lives in `app/frontend/src/lib/i18n.ts`, which now holds only the bootstrap. The strings moved to `src/lib/i18n/translations.json`.
+
+If you change the shared-key set, update that list in the same PR.

--- a/docs/TESTNET-INCIDENT-RUNBOOK.md
+++ b/docs/TESTNET-INCIDENT-RUNBOOK.md
@@ -1,0 +1,496 @@
+# Testnet Incident Response Runbook
+
+Substantial operational tooling exists in the backend — a contract-write kill switch, an indexer lag guard, dead-letter replay, support bundle export, reconciliation reports, an admin operations surface. This runbook says **which one to reach for, in what order, under pressure**.
+
+It is written for testnet. Mainnet promotion reuses the same steps; where the two differ, the difference is called out.
+
+Companion documents:
+
+- [RELEASE_READINESS_CHECKLIST.md](../RELEASE_READINESS_CHECKLIST.md) — the pre-release gate. Most bad deploys are prevented there, not here.
+- [BACKEND-MODULE-MAP.md](./BACKEND-MODULE-MAP.md) — which module owns which surface.
+- [app/contract/documentation/deployment-playbook.md](../app/contract/documentation/deployment-playbook.md) — contract pause, upgrade ceremony, and key management.
+
+---
+
+## 0. First five minutes
+
+Do these in order, before diagnosing anything. They take under a minute and they determine everything that follows.
+
+```bash
+export API=https://<backend-host>
+export KEY=<admin-scoped API key>
+
+curl -s $API/health                                          # is the process alive?
+curl -s $API/ready                                           # which dependency is down? (503 = hard failure)
+curl -s -H "X-API-Key: $KEY" $API/admin/operations/indexer    # indexer lag
+curl -s -H "X-API-Key: $KEY" $API/admin/operations/webhooks   # webhook backlog
+curl -s -H "X-API-Key: $KEY" $API/admin/operations/errors     # recent errors
+```
+
+`GET /ready` is the highest-value single call: it probes Supabase, Horizon, and Soroban RPC with per-dependency timeouts and returns 503 when a critical dependency has hard-failed. It tells you **which of the five scenarios below you are in**.
+
+Then pick your scenario:
+
+| Symptom | Scenario |
+|---|---|
+| `/ready` reports Soroban RPC unhealthy; simulate/submit failing | [§1 Soroban RPC outage](#1-soroban-rpc-outage) |
+| `lagLedgers` above threshold; stale reads; guard rejections | [§2 Indexer lag](#2-indexer-lag) |
+| Payments stuck `ACTIVE`; users report paid-but-not-credited | [§3 Stuck payments](#3-stuck-payments) |
+| Webhook backlog growing; DLQ depth climbing | [§4 Webhook delivery backlog](#4-webhook-delivery-backlog) |
+| Errors began at a deploy; contract calls failing broadly | [§5 Bad contract deploy](#5-bad-contract-deploy) |
+
+**Two things to do in parallel with everything below:**
+
+1. **Start an incident record** and note the time you began.
+2. **Capture a support bundle now** — before mitigating. State you change is state you cannot diagnose later. See [§7](#7-post-incident).
+
+---
+
+## Reference: signals and controls
+
+Every scenario draws from these. Bookmark this section.
+
+### Metrics (`GET /metrics`)
+
+| Metric | Reads on |
+|---|---|
+| `soroban_rpc_active_endpoint`, `soroban_rpc_failover_total` | RPC health and failover activity |
+| `indexer_lag_ledgers`, `indexer_lag_guard_status`, `indexer_lag_guard_blocked_requests_total` | Indexer lag and guard enforcement |
+| `ingestion_lag_seconds`, `soroban_indexer_unknown_schema_version_total` | Ingestion health; schema mismatch after a deploy |
+| `webhook_retry_total`, `webhook_delivery_duration_seconds` | Webhook delivery health |
+| `outbox_depth`, `outbox_dispatch_lag_seconds`, `outbox_dispatch_total` | Transactional outbox backlog |
+| `reconciliation_drift_active`, `reconciliation_consecutive_failures` | Ledger-vs-database divergence |
+| `error_total`, `http_requests_total`, `http_request_duration_seconds` | General error rate and latency |
+| `abuse_signals_high_score_total`, `http_rate_limited_requests_total` | Abuse or load-driven incidents |
+
+### Endpoints
+
+All admin routes require an API key with the `admin` scope, sent as `X-API-Key`.
+
+| Purpose | Endpoint |
+|---|---|
+| Liveness / readiness / public status | `GET /health`, `GET /ready`, `GET /status` |
+| Consolidated operator view | `GET /admin/operations/{indexer,ingestion,webhooks,errors}` |
+| Release-gate report | `GET /admin/rc-validation/report` |
+| Support bundle | `GET /admin/support/bundle?includeRequestIds=true` |
+| Feature flags / kill switch | `GET|PATCH /admin/feature-flags/:key` |
+| Job queue | `GET /admin/jobs`, `GET /admin/jobs/dlq`, `GET /admin/jobs/metrics/summary` |
+| Job recovery | `POST /admin/jobs/:id/retry`, `POST /admin/jobs/bulk-retry`, `POST /admin/jobs/:id/cancel` |
+| Indexer recovery | `POST /indexer/reindex`, `GET /indexer/unparsed-events`, `POST /indexer/unparsed-events/replay`, `POST /indexer/unparsed-events/replay/batch` |
+| Reconciliation | `GET /reconciliation/status`, `POST /reconciliation/trigger`, `GET /reconciliation/history`, `GET /reconciliation/unmatched`, `POST /reconciliation/backfill` |
+| Webhook recovery | `POST /webhooks/:publicKey/:id/redeliver`, `GET /webhooks/:publicKey/:id/{logs,stats,attempts}` |
+| Contract registry | `GET /contracts/registry`, `POST /contracts/registry/rollback` |
+
+### Environment controls
+
+Changing these requires a restart. Prefer the feature-flag kill switch, which does not.
+
+| Variable | Effect |
+|---|---|
+| `INDEXER_LAG_THRESHOLD_LEDGERS` | Ledgers of lag before the guard considers the indexer behind |
+| `INDEXER_LAG_GUARD_ENABLED` | Master switch for lag-based request rejection |
+| `INDEXER_LAG_GUARD_OVERRIDE` | Bypass the guard while still measuring lag |
+| `SOROBAN_RPC_URL`, `SOROBAN_RPC_URLS` | Primary and additional RPC endpoints for failover |
+| `SOROBAN_RPC_TIMEOUT_MS`, `SOROBAN_RPC_MAX_RETRIES` | Per-request RPC timeout and retry budget (defaults 10000 / 3) |
+| `RECONCILIATION_ENABLED`, `RECONCILIATION_CRON_EXPRESSION` | Scheduled reconciliation runs (default every 5 minutes) |
+| `RECONCILIATION_DRIFT_COUNT_THRESHOLD`, `RECONCILIATION_DRIFT_AMOUNT_THRESHOLD_STROOPS` | When a run is classified as drift |
+| `RECONCILIATION_CONSECUTIVE_FAILURE_ALERT_THRESHOLD` | Consecutive failed runs before alerting |
+| `DLQ_MONITOR_ENABLED`, `DLQ_ALERT_DEPTH_THRESHOLD`, `DLQ_ALERT_AGE_THRESHOLD_MS` | Dead-letter alerting |
+
+### ⚠️ Tooling that is not currently available
+
+**Seed reset is not served.** `DemoModule` is not imported in [app.module.ts](../app/backend/src/app.module.ts), so `POST /seed-reset/trigger`, `POST /seed-reset/force`, `GET /seed-reset/status`, and the `/v1/demo` routes return 404 despite the controllers, guards, and scheduler existing. **Do not plan a recovery around seed reset.** If demo or testnet data must be reset during an incident, either wire `DemoModule` and deploy, or reset the data directly. The same applies to `receipts`, `manifests`, and `crash-reporting` — see [BACKEND-MODULE-MAP.md §5](./BACKEND-MODULE-MAP.md#5-status-summary).
+
+**Reconciliation, notifications, and developer routes are skipped against a local Supabase.** If `SUPABASE_URL` points at `localhost` or `127.0.0.1`, those three modules are not registered. This affects local reproduction, not deployed environments.
+
+---
+
+## 1. Soroban RPC outage
+
+The RPC endpoint is unavailable, timing out, or returning errors. Reads served from indexed data continue; anything that simulates or submits fails.
+
+### Detection
+
+- `GET /ready` reports the Soroban RPC check failing; returns 503 if it hard-failed.
+- `soroban_rpc_failover_total` climbing; `soroban_rpc_active_endpoint` moving or pinned to a failing endpoint.
+- Elevated `error_total`; `/transactions/compose`, `/simulate`, `/submit` and `/stellar/soroban-preflight` failing.
+- User reports of failed preflight or payment composition.
+
+The backend already fails over across the endpoints in `SOROBAN_RPC_URL` + `SOROBAN_RPC_URLS`, retrying up to `SOROBAN_RPC_MAX_RETRIES`. A rising `soroban_rpc_failover_total` with a stable error rate means failover is **working** — that is degradation, not an outage. Escalate when every endpoint is failing.
+
+### Immediate mitigation
+
+1. **Confirm the outage is upstream, not ours.** Query the RPC URL directly. If it responds, the problem is network or config on our side.
+
+   ```bash
+   curl -s -X POST $SOROBAN_RPC_URL -H 'Content-Type: application/json' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}'
+   ```
+
+2. **Check whether an alternate endpoint is configured.** If `SOROBAN_RPC_URLS` holds only one entry, there is nothing to fail over to. Adding a second endpoint requires a restart — do it, and treat the single-endpoint configuration as a post-incident action item.
+
+3. **Engage the write kill switch** if simulation failures are producing user-visible errors or partial state:
+
+   ```bash
+   curl -X PATCH $API/admin/feature-flags/testnet.contract_writes \
+     -H "X-API-Key: $KEY" -H 'Content-Type: application/json' \
+     -d '{"enabled": false}'
+   ```
+
+   `NetworkSafetyGuard` reads this flag **fresh on every request**, so it takes effect across all instances immediately — no restart, no cache wait. Contract-write routes then return 503 with `CONTRACT_WRITES_DISABLED` and a clear message, and every block is written to the audit log. See [§6](#6-the-write-kill-switch) for when this is the right call.
+
+4. **Do not restart the backend to "clear" RPC errors.** Failover state is in-process and rebuilding it discards knowledge of which endpoints are unhealthy.
+
+### Recovery
+
+1. Confirm the RPC endpoint is healthy again.
+2. Re-enable writes: `PATCH /admin/feature-flags/testnet.contract_writes` with `{"enabled": true}`.
+3. Check whether the indexer fell behind during the outage → [§2](#2-indexer-lag).
+4. Run reconciliation → [§7](#7-post-incident).
+
+---
+
+## 2. Indexer lag
+
+The indexer has fallen behind the network. Reads backed by indexed data are stale; the guard may be rejecting lag-sensitive requests.
+
+### Detection
+
+- `GET /admin/operations/indexer` — `isLagging: true`, `lagLedgers` above `thresholdLedgers`.
+- `indexer_lag_ledgers` rising steadily; `indexer_lag_guard_blocked_requests_total` climbing.
+- `indexer_lag_guard_status` shows whether the guard is enabled, overridden, or off.
+- `ingestion_lag_seconds` rising.
+- 503s from routes decorated with `@RequiresIndexerLagCheck`.
+
+Lag is measured by a one-minute cron comparing the network's latest ledger against the last indexed checkpoint. A single elevated sample is not an incident — a **sustained rise** is.
+
+### Immediate mitigation
+
+1. **Determine whether the indexer is stalled or merely slow.** Poll twice, a minute apart:
+
+   ```bash
+   curl -s -H "X-API-Key: $KEY" $API/admin/operations/indexer
+   ```
+
+   If `lastIndexedLedger` is unchanged, ingestion is **stalled** — go to step 2. If it is advancing but slower than the network, it is **catching up**; monitor and hold.
+
+2. **Check the upstream the indexer reads from.** Ingestion polls Horizon and Soroban RPC and fails over across Horizon endpoints after three consecutive failures. If Horizon is the problem, this is really [§1](#1-soroban-rpc-outage) in a different coat.
+
+3. **Look for parse failures.** A schema change can stall progress by quarantining events:
+
+   ```bash
+   curl -s -H "X-API-Key: $KEY" $API/indexer/unparsed-events
+   ```
+
+   A rising `soroban_indexer_unknown_schema_version_total` alongside a recent deploy points at [§5](#5-bad-contract-deploy).
+
+4. **Decide about the guard.** The guard exists to stop serving stale data as if it were current.
+   - **Leave it on** when stale reads could cause a user to pay twice or act on a wrong balance. Rejecting is correct.
+   - **Override it** only when the lag is understood, bounded, and stale reads are less harmful than a full outage. `INDEXER_LAG_GUARD_OVERRIDE=true` keeps measuring but stops rejecting. **This requires a restart and is a deliberate decision to serve stale data — record it in the incident log with who approved it.**
+
+5. **Reindex from a known-good ledger** if the checkpoint is corrupt or events were missed:
+
+   ```bash
+   curl -X POST $API/indexer/reindex -H "X-API-Key: $KEY" \
+     -H 'Content-Type: application/json' -d '{"fromLedger": <ledger>}'
+   ```
+
+   Reindexing adds load. If lag is caused by the indexer struggling to keep up, reindexing will make it worse before it makes it better.
+
+6. **Replay quarantined events** once the parser handles them:
+
+   ```bash
+   curl -s -H "X-API-Key: $KEY" $API/indexer/unparsed-events
+   curl -X POST $API/indexer/unparsed-events/replay/batch -H "X-API-Key: $KEY"
+   # or one at a time:
+   curl -X POST $API/indexer/unparsed-events/<pagingToken>/replay -H "X-API-Key: $KEY"
+   ```
+
+### Recovery
+
+1. `lagLedgers` back under `thresholdLedgers`, `isLagging: false`.
+2. `GET /indexer/unparsed-events` empty, or the remainder is understood and triaged.
+3. If `INDEXER_LAG_GUARD_OVERRIDE` was set, **unset it and restart**. An override left on is a silent, indefinite commitment to serving stale data.
+4. Run reconciliation — a lag episode is exactly when database and ledger diverge.
+
+---
+
+## 3. Stuck payments
+
+Payments are not reaching a terminal state: links stay `ACTIVE` after payment, or users report paying without being credited.
+
+### Detection
+
+- User reports of paid-but-not-credited.
+- `reconciliation_drift_active` = 1, or unmatched entries accumulating in `GET /reconciliation/unmatched`.
+- `outbox_depth` or `outbox_dispatch_lag_seconds` rising — state changed but downstream effects did not fire.
+- `recurring_payment` jobs failing in `GET /admin/jobs/dlq`.
+
+Link states are `DRAFT → ACTIVE → EXPIRED | PAID → REFUNDED`. "Stuck" means a payment landed on chain but the link never moved to `PAID`.
+
+### Immediate mitigation
+
+1. **Establish whether the payment is on chain.** If it is not, this is a client or submission problem, not a stuck payment — check [§1](#1-soroban-rpc-outage).
+
+2. **Check indexer lag first.** The overwhelming majority of stuck payments are lag, not loss: the payment is on chain, the indexer has not caught up, and the state transition has not been triggered. Go to [§2](#2-indexer-lag) and come back. **Do not manually reconcile a payment while the indexer is behind** — you will race the indexer and may double-apply.
+
+3. **Check the outbox.** A rising `outbox_depth` with a flat `outbox_dispatch_total` means state changes are staged but not dispatching — the side effects, not the state, are stuck.
+
+4. **Check the job queue** for failed `recurring_payment` or related jobs:
+
+   ```bash
+   curl -s -H "X-API-Key: $KEY" "$API/admin/jobs/dlq?type=recurring_payment"
+   ```
+
+5. **Run reconciliation** to get an authoritative comparison of database against ledger:
+
+   ```bash
+   curl -X POST $API/reconciliation/trigger -H "X-API-Key: $KEY"
+   curl -s -H "X-API-Key: $KEY" $API/reconciliation/status
+   ```
+
+6. **Work the unmatched queue.** Reconciliation surfaces records it could not match; auto-matching handles the mechanical cases.
+
+   ```bash
+   curl -s -H "X-API-Key: $KEY" $API/reconciliation/unmatched
+   curl -s -H "X-API-Key: $KEY" $API/reconciliation/unmatched/<id>
+   curl -X POST $API/reconciliation/auto-match/trigger -H "X-API-Key: $KEY"
+   curl -X POST $API/reconciliation/unmatched/<id>/resolve -H "X-API-Key: $KEY" \
+     -H 'Content-Type: application/json' -d '{"resolution": "..."}'
+   ```
+
+   Resolving an unmatched record is an **auditable financial action**. Record the reason. `POST /reconciliation/backfill` re-runs over a historical range when the gap predates the incident.
+
+7. **Refunds are a last resort**, via `POST /admin/refunds` after checking eligibility. A refund is not a fix for a stuck payment — it is a decision to unwind one. Escalate before issuing refunds during an active incident: refunding a payment the indexer is about to reconcile creates a worse problem than the one you started with.
+
+### Recovery
+
+1. `reconciliation_drift_active` back to 0.
+2. Unmatched queue empty or every remaining entry triaged with a recorded reason.
+3. Affected links in the correct terminal state.
+4. Manual resolutions listed in the incident record with actor and rationale.
+
+---
+
+## 4. Webhook delivery backlog
+
+Outbound webhooks are queuing, retrying, or dead-lettering. Subscribers are not receiving events.
+
+### Detection
+
+- `GET /admin/operations/webhooks` — `totalPending` rising.
+- `webhook_retry_total` climbing; `webhook_delivery_duration_seconds` degrading.
+- DLQ alerts from the dead-letter monitor (depth over `DLQ_ALERT_DEPTH_THRESHOLD`, or oldest job older than `DLQ_ALERT_AGE_THRESHOLD_MS`); it logs on state transitions, so an alert means a *sustained* backlog.
+- Subscriber reports of missing events.
+
+### Immediate mitigation
+
+1. **Determine the blast radius — one subscriber or all of them.**
+
+   ```bash
+   curl -s -H "X-API-Key: $KEY" $API/admin/jobs/metrics/summary
+   curl -s -H "X-API-Key: $KEY" "$API/admin/jobs/dlq?type=webhook_delivery"
+   ```
+
+   Failures concentrated on one `publicKey` are a subscriber problem: their endpoint is down, slow, or rejecting signatures. Failures across all subscribers are ours.
+
+2. **For a single failing subscriber**, inspect the delivery history:
+
+   ```bash
+   curl -s -H "X-API-Key: $KEY" $API/webhooks/<publicKey>/<id>/stats
+   curl -s -H "X-API-Key: $KEY" $API/webhooks/<publicKey>/<id>/logs
+   curl -s -H "X-API-Key: $KEY" $API/webhooks/<publicKey>/<id>/attempts
+   ```
+
+   Persistent 401/403 usually means a signature mismatch after a secret rotation. Timeouts mean their endpoint is slow. Neither is fixed by retrying harder — contact the subscriber.
+
+3. **For a systemic backlog**, check whether job execution is healthy at all. If *every* job type is backed up, the problem is the queue or the database, not webhooks. Check `GET /ready` and Supabase health.
+
+4. **Do not bulk-retry into a still-broken endpoint.** Retrying a large DLQ against a subscriber that is still down burns the retry budget and re-dead-letters everything. Confirm the endpoint is healthy first with a single retry:
+
+   ```bash
+   curl -X POST $API/admin/jobs/<id>/retry -H "X-API-Key: $KEY"
+   ```
+
+5. **Then drain the DLQ** once a single retry succeeds:
+
+   ```bash
+   curl -X POST $API/admin/jobs/bulk-retry -H "X-API-Key: $KEY" \
+     -H 'Content-Type: application/json' \
+     -d '{"type": "webhook_delivery", "limit": 100}'
+   ```
+
+   Drain in bounded batches and re-check depth between them. Replay is tracked (`GET /admin/jobs/:id/replays`) and rate-limited, so duplicate delivery is bounded — but subscribers should be treating webhook delivery as at-least-once regardless.
+
+6. **Redeliver a specific event** when a subscriber needs one message rather than a drain:
+
+   ```bash
+   curl -X POST $API/webhooks/<publicKey>/<id>/redeliver -H "X-API-Key: $KEY" \
+     -H 'Content-Type: application/json' -d '{"eventId": "<id>"}'
+   ```
+
+7. **Cancel jobs that must not be delivered** — for example, notifications for state that has since been reversed: `POST /admin/jobs/:id/cancel`.
+
+### Recovery
+
+1. `totalPending` back to baseline; DLQ depth for `webhook_delivery` at or near zero.
+2. `webhook_retry_total` flat.
+3. Any subscriber whose events were dropped rather than replayed has been told, explicitly.
+
+---
+
+## 5. Bad contract deploy
+
+A newly deployed contract or registry change is causing failures — errors starting sharply at a deploy boundary.
+
+### Detection
+
+- Error rate steps up at a deploy timestamp rather than ramping.
+- Contract calls failing broadly; simulation errors mentioning unknown methods or bad arguments.
+- `soroban_indexer_unknown_schema_version_total` rising — the indexer is seeing events it does not recognise.
+- `GET /admin/rc-validation/report` returns `blocked` or `releaseReady: false` where it previously passed.
+- The method allowlist rejecting calls that previously succeeded.
+
+**The deploy boundary is the diagnostic.** If errors began exactly when the registry moved, treat this as a bad deploy until proven otherwise. Do not spend twenty minutes debugging the application.
+
+### Immediate mitigation
+
+**Order matters. Stop the bleeding, then roll back, then investigate.**
+
+1. **Engage the write kill switch first.** It is the fastest control available, needs no deploy, and prevents further writes against a suspect contract:
+
+   ```bash
+   curl -X PATCH $API/admin/feature-flags/testnet.contract_writes \
+     -H "X-API-Key: $KEY" -H 'Content-Type: application/json' \
+     -d '{"enabled": false}'
+   ```
+
+2. **Capture a support bundle before changing anything else** — it snapshots the registry state you are about to alter:
+
+   ```bash
+   curl -s -H "X-API-Key: $KEY" \
+     "$API/admin/support/bundle?includeRequestIds=true" > incident-bundle.json
+   ```
+
+3. **Confirm what is actually deployed:**
+
+   ```bash
+   curl -s -H "X-API-Key: $KEY" $API/contracts/registry
+   curl -s -H "X-API-Key: $KEY" $API/admin/rc-validation/report
+   ```
+
+4. **Pause the contract** if the contract itself is misbehaving rather than the registry pointing at the wrong thing — `set_paused` (global) or `set_pause_flags` (per-feature); emergency mode is a last resort. See [deployment-playbook.md §6](../app/contract/documentation/deployment-playbook.md).
+
+5. **Roll back the registry.** This is the fastest recovery when the contract code is fine but the registry points at a bad version — clients resolve addresses through the registry, so reverting the entry redirects everyone to the previous contract without a client deploy:
+
+   ```bash
+   curl -X POST $API/contracts/registry/rollback -H "X-API-Key: $KEY" \
+     -H 'Content-Type: application/json' \
+     -d '{"name": "<contract-name>", "version": "<previous-version>"}'
+   ```
+
+   Rollback is audited and rate-limited. Contract-change webhooks fire, so subscribers learn the registry moved.
+
+6. **If the contract itself is bad**, rollback is an upgrade ceremony, not an endpoint. `complete_upgrade` invariant failures roll back atomically; restoring a previous WASM hash requires a follow-up ceremony in the order `set_upgrade_window → start_upgrade → upgrade → complete_upgrade`. See the [deployment playbook](../app/contract/documentation/deployment-playbook.md) and [RELEASE_READINESS_CHECKLIST.md §10](../RELEASE_READINESS_CHECKLIST.md).
+
+7. **Reindex after the registry settles** if the indexer quarantined events under the bad version. Replay from `/indexer/unparsed-events` once the parser recognises them → [§2](#2-indexer-lag).
+
+### Escalation
+
+**Escalate to a contract maintainer immediately** — before rolling back — if any of these hold. Registry rollback is safe and reversible; contract-level actions are not.
+
+- The contract holds funds and the defect could affect balances.
+- A pause or emergency-mode decision is required.
+- An upgrade ceremony is needed to restore a previous WASM hash.
+- This is mainnet.
+
+### Recovery
+
+1. `GET /contracts/registry` shows the intended version; `GET /admin/rc-validation/report` returns `releaseReady: true`.
+2. Error rate back to the pre-deploy baseline.
+3. Writes re-enabled: `PATCH /admin/feature-flags/testnet.contract_writes` with `{"enabled": true}`.
+4. Indexer caught up and unparsed events cleared.
+5. Reconciliation run clean.
+
+---
+
+## 6. The write kill switch
+
+`testnet.contract_writes` is the single fastest lever in the system. Know when to pull it.
+
+**How it works.** `NetworkSafetyGuard` gates every route decorated with `@RequiresFlag(TESTNET_CONTRACT_WRITES_FLAG)`. Unlike normal flag evaluation, the guard calls `evaluateFlagFresh` — an **uncached read on every request** — so a flip propagates across all instances immediately. Blocked requests get a 503 with code `CONTRACT_WRITES_DISABLED` and a message directing the user to retry after the incident. Every block is written to the audit log with the actor, path, and reason.
+
+**It only applies on testnet.** The guard returns early when `config.isTestnet` is false. On mainnet, use contract-level pause instead.
+
+```bash
+# Disengage writes
+curl -X PATCH $API/admin/feature-flags/testnet.contract_writes \
+  -H "X-API-Key: $KEY" -H 'Content-Type: application/json' -d '{"enabled": false}'
+
+# Re-enable
+curl -X PATCH $API/admin/feature-flags/testnet.contract_writes \
+  -H "X-API-Key: $KEY" -H 'Content-Type: application/json' -d '{"enabled": true}'
+```
+
+**Use it when:**
+
+- A bad contract deploy is suspected — **first action, before diagnosis** (§5).
+- Writes are producing partial or inconsistent state.
+- Reconciliation shows active drift and continued writes would widen the gap.
+- You need a stable system to diagnose against.
+
+**Do not use it for:**
+
+- Read-only degradation. It gates writes only; disabling it does not help a read outage.
+- Indexer lag on its own — the lag guard is the targeted control, and it already rejects only the affected routes.
+- A single failing subscriber or job type. Cancel or pause that work instead.
+
+**Before flipping it back on:** the root cause is understood, the registry points at the intended version, the indexer has caught up, and a reconciliation run is clean. Re-enabling into an unresolved fault re-creates the incident with more damage.
+
+---
+
+## 7. Post-incident
+
+### Collect a support bundle
+
+If you did not capture one during the incident, capture one now. It is the sanitised diagnostic snapshot — network config, contract registry state, indexer status and checkpoints, and recent errors, with secrets and PII redacted:
+
+```bash
+curl -s -H "X-API-Key: $KEY" \
+  "$API/admin/support/bundle?includeRequestIds=true" > incident-<date>-bundle.json
+```
+
+`includeRequestIds=true` correlates errors with traces and is what you want for an incident record; it defaults to `false` because request IDs may carry context you would not want in a public issue. Attach the bundle to the incident record and to any GitHub issue. `POST /support/bundle-references` registers a bundle so an issue can cite it without re-exporting.
+
+### Reconcile
+
+**Every incident that touched writes, the indexer, or the contract registry ends with a reconciliation run.** This is the check that money and state agree.
+
+```bash
+curl -X POST $API/reconciliation/trigger -H "X-API-Key: $KEY"
+curl -s -H "X-API-Key: $KEY" $API/reconciliation/status
+curl -s -H "X-API-Key: $KEY" $API/reconciliation/history
+curl -s -H "X-API-Key: $KEY" $API/reconciliation/unmatched
+```
+
+If the incident spanned a period the scheduled runs missed, backfill it:
+
+```bash
+curl -X POST $API/reconciliation/backfill -H "X-API-Key: $KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"fromLedger": <start>, "toLedger": <end>}'
+```
+
+The incident is not closed until `reconciliation_drift_active` is 0 and the unmatched queue is empty or every remaining entry is triaged with a recorded reason.
+
+### Close-out checklist
+
+- [ ] Support bundle captured and attached to the incident record.
+- [ ] Reconciliation run clean; unmatched queue empty or triaged.
+- [ ] **Every temporary control reverted** — kill switch re-enabled, `INDEXER_LAG_GUARD_OVERRIDE` unset, paused contracts unpaused, cancelled jobs accounted for. Left-on overrides are the most common way one incident becomes the next.
+- [ ] Audit log reviewed for the incident window (`GET /admin/audit`) — it holds every privileged action taken, including automated kill-switch blocks.
+- [ ] `GET /admin/rc-validation/report` returns `releaseReady: true`.
+- [ ] Timeline written: detection time, actions with timestamps, who decided what.
+- [ ] Manual resolutions and refunds listed with actor and rationale.
+- [ ] Detection gaps filed — if you found this from a user report rather than a metric, the missing alert is an action item.
+- [ ] If tooling was missing or broken during the incident, file it. Seed reset being unserved is already known; add anything else you hit.


### PR DESCRIPTION
Closes #828 
Closes #830 
Closes #831 

Three Wave 8 documentation issues, grouped because they all describe the
same tree and cross-link to each other. Committed under `docs/`, which is
this repo's existing convention — there is no `doc/` directory.

Everything below was verified against the code rather than inferred, and
where the tree contradicts the issue description, the doc describes the
tree.

## docs/BACKEND-MODULE-MAP.md (#828)

A one-paragraph ownership statement for each of the **50** directories
under `app/backend/src/`, a five-layer model with the rule that **imports
point downward**, the five shared-infrastructure modules and their
contracts with callers, and a stop-at-first-match decision procedure for
new code.

The overlapping search/discovery/profile paths the issue names trace to
four concrete boundary breaks, all documented with file references:

- **Two `HorizonService` classes** — `stellar/` (88 lines) and
  `transactions/` (291 lines). Same class name, different capabilities,
  neither a superset. `asset-metadata`, `health`, and `soroban-tooling`
  use one; `links`, `payments`, `scam-alerts`, and `transaction-timeline`
  use the other.
- **Route-prefix collision** — `links` and `scam-alerts` both declare
  `@Controller("links")`, so route ownership is not discoverable from the
  URL.
- `supabase` (platform layer) imports reconciliation types;
  `dto` imports `LinkState` from `links`. Both invert the intended
  direction.

Modules flagged as incomplete:

| Module | Status |
|---|---|
| `receipts`, `manifests`, `crash-reporting`, `demos` | **Unwired** — module never imported, controllers serve no traffic |
| `reconciliation`, `notifications`, `developer` | Conditional — skipped against a local Supabase |
| `payments`, `dashboard-feed`, `types`, `manifests`, `soroban-tooling`, `developer` | Intentionally thin, with the reason stated |

`payments` is worth calling out: despite the name it is ~40 lines over
one Horizon read and owns no payment domain logic. It reads as the obvious
home for payment code and is not.

## docs/LOCALIZATION-GUIDE.md (#830)

The tree has moved since the issue was filed — strings now live in
`translations.json` per client with CI parity checks wired into both
workflows, and **`i18n.ts.backup` no longer exists**. The guide documents
the current state: adding a string on each client, flat camelCase key
conventions, the shared vs client-specific rule, adding a locale (one step
on mobile, three on the frontend, and the frontend's extra steps fail
silently), and pluralization, interpolation, and amount/date formatting.

Drift is measured, not estimated:

- **The mobile i18n bootstrap import is broken.**
  `app/mobile/app/_layout.tsx:15` imports `"../../src/lib/i18n"`, which
  resolves to `app/src/lib/i18n` — a path that does not exist, and no
  tsconfig alias covers it. `i18next` never initialises, so `t()` returns
  raw key names at runtime. Neither parity check can catch this because
  both only read the JSON. Fixing this is a prerequisite for any mobile
  translation work being visible.
- Mobile's locale picker offers **only English** despite complete `es`
  and `fr` dictionaries.
- 129 keys vs 67, 49 shared — and **17 shared keys have different English
  text on the two clients**, tabulated in full. Split into cosmetic
  differences (mechanical fix) and substantively different copy where
  mobile carries developer-facing detail, which needs a per-key decision
  rather than an overwrite.
- Formatting helpers exist only on the frontend, and ~24 frontend call
  sites bypass them with hardcoded `"en-US"`.
- No tooling compares the two dictionaries; nothing would have caught any
  of the above.

Each drift item names the fix. None are applied here — this is a
documentation PR.

## docs/TESTNET-INCIDENT-RUNBOOK.md (#831)

A first-five-minutes triage block that routes to five scenarios — Soroban
RPC outage, indexer lag, stuck payments, webhook delivery backlog, bad
contract deploy — each with detection signals, immediate mitigation, and
the exact endpoint to call. Plus a metrics/endpoint/env-var reference
section, escalation criteria, rollback ordering, and a close-out
checklist.

The `testnet.contract_writes` kill switch gets its own section: how the
fresh-read-per-request evaluation makes it propagate without a restart,
when it is the first action (suspected bad deploy, before diagnosis), and
when it is the wrong tool (read-only degradation, indexer lag alone, a
single failing subscriber).

**Correction to the issue description:** it lists seed reset as available
tooling. `DemoModule` is not imported in `app.module.ts`, so
`/seed-reset/*` and `/v1/demo/*` return 404 despite complete controllers,
guards, and a scheduler. The runbook says so explicitly, because
discovering it mid-incident is exactly the failure mode the issue is
trying to prevent.

Several ordering constraints are stated rather than left implicit — check
indexer lag before manually reconciling a stuck payment, confirm one retry
succeeds before draining a webhook DLQ, capture a support bundle before
mitigating.

## Also changed

- `RELEASE_READINESS_CHECKLIST.md` — runbook linked in three places:
  related documents, the rollback section, and a rollout-window checklist
  item for on-call.
- `CONTRIBUTING.md` — all three docs added to the architecture section.

## Verification

- Every module directory confirmed present in both the layer table and
  the ownership section (50/50).
- Every relative link in the three new documents resolves.
- Key counts, the shared-key set, and the 17 divergent values computed
  from the dictionaries rather than read off the existing README.
- Unwired modules confirmed by grepping for each module class across the
  whole backend, not just `app.module.ts`.


